### PR TITLE
mod : Fail safe for loading failure of misc.RibiArrow.pak

### DIFF
--- a/simskin.cc
+++ b/simskin.cc
@@ -169,11 +169,6 @@ bool skinverwaltung_t::successfully_loaded(skintyp_t type)
 			if (tunnel_texture==NULL) {
 				tunnel_texture = fussweg;
 			}
-			// [mod : shingoushori] Fail safe for loading failure of misc.RibiArrow.pak
-			// for compatibility: use sidewalk as ribi_arrow
-			if (ribi_arrow==NULL) {
-				ribi_arrow = fussweg;
-			}
 			break;
 		case nothing: return true;
 		default:      return false;

--- a/simskin.cc
+++ b/simskin.cc
@@ -78,12 +78,12 @@ slist_tpl<const skin_desc_t *>skinverwaltung_t::extra_obj;
 
 
 static special_obj_tpl<skin_desc_t> const misc_objekte[] = {
+	{ &skinverwaltung_t::ribi_arrow,        "RibiArrow"    },
 	{ &skinverwaltung_t::senke,             "PowerDest"    },
 	{ &skinverwaltung_t::pumpe,             "PowerSource"  },
 	{ &skinverwaltung_t::construction_site, "Construction" },
 	{ &skinverwaltung_t::fussweg,           "Sidewalk"     },
 	{ &skinverwaltung_t::tunnel_texture,    "TunnelTexture"},
-	{ &skinverwaltung_t::ribi_arrow,        "RibiArrow"    },
 	{ NULL, NULL }
 };
 
@@ -164,7 +164,7 @@ bool skinverwaltung_t::successfully_loaded(skintyp_t type)
 		case cursor:  sd = cursor_objekte;     break;
 		case symbol:  sd = symbol_objekte;     break;
 		case misc:
-			sd = misc_objekte+2;
+			sd = misc_objekte+3;
 			// for compatibility: use sidewalk as tunneltexture
 			if (tunnel_texture==NULL) {
 				tunnel_texture = fussweg;

--- a/simskin.cc
+++ b/simskin.cc
@@ -169,6 +169,11 @@ bool skinverwaltung_t::successfully_loaded(skintyp_t type)
 			if (tunnel_texture==NULL) {
 				tunnel_texture = fussweg;
 			}
+			// [mod : shingoushori] Fail safe for loading failure of misc.RibiArrow.pak
+			// for compatibility: use sidewalk as ribi_arrow
+			if (ribi_arrow==NULL) {
+				ribi_arrow = fussweg;
+			}
 			break;
 		case nothing: return true;
 		default:      return false;

--- a/simtool.h
+++ b/simtool.h
@@ -1011,8 +1011,13 @@ public:
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("view masked ribi"); }
 	bool is_selected() const OVERRIDE { return strasse_t::show_masked_ribi; }
 	bool init( player_t * ) override {
-		strasse_t::show_masked_ribi ^= 1;
-		welt->set_dirty();
+		if(  skinverwaltung_t::ribi_arrow  ) {
+			strasse_t::show_masked_ribi ^= 1;
+			welt->set_dirty();
+		} else {
+			// no ribi_arrow pak.
+			dbg->warning("tool_show_ribi_t::init()", "the ribi_arrow pak is not installed!");
+		}
 		return false;
 	}
 	bool is_init_network_save() const OVERRIDE { return true; }


### PR DESCRIPTION
On the original OTRP, misc.RibiArrow.pak is forcibly necessary for the pak set.
So then, I propose easing of that with conventional method : "for compatibility: use sidewalk as tunneltexture".