### PR TITLE
extend tool_build_house_t : regional mass treatment

### DIFF
--- a/gui/citybuilding_edit.cc
+++ b/gui/citybuilding_edit.cc
@@ -30,7 +30,7 @@
 
 
 // new tool definition
-tool_build_house_t citybuilding_edit_frame_t::haus_tool=tool_build_house_t();
+tool_build_house_t* citybuilding_edit_frame_t::haus_tool=new tool_build_house_t();
 char citybuilding_edit_frame_t::param_str[256];
 
 
@@ -71,8 +71,8 @@ citybuilding_edit_frame_t::citybuilding_edit_frame_t(player_t* player_) :
 {
 	rot_str[0] = 0;
 	desc = NULL;
-	haus_tool.set_default_param(NULL);
-	haus_tool.cursor = tool_t::general_tool[TOOL_BUILD_HOUSE]->cursor;
+	haus_tool->set_default_param(NULL);
+	static_cast<kartenboden_tool_t*>(haus_tool)->cursor = tool_t::general_tool[TOOL_BUILD_HOUSE]->cursor;
 
 	bt_res.init( button_t::square_state, "residential house", scr_coord(get_tab_panel_width()+2*MARGIN, offset_of_comp-4 ) );
 	bt_res.add_listener(this);
@@ -287,10 +287,10 @@ void citybuilding_edit_frame_t::change_item_info(sint32 entry)
 
 		// the tools will be always updated, even though the data up there might be still current
 		sprintf( param_str, "%i%c%s", bt_climates.pressed, rotation>253 ? (rotation==254 ? 'A' : '#') : '0'+rotation, desc->get_name() );
-		haus_tool.set_default_param(param_str);
-		welt->set_tool( &haus_tool, player );
+		haus_tool->set_default_param(param_str);
+		welt->set_tool( static_cast<tool_t*>(static_cast<kartenboden_tool_t*>(haus_tool)), player );
 	}
-	else if(welt->get_tool(player->get_player_nr())==&haus_tool) {
+	else if(welt->get_tool(player->get_player_nr())==static_cast<tool_t*>(static_cast<kartenboden_tool_t*>(haus_tool))) {
 		desc = NULL;
 		welt->set_tool( tool_t::general_tool[TOOL_QUERY], player );
 	}

--- a/gui/citybuilding_edit.cc
+++ b/gui/citybuilding_edit.cc
@@ -72,7 +72,7 @@ citybuilding_edit_frame_t::citybuilding_edit_frame_t(player_t* player_) :
 	rot_str[0] = 0;
 	desc = NULL;
 	haus_tool->set_default_param(NULL);
-	static_cast<kartenboden_tool_t*>(haus_tool)->cursor = tool_t::general_tool[TOOL_BUILD_HOUSE]->cursor;
+	haus_tool->cursor = tool_t::general_tool[TOOL_BUILD_HOUSE]->cursor;
 
 	bt_res.init( button_t::square_state, "residential house", scr_coord(get_tab_panel_width()+2*MARGIN, offset_of_comp-4 ) );
 	bt_res.add_listener(this);
@@ -288,9 +288,9 @@ void citybuilding_edit_frame_t::change_item_info(sint32 entry)
 		// the tools will be always updated, even though the data up there might be still current
 		sprintf( param_str, "%i%c%s", bt_climates.pressed, rotation>253 ? (rotation==254 ? 'A' : '#') : '0'+rotation, desc->get_name() );
 		haus_tool->set_default_param(param_str);
-		welt->set_tool( static_cast<tool_t*>(static_cast<kartenboden_tool_t*>(haus_tool)), player );
+		welt->set_tool( haus_tool, player );
 	}
-	else if(welt->get_tool(player->get_player_nr())==static_cast<tool_t*>(static_cast<kartenboden_tool_t*>(haus_tool))) {
+	else if(welt->get_tool(player->get_player_nr())==haus_tool) {
 		desc = NULL;
 		welt->set_tool( tool_t::general_tool[TOOL_QUERY], player );
 	}

--- a/gui/citybuilding_edit.h
+++ b/gui/citybuilding_edit.h
@@ -16,7 +16,7 @@ class tool_build_house_t;
 class citybuilding_edit_frame_t : public extend_edit_gui_t
 {
 private:
-	static tool_build_house_t haus_tool;
+	static tool_build_house_t* haus_tool;
 	static char param_str[256];
 
 	const building_desc_t *desc;

--- a/gui/curiosity_edit.cc
+++ b/gui/curiosity_edit.cc
@@ -61,7 +61,7 @@ curiosity_edit_frame_t::curiosity_edit_frame_t(player_t* player_) :
 	rotation = 255;
 	desc = NULL;
 	haus_tool->set_default_param(NULL);
-	static_cast<tool_t*>(static_cast<kartenboden_tool_t*>(haus_tool))->cursor = tool_t::general_tool[TOOL_BUILD_HOUSE]->cursor;
+	haus_tool->cursor = tool_t::general_tool[TOOL_BUILD_HOUSE]->cursor;
 
 	bt_city_attraction.init( button_t::square_state, "City attraction", scr_coord(get_tab_panel_width()+2*MARGIN, offset_of_comp-4 ) );
 	bt_city_attraction.add_listener(this);
@@ -293,9 +293,9 @@ void curiosity_edit_frame_t::change_item_info(sint32 entry)
 		// the tools will be always updated, even though the data up there might be still current
 		sprintf( param_str, "%i%c%s", bt_climates.pressed, rotation==255 ? '#' : '0'+rotation, desc->get_name() );
 		haus_tool->set_default_param(param_str);
-		welt->set_tool( static_cast<tool_t*>(static_cast<kartenboden_tool_t*>(haus_tool)), player );
+		welt->set_tool( haus_tool, player );
 	}
-	else if(welt->get_tool(player->get_player_nr())==static_cast<tool_t*>(static_cast<kartenboden_tool_t*>(haus_tool))) {
+	else if(welt->get_tool(player->get_player_nr())==haus_tool) {
 		for(int i=0;  i<4;  i++  ) {
 			img[i].set_image( IMG_EMPTY );
 		}

--- a/gui/curiosity_edit.cc
+++ b/gui/curiosity_edit.cc
@@ -30,7 +30,7 @@
 
 
 // new tool definition
-tool_build_house_t curiosity_edit_frame_t::haus_tool=tool_build_house_t();
+tool_build_house_t* curiosity_edit_frame_t::haus_tool=new tool_build_house_t();
 char curiosity_edit_frame_t::param_str[256];
 
 
@@ -60,8 +60,8 @@ curiosity_edit_frame_t::curiosity_edit_frame_t(player_t* player_) :
 	rot_str[0] = 0;
 	rotation = 255;
 	desc = NULL;
-	haus_tool.set_default_param(NULL);
-	haus_tool.cursor = tool_t::general_tool[TOOL_BUILD_HOUSE]->cursor;
+	haus_tool->set_default_param(NULL);
+	static_cast<tool_t*>(static_cast<kartenboden_tool_t*>(haus_tool))->cursor = tool_t::general_tool[TOOL_BUILD_HOUSE]->cursor;
 
 	bt_city_attraction.init( button_t::square_state, "City attraction", scr_coord(get_tab_panel_width()+2*MARGIN, offset_of_comp-4 ) );
 	bt_city_attraction.add_listener(this);
@@ -292,10 +292,10 @@ void curiosity_edit_frame_t::change_item_info(sint32 entry)
 
 		// the tools will be always updated, even though the data up there might be still current
 		sprintf( param_str, "%i%c%s", bt_climates.pressed, rotation==255 ? '#' : '0'+rotation, desc->get_name() );
-		haus_tool.set_default_param(param_str);
-		welt->set_tool( &haus_tool, player );
+		haus_tool->set_default_param(param_str);
+		welt->set_tool( static_cast<tool_t*>(static_cast<kartenboden_tool_t*>(haus_tool)), player );
 	}
-	else if(welt->get_tool(player->get_player_nr())==&haus_tool) {
+	else if(welt->get_tool(player->get_player_nr())==static_cast<tool_t*>(static_cast<kartenboden_tool_t*>(haus_tool))) {
 		for(int i=0;  i<4;  i++  ) {
 			img[i].set_image( IMG_EMPTY );
 		}

--- a/gui/curiosity_edit.h
+++ b/gui/curiosity_edit.h
@@ -16,7 +16,7 @@ class building_desc_t;
 class curiosity_edit_frame_t : public extend_edit_gui_t
 {
 private:
-	static tool_build_house_t haus_tool;
+	static tool_build_house_t* haus_tool;
 	static char param_str[256];
 
 	const building_desc_t *desc;

--- a/gui/factory_edit.cc
+++ b/gui/factory_edit.cc
@@ -30,9 +30,9 @@
 
 
 // new tool definition
-tool_build_land_chain_t factory_edit_frame_t::land_chain_tool = tool_build_land_chain_t();
-tool_city_chain_t factory_edit_frame_t::city_chain_tool = tool_city_chain_t();
-tool_build_factory_t factory_edit_frame_t::fab_tool = tool_build_factory_t();
+tool_build_land_chain_t* factory_edit_frame_t::land_chain_tool = new tool_build_land_chain_t();
+tool_city_chain_t* factory_edit_frame_t::city_chain_tool = new tool_city_chain_t();
+tool_build_factory_t* factory_edit_frame_t::fab_tool = new tool_build_factory_t();
 char factory_edit_frame_t::param_str[256];
 
 static bool compare_fabrik_desc(const factory_desc_t* a, const factory_desc_t* b)
@@ -56,10 +56,10 @@ factory_edit_frame_t::factory_edit_frame_t(player_t* player_) :
 {
 	rot_str[0] = 0;
 	prod_str[0] = 0;
-	land_chain_tool.set_default_param(param_str);
-	city_chain_tool.set_default_param(param_str);
-	fab_tool.set_default_param(param_str);
-	land_chain_tool.cursor = city_chain_tool.cursor = fab_tool.cursor = tool_t::general_tool[TOOL_BUILD_FACTORY]->cursor;
+	land_chain_tool->set_default_param(param_str);
+	city_chain_tool->set_default_param(param_str);
+	fab_tool->set_default_param(param_str);
+	land_chain_tool->cursor = city_chain_tool->cursor = fab_tool->cursor = tool_t::general_tool[TOOL_BUILD_FACTORY]->cursor;
 
 	fac_desc = NULL;
 
@@ -350,13 +350,13 @@ void factory_edit_frame_t::change_item_info(sint32 entry)
 		// the tools will be always updated, even though the data up there might be still current
 		sprintf( param_str, "%i%c%i,%s", bt_climates.pressed, rotation==255 ? '#' : '0'+rotation, production, fac_desc->get_name() );
 		if(bt_land_chain.pressed) {
-			welt->set_tool( &land_chain_tool, player );
+			welt->set_tool( land_chain_tool, player );
 		}
 		else if(bt_city_chain.pressed) {
-			welt->set_tool( &city_chain_tool, player );
+			welt->set_tool( city_chain_tool, player );
 		}
 		else {
-			welt->set_tool( &fab_tool, player );
+			welt->set_tool( fab_tool, player );
 		}
 	}
 	else if(fac_desc!=NULL) {

--- a/gui/factory_edit.h
+++ b/gui/factory_edit.h
@@ -19,9 +19,9 @@ class tool_build_factory_t;
 class factory_edit_frame_t : public extend_edit_gui_t
 {
 private:
-	static tool_build_land_chain_t land_chain_tool;
-	static tool_city_chain_t city_chain_tool;
-	static tool_build_factory_t fab_tool;
+	static tool_build_land_chain_t* land_chain_tool;
+	static tool_city_chain_t* city_chain_tool;
+	static tool_build_factory_t* fab_tool;
 	static char param_str[256];
 
 	const factory_desc_t *fac_desc;

--- a/simmenu.cc
+++ b/simmenu.cc
@@ -1226,3 +1226,9 @@ image_id two_click_tool_t::get_marker_image()
 {
 	return skinverwaltung_t::bauigelsymbol->get_image_id(0);
 }
+
+/*const char *two_click_kartenboden_tool_t::check_pos(player_t *, koord3d pos )
+{
+	grund_t *gr = welt->lookup_kartenboden(pos.get_2d());
+	return (gr  &&  !gr->is_visible()) ? "" : NULL;
+}*/

--- a/simmenu.cc
+++ b/simmenu.cc
@@ -805,6 +805,12 @@ const char *kartenboden_tool_t::check_pos(player_t *, koord3d pos )
 	return (gr  &&  !gr->is_visible()) ? "" : NULL;
 }
 
+const char *two_click_kartenboden_tool_t::check_pos(player_t *, koord3d pos )
+{
+	grund_t *gr = welt->lookup_kartenboden(pos.get_2d());
+	return (gr  &&  !gr->is_visible()) ? "" : NULL;
+}
+
 
 
 image_id toolbar_t::get_icon(player_t *player) const

--- a/simmenu.cc
+++ b/simmenu.cc
@@ -1108,6 +1108,10 @@ const char *two_click_tool_t::work(player_t *player, koord3d pos )
 	}
 
 	if(  is_first_click()  ) {
+		// For co-existence with one_click mode
+		if (one_click) {
+			return do_work( player, pos, koord3d::invalid );
+		}
 		// work directly if possible and ctrl is NOT pressed
 		if( (value & 1)  &&  !( (value & 2)  &&  is_ctrl_pressed())) {
 			// Work here directly.

--- a/simmenu.h
+++ b/simmenu.h
@@ -339,7 +339,7 @@ public:
 /*
  * Class for tools that work only on ground (kartenboden)
  */
-class kartenboden_tool_t : public tool_t {
+class kartenboden_tool_t : virtual public tool_t {
 public:
 	kartenboden_tool_t(uint16 const id) : tool_t(id) {}
 
@@ -351,7 +351,7 @@ public:
  * Dragging is also possible.
  * @author Gerd Wachsmuth
  */
-class two_click_tool_t : public tool_t {
+class two_click_tool_t : virtual public tool_t {
 public:
 	two_click_tool_t(uint16 const id) : tool_t(id) {
 		MEMZERO(start_marker);
@@ -422,6 +422,25 @@ protected:
 	virtual void start_at( koord3d &new_start );
 
 	slist_tpl< zeiger_t* > marked;
+};
+
+/*
+ * Class for tools that work only on ground (kartenboden)
+ */
+class two_click_kartenboden_tool_t : public two_click_tool_t, public kartenboden_tool_t {
+public:
+	//two_click_kartenboden_tool_t(uint16 const id) : two_click_tool_t(id){}
+	two_click_kartenboden_tool_t(uint16 const id) : tool_t(id), two_click_tool_t(id), kartenboden_tool_t(id) {}
+
+	//char const* check_pos(player_t*, koord3d) OVERRIDE;
+	using kartenboden_tool_t::check_pos;
+	void set_default_param(const char* str) OVERRIDE {	kartenboden_tool_t::set_default_param(str);};
+	using kartenboden_tool_t::set_default_param;
+	using kartenboden_tool_t::cursor;//using tool_t::cursor;
+	
+	char const* do_work(player_t* player, koord3d const&, koord3d const& pos) OVERRIDE {return work(player, pos);};
+	void mark_tiles(player_t*, koord3d const&, koord3d const&) OVERRIDE {};
+	uint8 is_valid_pos(player_t*, koord3d const&, char const*&, koord3d const&) OVERRIDE {return 2;};
 };
 
 /* toolbar are a new overclass */

--- a/simmenu.h
+++ b/simmenu.h
@@ -339,7 +339,7 @@ public:
 /*
  * Class for tools that work only on ground (kartenboden)
  */
-class kartenboden_tool_t : virtual public tool_t {
+class kartenboden_tool_t : public tool_t {
 public:
 	kartenboden_tool_t(uint16 const id) : tool_t(id) {}
 
@@ -351,7 +351,7 @@ public:
  * Dragging is also possible.
  * @author Gerd Wachsmuth
  */
-class two_click_tool_t : virtual public tool_t {
+class two_click_tool_t : public tool_t {
 public:
 	two_click_tool_t(uint16 const id) : tool_t(id) {
 		MEMZERO(start_marker);
@@ -427,16 +427,16 @@ protected:
 /*
  * Class for tools that work only on ground (kartenboden)
  */
-class two_click_kartenboden_tool_t : public two_click_tool_t, public kartenboden_tool_t {
+class two_click_kartenboden_tool_t : public two_click_tool_t {
 public:
-	//two_click_kartenboden_tool_t(uint16 const id) : two_click_tool_t(id){}
-	two_click_kartenboden_tool_t(uint16 const id) : tool_t(id), two_click_tool_t(id), kartenboden_tool_t(id) {}
+	two_click_kartenboden_tool_t(uint16 const id) : two_click_tool_t(id){}
 
-	//char const* check_pos(player_t*, koord3d) OVERRIDE;
-	using kartenboden_tool_t::check_pos;
-	void set_default_param(const char* str) OVERRIDE {	kartenboden_tool_t::set_default_param(str);};
-	using kartenboden_tool_t::set_default_param;
-	using kartenboden_tool_t::cursor;//using tool_t::cursor;
+	char const* check_pos(player_t*, koord3d);
+	
+	//using kartenboden_tool_t::check_pos;
+	//void set_default_param(const char* str) OVERRIDE {	kartenboden_tool_t::set_default_param(str);};
+	//using kartenboden_tool_t::set_default_param;
+	//using kartenboden_tool_t::cursor;//using tool_t::cursor;
 	
 	char const* do_work(player_t* player, koord3d const&, koord3d const& pos) OVERRIDE {return work(player, pos);};
 	void mark_tiles(player_t*, koord3d const&, koord3d const&) OVERRIDE {};

--- a/simmenu.h
+++ b/simmenu.h
@@ -356,6 +356,8 @@ public:
 	two_click_tool_t(uint16 const id) : tool_t(id) {
 		MEMZERO(start_marker);
 		first_click_var = true;
+		// For co-existence with one_click mode
+		one_click = false;
 	}
 
 	void rdwr_custom_data(memory_rw_t*) OVERRIDE;
@@ -422,6 +424,9 @@ protected:
 	virtual void start_at( koord3d &new_start );
 
 	slist_tpl< zeiger_t* > marked;
+
+	// For co-existence with one_click mode
+	bool one_click;
 };
 
 /*
@@ -432,11 +437,6 @@ public:
 	two_click_kartenboden_tool_t(uint16 const id) : two_click_tool_t(id){}
 
 	char const* check_pos(player_t*, koord3d);
-	
-	//using kartenboden_tool_t::check_pos;
-	//void set_default_param(const char* str) OVERRIDE {	kartenboden_tool_t::set_default_param(str);};
-	//using kartenboden_tool_t::set_default_param;
-	//using kartenboden_tool_t::cursor;//using tool_t::cursor;
 	
 	char const* do_work(player_t* player, koord3d const&, koord3d const& pos) OVERRIDE {return work(player, pos);};
 	void mark_tiles(player_t*, koord3d const&, koord3d const&) OVERRIDE {};

--- a/simtool.cc
+++ b/simtool.cc
@@ -5583,22 +5583,33 @@ void tool_build_house_t::mark_tiles(  player_t *, const koord3d &start, const ko
 
 const char *tool_build_house_t::do_work( player_t *player, const koord3d &start, const koord3d &end )
 {
-	koord wh, nw;
-	wh.x = abs(end.x-start.x)+1;
-	wh.y = abs(end.y-start.y)+1;
-	nw.x = min(start.x, end.x)+(wh.x/2);
-	nw.y = min(start.y, end.y)+(wh.y/2);
-	
-	int dx = (start.x < end.x) ? 1 : -1;
-	int dy = (start.y < end.y) ? 1 : -1;
-	for(int x=start.x; x!=(end.x+dx); x+=dx) {
-		for(int y=start.y; y!=(end.y+dy); y+=dy) {
-			work(player, koord(x,y));
+	if(  end == koord3d::invalid  ) {
+		koord k;
+		k.x = start.x;
+		k.y = start.y;
+		if(  grund_t *gr=welt->lookup_kartenboden(k)  ) {
+			work(player, k);
 		}
 	}
-	//sint64 costs = baum_t::create_forest( nw, wh );
-	//player_t::book_construction_costs(player, costs * welt->get_settings().cst_remove_tree, end.get_2d(), ignore_wt);
-	
+	else {
+		koord wh, nw;
+		wh.x = abs(end.x-start.x)+1;
+		wh.y = abs(end.y-start.y)+1;
+		nw.x = min(start.x, end.x)+(wh.x/2);
+		nw.y = min(start.y, end.y)+(wh.y/2);
+		
+		int dx = (start.x < end.x) ? 1 : -1;
+		int dy = (start.y < end.y) ? 1 : -1;
+		
+		koord k;
+		for( k.x = start.x; k.x != (end.x+dx); k.x += dx) {
+			for( k.y = start.y; k.y != (end.y+dy); k.y += dy) {
+				if(  grund_t *gr=welt->lookup_kartenboden(k)  ) {
+					work(player, k);
+				}
+			}
+		}
+	}
 	return NULL;
 }
 

--- a/simtool.cc
+++ b/simtool.cc
@@ -5455,7 +5455,7 @@ const char *tool_build_depot_t::work( player_t *player, koord3d pos )
  * finally building name
  * @author prissi
  */
-bool tool_build_house_t::init( player_t * )
+bool tool_build_house_t::init( player_t * player)
 {
 	if (can_use_gui() && !strempty(default_param)) {
 		const char *c = default_param+2;
@@ -5465,14 +5465,18 @@ bool tool_build_house_t::init( player_t * )
 			cursor_area = tile->get_desc()->get_size(rotation);
 		}
 	}
-	return true;
+	return two_click_tool_t::init(player);
 }
 
 
-const char *tool_build_house_t::work( player_t *player, koord3d pos )
+/*const char *tool_build_house_t::work( player_t *player, koord3d pos )
 {
-	koord k(pos.get_2d());
-
+	//koord k(pos.get_2d());
+	//work( player, k );
+	return "";
+}*/
+const char *tool_build_house_t::work( player_t *player, koord k )
+{
 	const grund_t* gr = welt->lookup_kartenboden(k);
 	if(gr==NULL) {
 		return "";
@@ -5545,6 +5549,58 @@ const char *tool_build_house_t::work( player_t *player, koord3d pos )
 	return NOTICE_UNSUITABLE_GROUND;
 }
 
+void tool_build_house_t::mark_tiles(  player_t *, const koord3d &start, const koord3d &end )
+{
+	koord k1, k2;
+	k1.x = start.x < end.x ? start.x : end.x;
+	k1.y = start.y < end.y ? start.y : end.y;
+	k2.x = start.x + end.x - k1.x;
+	k2.y = start.y + end.y - k1.y;
+	koord k;
+	for(  k.x = k1.x;  k.x <= k2.x;  k.x++  ) {
+		for(  k.y = k1.y;  k.y <= k2.y;  k.y++  ) {
+			grund_t *gr = welt->lookup_kartenboden( k );
+			
+			zeiger_t *marker = new zeiger_t(gr->get_pos(), NULL );
+			
+			const uint8 grund_hang = gr->get_grund_hang();
+			const uint8 weg_hang = gr->get_weg_hang();
+			const uint8 hang = max( corner_sw(grund_hang), corner_sw(weg_hang)) +
+					3 * max( corner_se(grund_hang), corner_se(weg_hang)) +
+					9 * max( corner_ne(grund_hang), corner_ne(weg_hang)) +
+					27 * max( corner_nw(grund_hang), corner_nw(weg_hang));
+			uint8 back_hang = (hang % 3) + 3 * ((uint8)(hang / 9)) + 27;
+			marker->set_foreground_image( ground_desc_t::marker->get_image( grund_hang % 27 ) );
+			marker->set_image( ground_desc_t::marker->get_image( back_hang ) );
+			
+			marker->mark_image_dirty( marker->get_image(), 0 );
+			gr->obj_add( marker );
+			marked.insert( marker );
+		}
+	}
+}
+
+
+const char *tool_build_house_t::do_work( player_t *player, const koord3d &start, const koord3d &end )
+{
+	koord wh, nw;
+	wh.x = abs(end.x-start.x)+1;
+	wh.y = abs(end.y-start.y)+1;
+	nw.x = min(start.x, end.x)+(wh.x/2);
+	nw.y = min(start.y, end.y)+(wh.y/2);
+	
+	int dx = (start.x < end.x) ? 1 : -1;
+	int dy = (start.y < end.y) ? 1 : -1;
+	for(int x=start.x; x!=(end.x+dx); x+=dx) {
+		for(int y=start.y; y!=(end.y+dy); y+=dy) {
+			work(player, koord(x,y));
+		}
+	}
+	//sint64 costs = baum_t::create_forest( nw, wh );
+	//player_t::book_construction_costs(player, costs * welt->get_settings().cst_remove_tree, end.get_2d(), ignore_wt);
+	
+	return NULL;
+}
 
 
 // show industry size in cursor (in known)

--- a/simtool.h
+++ b/simtool.h
@@ -146,7 +146,7 @@ public:
 
 class tool_marker_t : public kartenboden_tool_t {
 public:
-	tool_marker_t() : tool_t(TOOL_MARKER | GENERAL_TOOL), kartenboden_tool_t(TOOL_MARKER | GENERAL_TOOL) {}
+	tool_marker_t() : kartenboden_tool_t(TOOL_MARKER | GENERAL_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return tooltip_with_price("Marker", welt->get_settings().cst_buy_land); }
 	char const* work(player_t*, koord3d) OVERRIDE;
 	bool is_init_network_save() const OVERRIDE { return true; }
@@ -166,7 +166,7 @@ class tool_transformer_t : public kartenboden_tool_t {
 private:
 	bool is_powerline_available() const;
 public:
-	tool_transformer_t() : tool_t(TOOL_TRANSFORMER | GENERAL_TOOL), kartenboden_tool_t(TOOL_TRANSFORMER | GENERAL_TOOL) {}
+	tool_transformer_t() : kartenboden_tool_t(TOOL_TRANSFORMER | GENERAL_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE;
 	image_id get_icon(player_t*) const OVERRIDE;
 	bool init(player_t*) OVERRIDE;
@@ -178,7 +178,7 @@ public:
 
 class tool_add_city_t : public kartenboden_tool_t {
 public:
-	tool_add_city_t() : tool_t(TOOL_ADD_CITY | GENERAL_TOOL), kartenboden_tool_t(TOOL_ADD_CITY | GENERAL_TOOL) {}
+	tool_add_city_t() : kartenboden_tool_t(TOOL_ADD_CITY | GENERAL_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return tooltip_with_price("Found new city", welt->get_settings().cst_found_city); }
 	char const* work(player_t*, koord3d) OVERRIDE;
 	bool is_init_network_save() const OVERRIDE { return true; }
@@ -187,7 +187,7 @@ public:
 // buy a house to protect it from renovating
 class tool_buy_house_t : public kartenboden_tool_t {
 public:
-	tool_buy_house_t() : tool_t(TOOL_BUY_HOUSE | GENERAL_TOOL), kartenboden_tool_t(TOOL_BUY_HOUSE | GENERAL_TOOL) {}
+	tool_buy_house_t() : kartenboden_tool_t(TOOL_BUY_HOUSE | GENERAL_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("Haus kaufen"); }
 	char const* work(player_t*, koord3d) OVERRIDE;
 	bool is_init_network_save() const OVERRIDE { return true; }
@@ -218,7 +218,7 @@ public:
 // height change by default_param
 class tool_set_climate_t : public two_click_tool_t {
 public:
-	tool_set_climate_t() : tool_t(TOOL_SET_CLIMATE | GENERAL_TOOL), two_click_tool_t(TOOL_SET_CLIMATE | GENERAL_TOOL) {}
+	tool_set_climate_t() : two_click_tool_t(TOOL_SET_CLIMATE | GENERAL_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE;
 private:
 	char const* do_work(player_t*, koord3d const&, koord3d const&) OVERRIDE;
@@ -229,7 +229,7 @@ private:
 
 class tool_plant_tree_t : public kartenboden_tool_t {
 public:
-	tool_plant_tree_t() : tool_t(TOOL_PLANT_TREE | GENERAL_TOOL), kartenboden_tool_t(TOOL_PLANT_TREE | GENERAL_TOOL) {}
+	tool_plant_tree_t() : kartenboden_tool_t(TOOL_PLANT_TREE | GENERAL_TOOL) {}
 	image_id get_icon(player_t *) const { return baum_t::get_count() > 0 ? icon : IMG_EMPTY; }
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate( "Plant tree" ); }
 	bool init(player_t*) { return baum_t::get_count() > 0; }
@@ -277,7 +277,7 @@ protected:
 	virtual void start_at( koord3d &new_start );
 
 public:
-	tool_build_way_t(uint16 const id = TOOL_BUILD_WAY | GENERAL_TOOL) : tool_t(id), two_click_tool_t(id), desc() {
+	tool_build_way_t(uint16 const id = TOOL_BUILD_WAY | GENERAL_TOOL) : two_click_tool_t(id), desc() {
 		overtaking_mode = twoway_mode;
 	 }
 	image_id get_icon(player_t*) const OVERRIDE;
@@ -305,7 +305,7 @@ class tool_build_cityroad : public tool_build_way_t {
 private:
 	char const* do_work(player_t*, koord3d const&, koord3d const&) OVERRIDE;
 public:
-	tool_build_cityroad() : tool_t(TOOL_BUILD_CITYROAD | GENERAL_TOOL), tool_build_way_t(TOOL_BUILD_CITYROAD | GENERAL_TOOL) {}
+	tool_build_cityroad() : tool_build_way_t(TOOL_BUILD_CITYROAD | GENERAL_TOOL) {}
 	way_desc_t const* get_desc(uint16, bool) const OVERRIDE;
 	image_id get_icon(player_t* const player) const OVERRIDE { return tool_t::get_icon(player); }
 	bool is_selected() const OVERRIDE { return tool_t::is_selected(); }
@@ -323,7 +323,7 @@ private:
 	uint8 is_valid_pos(player_t*, koord3d const&, char const*&, koord3d const&) OVERRIDE;
 
 public:
-	tool_build_bridge_t() : tool_t(TOOL_BUILD_BRIDGE | GENERAL_TOOL), two_click_tool_t(TOOL_BUILD_BRIDGE | GENERAL_TOOL) {
+	tool_build_bridge_t() : two_click_tool_t(TOOL_BUILD_BRIDGE | GENERAL_TOOL) {
 		overtaking_mode = twoway_mode;
 	}
 	image_id get_icon(player_t*) const OVERRIDE { return grund_t::underground_mode==grund_t::ugm_all ? IMG_EMPTY : icon; }
@@ -350,7 +350,7 @@ private:
 	uint8 is_valid_pos(player_t*, koord3d const&, char const*&, koord3d const&) OVERRIDE;
 
 public:
-	tool_build_tunnel_t() : tool_t(TOOL_BUILD_TUNNEL | GENERAL_TOOL), two_click_tool_t(TOOL_BUILD_TUNNEL | GENERAL_TOOL) {
+	tool_build_tunnel_t() : two_click_tool_t(TOOL_BUILD_TUNNEL | GENERAL_TOOL) {
 		overtaking_mode = twoway_mode;
 	}
 	char const* get_tooltip(player_t const*) const OVERRIDE;
@@ -375,7 +375,7 @@ private:
 	// error message to be returned by calc_route
 	const char *calc_route_error;
 public:
-	tool_wayremover_t() : tool_t(TOOL_WAYREMOVER | GENERAL_TOOL), two_click_tool_t(TOOL_WAYREMOVER | GENERAL_TOOL) {}
+	tool_wayremover_t() : two_click_tool_t(TOOL_WAYREMOVER | GENERAL_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE;
 	image_id get_icon(player_t*) const OVERRIDE;
 	bool is_init_network_save() const OVERRIDE { return true; }
@@ -398,7 +398,7 @@ private:
 	uint8 is_valid_pos(player_t*, koord3d const&, char const*&, koord3d const&) OVERRIDE;
 
 public:
-	tool_build_wayobj_t(uint16 const id = TOOL_BUILD_WAYOBJ | GENERAL_TOOL, bool b = true) : tool_t(id), two_click_tool_t(id), build(b) {}
+	tool_build_wayobj_t(uint16 const id = TOOL_BUILD_WAYOBJ | GENERAL_TOOL, bool b = true) : two_click_tool_t(id), build(b) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE;
 	bool is_selected() const OVERRIDE;
 	bool init(player_t*) OVERRIDE;
@@ -408,7 +408,7 @@ public:
 
 class tool_remove_wayobj_t : public tool_build_wayobj_t {
 public:
-	tool_remove_wayobj_t() : tool_t(TOOL_REMOVE_WAYOBJ | GENERAL_TOOL), tool_build_wayobj_t(TOOL_REMOVE_WAYOBJ | GENERAL_TOOL, false) {}
+	tool_remove_wayobj_t() : tool_build_wayobj_t(TOOL_REMOVE_WAYOBJ | GENERAL_TOOL, false) {}
 	bool is_selected() const OVERRIDE { return tool_t::is_selected(); }
 	bool is_init_network_save() const OVERRIDE { return true; }
 };
@@ -475,7 +475,7 @@ private:
 	vector_tpl< ribi_t::ribi > directions;
 
 public:
-	tool_build_roadsign_t() : tool_t(TOOL_BUILD_ROADSIGN | GENERAL_TOOL), two_click_tool_t(TOOL_BUILD_ROADSIGN | GENERAL_TOOL), desc() {}
+	tool_build_roadsign_t() : two_click_tool_t(TOOL_BUILD_ROADSIGN | GENERAL_TOOL), desc() {}
 
 	char const* get_tooltip(player_t const*) const OVERRIDE;
 	bool init(player_t*) OVERRIDE;
@@ -510,19 +510,9 @@ public:
  * finally building name
  * @author prissi
  */
-/*
-class tool_build_house_t : public kartenboden_tool_t {
-public:
-	tool_build_house_t() : tool_t(TOOL_BUILD_HOUSE | GENERAL_TOOL), kartenboden_tool_t(TOOL_BUILD_HOUSE | GENERAL_TOOL) {}
-	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("Built random attraction"); }
-	bool init(player_t*) OVERRIDE;
-	char const* work(player_t*, koord3d) OVERRIDE;
-	bool is_init_network_save() const OVERRIDE { return true; }
-};
-*/
 class tool_build_house_t : public two_click_kartenboden_tool_t {
 public:
-	tool_build_house_t() : tool_t(TOOL_BUILD_HOUSE | GENERAL_TOOL), two_click_kartenboden_tool_t(TOOL_BUILD_HOUSE | GENERAL_TOOL) {}
+	tool_build_house_t() : two_click_kartenboden_tool_t(TOOL_BUILD_HOUSE | GENERAL_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("Built random attraction"); }
 	bool init(player_t*) OVERRIDE;
 	//char const* work(player_t*, koord3d) OVERRIDE;
@@ -546,7 +536,7 @@ public:
  */
 class tool_build_land_chain_t : public kartenboden_tool_t {
 public:
-	tool_build_land_chain_t() : tool_t(TOOL_BUILD_LAND_CHAIN | GENERAL_TOOL), kartenboden_tool_t(TOOL_BUILD_LAND_CHAIN | GENERAL_TOOL) {}
+	tool_build_land_chain_t() : kartenboden_tool_t(TOOL_BUILD_LAND_CHAIN | GENERAL_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("Build land consumer"); }
 	bool init(player_t*) OVERRIDE;
 	char const* work(player_t*, koord3d) OVERRIDE;
@@ -555,7 +545,7 @@ public:
 
 class tool_city_chain_t : public kartenboden_tool_t {
 public:
-	tool_city_chain_t() : tool_t(TOOL_CITY_CHAIN | GENERAL_TOOL), kartenboden_tool_t(TOOL_CITY_CHAIN | GENERAL_TOOL) {}
+	tool_city_chain_t() : kartenboden_tool_t(TOOL_CITY_CHAIN | GENERAL_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("Build city market"); }
 	bool init(player_t*) OVERRIDE;
 	char const* work(player_t*, koord3d) OVERRIDE;
@@ -564,7 +554,7 @@ public:
 
 class tool_build_factory_t : public kartenboden_tool_t {
 public:
-	tool_build_factory_t() : tool_t(TOOL_BUILD_FACTORY | GENERAL_TOOL), kartenboden_tool_t(TOOL_BUILD_FACTORY | GENERAL_TOOL) {}
+	tool_build_factory_t() : kartenboden_tool_t(TOOL_BUILD_FACTORY | GENERAL_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("Build city market"); }
 	bool init(player_t*) OVERRIDE;
 	char const* work(player_t*, koord3d) OVERRIDE;
@@ -573,7 +563,7 @@ public:
 
 class tool_link_factory_t : public two_click_tool_t {
 public:
-	tool_link_factory_t() : tool_t(TOOL_LINK_FACTORY | GENERAL_TOOL), two_click_tool_t(TOOL_LINK_FACTORY | GENERAL_TOOL) {}
+	tool_link_factory_t() : two_click_tool_t(TOOL_LINK_FACTORY | GENERAL_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("Connect factory"); }
 	bool is_init_network_save() const OVERRIDE { return true; }
 private:
@@ -587,7 +577,7 @@ class tool_headquarter_t : public kartenboden_tool_t {
 private:
 	const building_desc_t *next_level( const player_t *player ) const;
 public:
-	tool_headquarter_t() : tool_t(TOOL_HEADQUARTER | GENERAL_TOOL), kartenboden_tool_t(TOOL_HEADQUARTER | GENERAL_TOOL) {}
+	tool_headquarter_t() : kartenboden_tool_t(TOOL_HEADQUARTER | GENERAL_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE;
 	bool init(player_t*) OVERRIDE;
 	char const* work(player_t*, koord3d) OVERRIDE;
@@ -618,7 +608,7 @@ public:
 /* make forest */
 class tool_forest_t : public two_click_tool_t {
 public:
-	tool_forest_t() : tool_t(TOOL_FOREST | GENERAL_TOOL), two_click_tool_t(TOOL_FOREST | GENERAL_TOOL) {}
+	tool_forest_t() : two_click_tool_t(TOOL_FOREST | GENERAL_TOOL) {}
 	image_id get_icon(player_t *) const { return baum_t::get_count() > 0 ? icon : IMG_EMPTY; }
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("Add forest"); }
 	bool init( player_t *player) { return  baum_t::get_count() > 0  &&  two_click_tool_t::init(player); }
@@ -635,7 +625,7 @@ private:
 	waytype_t waytype[2];
 	halthandle_t last_halt;
 public:
-	tool_stop_mover_t() : tool_t(TOOL_STOP_MOVER | GENERAL_TOOL), two_click_tool_t(TOOL_STOP_MOVER | GENERAL_TOOL) {}
+	tool_stop_mover_t() : two_click_tool_t(TOOL_STOP_MOVER | GENERAL_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("replace stop"); }
 	bool is_init_network_save() const OVERRIDE { return true; }
 

--- a/simtool.h
+++ b/simtool.h
@@ -512,10 +512,9 @@ public:
  */
 class tool_build_house_t : public two_click_kartenboden_tool_t {
 public:
-	tool_build_house_t() : two_click_kartenboden_tool_t(TOOL_BUILD_HOUSE | GENERAL_TOOL) {}
+	tool_build_house_t() : two_click_kartenboden_tool_t(TOOL_BUILD_HOUSE | GENERAL_TOOL) {one_click = true;}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("Built random attraction"); }
 	bool init(player_t*) OVERRIDE;
-	//char const* work(player_t*, koord3d) OVERRIDE;
 	char const* work(player_t*, koord);
 	bool is_init_network_save() const OVERRIDE { return true; }
 

--- a/simtool.h
+++ b/simtool.h
@@ -146,7 +146,7 @@ public:
 
 class tool_marker_t : public kartenboden_tool_t {
 public:
-	tool_marker_t() : kartenboden_tool_t(TOOL_MARKER | GENERAL_TOOL) {}
+	tool_marker_t() : tool_t(TOOL_MARKER | GENERAL_TOOL), kartenboden_tool_t(TOOL_MARKER | GENERAL_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return tooltip_with_price("Marker", welt->get_settings().cst_buy_land); }
 	char const* work(player_t*, koord3d) OVERRIDE;
 	bool is_init_network_save() const OVERRIDE { return true; }
@@ -166,7 +166,7 @@ class tool_transformer_t : public kartenboden_tool_t {
 private:
 	bool is_powerline_available() const;
 public:
-	tool_transformer_t() : kartenboden_tool_t(TOOL_TRANSFORMER | GENERAL_TOOL) {}
+	tool_transformer_t() : tool_t(TOOL_TRANSFORMER | GENERAL_TOOL), kartenboden_tool_t(TOOL_TRANSFORMER | GENERAL_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE;
 	image_id get_icon(player_t*) const OVERRIDE;
 	bool init(player_t*) OVERRIDE;
@@ -178,7 +178,7 @@ public:
 
 class tool_add_city_t : public kartenboden_tool_t {
 public:
-	tool_add_city_t() : kartenboden_tool_t(TOOL_ADD_CITY | GENERAL_TOOL) {}
+	tool_add_city_t() : tool_t(TOOL_ADD_CITY | GENERAL_TOOL), kartenboden_tool_t(TOOL_ADD_CITY | GENERAL_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return tooltip_with_price("Found new city", welt->get_settings().cst_found_city); }
 	char const* work(player_t*, koord3d) OVERRIDE;
 	bool is_init_network_save() const OVERRIDE { return true; }
@@ -187,7 +187,7 @@ public:
 // buy a house to protect it from renovating
 class tool_buy_house_t : public kartenboden_tool_t {
 public:
-	tool_buy_house_t() : kartenboden_tool_t(TOOL_BUY_HOUSE | GENERAL_TOOL) {}
+	tool_buy_house_t() : tool_t(TOOL_BUY_HOUSE | GENERAL_TOOL), kartenboden_tool_t(TOOL_BUY_HOUSE | GENERAL_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("Haus kaufen"); }
 	char const* work(player_t*, koord3d) OVERRIDE;
 	bool is_init_network_save() const OVERRIDE { return true; }
@@ -218,7 +218,7 @@ public:
 // height change by default_param
 class tool_set_climate_t : public two_click_tool_t {
 public:
-	tool_set_climate_t() : two_click_tool_t(TOOL_SET_CLIMATE | GENERAL_TOOL) {}
+	tool_set_climate_t() : tool_t(TOOL_SET_CLIMATE | GENERAL_TOOL), two_click_tool_t(TOOL_SET_CLIMATE | GENERAL_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE;
 private:
 	char const* do_work(player_t*, koord3d const&, koord3d const&) OVERRIDE;
@@ -229,7 +229,7 @@ private:
 
 class tool_plant_tree_t : public kartenboden_tool_t {
 public:
-	tool_plant_tree_t() : kartenboden_tool_t(TOOL_PLANT_TREE | GENERAL_TOOL) {}
+	tool_plant_tree_t() : tool_t(TOOL_PLANT_TREE | GENERAL_TOOL), kartenboden_tool_t(TOOL_PLANT_TREE | GENERAL_TOOL) {}
 	image_id get_icon(player_t *) const { return baum_t::get_count() > 0 ? icon : IMG_EMPTY; }
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate( "Plant tree" ); }
 	bool init(player_t*) { return baum_t::get_count() > 0; }
@@ -277,7 +277,7 @@ protected:
 	virtual void start_at( koord3d &new_start );
 
 public:
-	tool_build_way_t(uint16 const id = TOOL_BUILD_WAY | GENERAL_TOOL) : two_click_tool_t(id), desc() {
+	tool_build_way_t(uint16 const id = TOOL_BUILD_WAY | GENERAL_TOOL) : tool_t(id), two_click_tool_t(id), desc() {
 		overtaking_mode = twoway_mode;
 	 }
 	image_id get_icon(player_t*) const OVERRIDE;
@@ -305,7 +305,7 @@ class tool_build_cityroad : public tool_build_way_t {
 private:
 	char const* do_work(player_t*, koord3d const&, koord3d const&) OVERRIDE;
 public:
-	tool_build_cityroad() : tool_build_way_t(TOOL_BUILD_CITYROAD | GENERAL_TOOL) {}
+	tool_build_cityroad() : tool_t(TOOL_BUILD_CITYROAD | GENERAL_TOOL), tool_build_way_t(TOOL_BUILD_CITYROAD | GENERAL_TOOL) {}
 	way_desc_t const* get_desc(uint16, bool) const OVERRIDE;
 	image_id get_icon(player_t* const player) const OVERRIDE { return tool_t::get_icon(player); }
 	bool is_selected() const OVERRIDE { return tool_t::is_selected(); }
@@ -323,7 +323,7 @@ private:
 	uint8 is_valid_pos(player_t*, koord3d const&, char const*&, koord3d const&) OVERRIDE;
 
 public:
-	tool_build_bridge_t() : two_click_tool_t(TOOL_BUILD_BRIDGE | GENERAL_TOOL) {
+	tool_build_bridge_t() : tool_t(TOOL_BUILD_BRIDGE | GENERAL_TOOL), two_click_tool_t(TOOL_BUILD_BRIDGE | GENERAL_TOOL) {
 		overtaking_mode = twoway_mode;
 	}
 	image_id get_icon(player_t*) const OVERRIDE { return grund_t::underground_mode==grund_t::ugm_all ? IMG_EMPTY : icon; }
@@ -350,7 +350,7 @@ private:
 	uint8 is_valid_pos(player_t*, koord3d const&, char const*&, koord3d const&) OVERRIDE;
 
 public:
-	tool_build_tunnel_t() : two_click_tool_t(TOOL_BUILD_TUNNEL | GENERAL_TOOL) {
+	tool_build_tunnel_t() : tool_t(TOOL_BUILD_TUNNEL | GENERAL_TOOL), two_click_tool_t(TOOL_BUILD_TUNNEL | GENERAL_TOOL) {
 		overtaking_mode = twoway_mode;
 	}
 	char const* get_tooltip(player_t const*) const OVERRIDE;
@@ -375,7 +375,7 @@ private:
 	// error message to be returned by calc_route
 	const char *calc_route_error;
 public:
-	tool_wayremover_t() : two_click_tool_t(TOOL_WAYREMOVER | GENERAL_TOOL) {}
+	tool_wayremover_t() : tool_t(TOOL_WAYREMOVER | GENERAL_TOOL), two_click_tool_t(TOOL_WAYREMOVER | GENERAL_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE;
 	image_id get_icon(player_t*) const OVERRIDE;
 	bool is_init_network_save() const OVERRIDE { return true; }
@@ -398,7 +398,7 @@ private:
 	uint8 is_valid_pos(player_t*, koord3d const&, char const*&, koord3d const&) OVERRIDE;
 
 public:
-	tool_build_wayobj_t(uint16 const id = TOOL_BUILD_WAYOBJ | GENERAL_TOOL, bool b = true) : two_click_tool_t(id), build(b) {}
+	tool_build_wayobj_t(uint16 const id = TOOL_BUILD_WAYOBJ | GENERAL_TOOL, bool b = true) : tool_t(id), two_click_tool_t(id), build(b) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE;
 	bool is_selected() const OVERRIDE;
 	bool init(player_t*) OVERRIDE;
@@ -408,7 +408,7 @@ public:
 
 class tool_remove_wayobj_t : public tool_build_wayobj_t {
 public:
-	tool_remove_wayobj_t() : tool_build_wayobj_t(TOOL_REMOVE_WAYOBJ | GENERAL_TOOL, false) {}
+	tool_remove_wayobj_t() : tool_t(TOOL_REMOVE_WAYOBJ | GENERAL_TOOL), tool_build_wayobj_t(TOOL_REMOVE_WAYOBJ | GENERAL_TOOL, false) {}
 	bool is_selected() const OVERRIDE { return tool_t::is_selected(); }
 	bool is_init_network_save() const OVERRIDE { return true; }
 };
@@ -475,7 +475,7 @@ private:
 	vector_tpl< ribi_t::ribi > directions;
 
 public:
-	tool_build_roadsign_t() : two_click_tool_t(TOOL_BUILD_ROADSIGN | GENERAL_TOOL), desc() {}
+	tool_build_roadsign_t() : tool_t(TOOL_BUILD_ROADSIGN | GENERAL_TOOL), two_click_tool_t(TOOL_BUILD_ROADSIGN | GENERAL_TOOL), desc() {}
 
 	char const* get_tooltip(player_t const*) const OVERRIDE;
 	bool init(player_t*) OVERRIDE;
@@ -510,13 +510,29 @@ public:
  * finally building name
  * @author prissi
  */
+/*
 class tool_build_house_t : public kartenboden_tool_t {
 public:
-	tool_build_house_t() : kartenboden_tool_t(TOOL_BUILD_HOUSE | GENERAL_TOOL) {}
+	tool_build_house_t() : tool_t(TOOL_BUILD_HOUSE | GENERAL_TOOL), kartenboden_tool_t(TOOL_BUILD_HOUSE | GENERAL_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("Built random attraction"); }
 	bool init(player_t*) OVERRIDE;
 	char const* work(player_t*, koord3d) OVERRIDE;
 	bool is_init_network_save() const OVERRIDE { return true; }
+};
+*/
+class tool_build_house_t : public two_click_kartenboden_tool_t {
+public:
+	tool_build_house_t() : tool_t(TOOL_BUILD_HOUSE | GENERAL_TOOL), two_click_kartenboden_tool_t(TOOL_BUILD_HOUSE | GENERAL_TOOL) {}
+	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("Built random attraction"); }
+	bool init(player_t*) OVERRIDE;
+	//char const* work(player_t*, koord3d) OVERRIDE;
+	char const* work(player_t*, koord);
+	bool is_init_network_save() const OVERRIDE { return true; }
+
+	char const* do_work(player_t*, koord3d const&, koord3d const&) OVERRIDE;
+	void mark_tiles(player_t*, koord3d const&, koord3d const&) OVERRIDE;
+	uint8 is_valid_pos(player_t*, koord3d const&, char const*&, koord3d const&) OVERRIDE {return 2;};
+	image_id get_icon(player_t *) const { return baum_t::get_count() > 0 ? icon : IMG_EMPTY; }
 };
 
 /* builds an (if param=NULL random) industry chain starting here *
@@ -530,7 +546,7 @@ public:
  */
 class tool_build_land_chain_t : public kartenboden_tool_t {
 public:
-	tool_build_land_chain_t() : kartenboden_tool_t(TOOL_BUILD_LAND_CHAIN | GENERAL_TOOL) {}
+	tool_build_land_chain_t() : tool_t(TOOL_BUILD_LAND_CHAIN | GENERAL_TOOL), kartenboden_tool_t(TOOL_BUILD_LAND_CHAIN | GENERAL_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("Build land consumer"); }
 	bool init(player_t*) OVERRIDE;
 	char const* work(player_t*, koord3d) OVERRIDE;
@@ -539,7 +555,7 @@ public:
 
 class tool_city_chain_t : public kartenboden_tool_t {
 public:
-	tool_city_chain_t() : kartenboden_tool_t(TOOL_CITY_CHAIN | GENERAL_TOOL) {}
+	tool_city_chain_t() : tool_t(TOOL_CITY_CHAIN | GENERAL_TOOL), kartenboden_tool_t(TOOL_CITY_CHAIN | GENERAL_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("Build city market"); }
 	bool init(player_t*) OVERRIDE;
 	char const* work(player_t*, koord3d) OVERRIDE;
@@ -548,7 +564,7 @@ public:
 
 class tool_build_factory_t : public kartenboden_tool_t {
 public:
-	tool_build_factory_t() : kartenboden_tool_t(TOOL_BUILD_FACTORY | GENERAL_TOOL) {}
+	tool_build_factory_t() : tool_t(TOOL_BUILD_FACTORY | GENERAL_TOOL), kartenboden_tool_t(TOOL_BUILD_FACTORY | GENERAL_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("Build city market"); }
 	bool init(player_t*) OVERRIDE;
 	char const* work(player_t*, koord3d) OVERRIDE;
@@ -557,7 +573,7 @@ public:
 
 class tool_link_factory_t : public two_click_tool_t {
 public:
-	tool_link_factory_t() : two_click_tool_t(TOOL_LINK_FACTORY | GENERAL_TOOL) {}
+	tool_link_factory_t() : tool_t(TOOL_LINK_FACTORY | GENERAL_TOOL), two_click_tool_t(TOOL_LINK_FACTORY | GENERAL_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("Connect factory"); }
 	bool is_init_network_save() const OVERRIDE { return true; }
 private:
@@ -571,7 +587,7 @@ class tool_headquarter_t : public kartenboden_tool_t {
 private:
 	const building_desc_t *next_level( const player_t *player ) const;
 public:
-	tool_headquarter_t() : kartenboden_tool_t(TOOL_HEADQUARTER | GENERAL_TOOL) {}
+	tool_headquarter_t() : tool_t(TOOL_HEADQUARTER | GENERAL_TOOL), kartenboden_tool_t(TOOL_HEADQUARTER | GENERAL_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE;
 	bool init(player_t*) OVERRIDE;
 	char const* work(player_t*, koord3d) OVERRIDE;
@@ -602,7 +618,7 @@ public:
 /* make forest */
 class tool_forest_t : public two_click_tool_t {
 public:
-	tool_forest_t() : two_click_tool_t(TOOL_FOREST | GENERAL_TOOL) {}
+	tool_forest_t() : tool_t(TOOL_FOREST | GENERAL_TOOL), two_click_tool_t(TOOL_FOREST | GENERAL_TOOL) {}
 	image_id get_icon(player_t *) const { return baum_t::get_count() > 0 ? icon : IMG_EMPTY; }
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("Add forest"); }
 	bool init( player_t *player) { return  baum_t::get_count() > 0  &&  two_click_tool_t::init(player); }
@@ -619,7 +635,7 @@ private:
 	waytype_t waytype[2];
 	halthandle_t last_halt;
 public:
-	tool_stop_mover_t() : two_click_tool_t(TOOL_STOP_MOVER | GENERAL_TOOL) {}
+	tool_stop_mover_t() : tool_t(TOOL_STOP_MOVER | GENERAL_TOOL), two_click_tool_t(TOOL_STOP_MOVER | GENERAL_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("replace stop"); }
 	bool is_init_network_save() const OVERRIDE { return true; }
 


### PR DESCRIPTION
This modification will realizes "regional mass treatment of citybuilding and Curiosity" with each current tool icon.

And additional value of this commit is "extention for co-existence with one_click mode on two_click_tool_t" .
By this value, more others class which is derived from tool_t will be able to extend to be two_click_tool_t without losing current its "work", as you like.

Please pull this, if you are interested in. Best regards.