### PR TITLE
tool_remover_t area proc : bugfix : Resolve the build error using MinGW

### DIFF
--- a/simtool.h
+++ b/simtool.h
@@ -59,7 +59,7 @@ private:
 public:
 	tool_remover_t() : two_click_tool_t(TOOL_REMOVER | GENERAL_TOOL) { one_click = true; }
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("Abriss"); }
-	char const* process(player_t*, koord3d) OVERRIDE;
+	char const* process(player_t*, koord3d);
 	bool is_init_network_save() const OVERRIDE { return true; }
 	
 	char const* do_work(player_t*, koord3d const&, koord3d const&) OVERRIDE;


### PR DESCRIPTION
This commit is for resolving the build error when build with MinGW.
I'm sorry for my failure about 'tool_remover_t area proc' (https://github.com/shingoushori/simutrans/commit/206cc809344daeb1eb4875be116af2357e472b8f).
Would you please pull this resolve?
Best regards.