### PR TITLE
-snapshot

### DIFF
--- a/dataobj/environment.cc
+++ b/dataobj/environment.cc
@@ -156,6 +156,10 @@ bool env_t::hide_keyboard = false;
 
 bool env_t::previous_OTRP_data;
 
+bool  env_t::commandline_snapshot = false;
+koord env_t::commandline_snapshot_world_position = koord(0, 0);
+sint8 env_t::commandline_snapshot_world_position_z = 0;
+int   env_t::commandline_snapshot_zoom_factor = 3; // ZOOM_NEUTRAL (3)
 
 
 // Hajo: Define default settings.

--- a/dataobj/environment.h
+++ b/dataobj/environment.h
@@ -421,6 +421,14 @@ public:
 	static bool previous_OTRP_data;
 
 
+    /// To make the snapshot like a commandline tool
+	/// can be set by command-line switch '-snapshot'
+	/// @author shingoushori
+	static bool commandline_snapshot;
+	static koord commandline_snapshot_world_position;
+	static sint8 commandline_snapshot_world_position_z;
+	static int commandline_snapshot_zoom_factor;
+	
 	/**
 	 * @name Midi/sound options
 	 */

--- a/display/simgraph.h
+++ b/display/simgraph.h
@@ -120,6 +120,7 @@ extern KOORD_VAL base_tile_raster_width;
 KOORD_VAL display_set_base_raster_width(KOORD_VAL new_raster);
 
 
+void set_zoom_factor_safe(int);
 int zoom_factor_up();
 int zoom_factor_down();
 

--- a/display/simgraph0.cc
+++ b/display/simgraph0.cc
@@ -46,6 +46,10 @@ void set_zoom_factor(int)
 {
 }
 
+void set_zoom_factor_safe(int)
+{
+}
+
 int zoom_factor_up()
 {
 	return false;

--- a/display/simgraph16.cc
+++ b/display/simgraph16.cc
@@ -1143,6 +1143,15 @@ void set_zoom_factor(int z)
 }
 
 
+void set_zoom_factor_safe(int z)
+{
+	if(  z < 0  ||  MAX_ZOOM_FACTOR < z  ) {
+		return;
+	}
+	set_zoom_factor(z);
+}
+
+
 int zoom_factor_up()
 {
 	// zoom out, if size permits

--- a/simmain.cc
+++ b/simmain.cc
@@ -430,7 +430,7 @@ int simu_main(int argc, char** argv)
 			"  <markus@pristovsek.de>\n"
 			"\n"
 			"  Based on Simutrans 0.84.21.2\n"
-			"  by Hansjörg Malthaner et. al.\n"
+			"  by Hansjï¿½rg Malthaner et. al.\n"
 			"---------------------------------------\n"
 			"command line parameters available: \n"
 			" -addons             loads also addons (with -objects)\n"
@@ -482,6 +482,8 @@ int simu_main(int argc, char** argv)
 			" -until YEAR.MONTH   quits when MONTH of YEAR starts\n"
 #endif
 			" -use_workdir        use current dir as basedir\n"
+			" -snapshot x,y,z,f   to make the snapshot like a commandline tool\n"
+			"                     (x,y,z) : center position, f : zoom_factor (from 0 to 9)\n"
 		);
 		return 0;
 	}
@@ -1122,6 +1124,21 @@ int simu_main(int argc, char** argv)
 
 	if(  translator::get_language()==-1  ) {
 		ask_language();
+	}
+
+	env_t::commandline_snapshot = false;
+	if(  gimme_arg(argc, argv, "-snapshot", 0) != NULL  ) {
+		const char *s = gimme_arg(argc, argv, "-snapshot", 1);
+		int x = 0, y = 0, z = 0, f = 0;
+		if(  s!=NULL  ) {
+			if(  sscanf(s,"%d,%d,%d,%d",&x,&y,&z,&f) == 4  ) {
+				dbg->message("simmain()", "-snapshot x,y,z,f=%d,%d,%d,%d", x, y, z, f );
+				env_t::commandline_snapshot = true;
+				env_t::commandline_snapshot_world_position = koord(x,y);
+				env_t::commandline_snapshot_world_position_z = (sint8)z;
+				env_t::commandline_snapshot_zoom_factor = f;
+			}
+		}
 	}
 
 	bool new_world = true;

--- a/simworld.cc
+++ b/simworld.cc
@@ -6722,7 +6722,16 @@ bool karte_t::interactive(uint32 quit_month)
 		// time for the next step?
 		uint32 time = dr_time();
 		if(  (sint32)next_step_time - (sint32)time <= 0  ) {
-			if(  step_mode&PAUSE_FLAG  ) {
+			if(  env_t::commandline_snapshot  ) {
+				destroy_all_win(true);
+				get_viewport()->change_world_position( koord3d( env_t::commandline_snapshot_world_position, env_t::commandline_snapshot_world_position_z ) );
+				set_zoom_factor_safe( env_t::commandline_snapshot_zoom_factor );
+				get_viewport()->metrics_updated();
+				sync_step( 0, false, true );
+				display_snapshot( 0, 0, display_get_width(), display_get_height() );
+				env_t::quit_simutrans = true;
+			}
+			else if(  step_mode&PAUSE_FLAG  ) {
 				// only update display
 				sync_step( 0, false, true );
 				idle_time = 100;


### PR DESCRIPTION
This modify supplies '-snapshot' option, 
which for to make the snapshot like a command line tool.

Additionally, recommend to use -load and -pause with -snapshot.
ex : in case of set center position as (1,2,3) and zoom_factor as 4
./simutrans -pause -snapshot 1,2,3,4 -load hoge.sve

Please pull this, if you are interested in. Best regards.