### PR TITLE
Add Reverse Convoy Direction and Add Reverse Orders of Conpling/Coupled Convoys

### DIFF
--- a/dataobj/environment.h
+++ b/dataobj/environment.h
@@ -505,6 +505,10 @@ public:
 	/// put a newly created toolbar below other toolbars.
 	static bool put_new_toolbar_below_others;
 
+	
+	// Graphical offsets for reverseing vehicles
+	static sint8 reverse_base_offsets[8][3];
+
 	/// initialize with default values
 	static void init();
 

--- a/dataobj/environment.h
+++ b/dataobj/environment.h
@@ -506,8 +506,7 @@ public:
 	static bool put_new_toolbar_below_others;
 
 	
-	// Graphical offsets for reverseing vehicles
-	static sint8 reverse_base_offsets[8][3];
+
 
 	/// initialize with default values
 	static void init();

--- a/dataobj/schedule.cc
+++ b/dataobj/schedule.cc
@@ -48,7 +48,6 @@ void schedule_t::copy_from(const schedule_t *src)
 
 	editing_finished = src->is_editing_finished();
 	flags = src->get_flags();
-	flag2 = src->get_flag2();
 	max_speed = src->get_max_speed();
 	departure_slot_group_id = src->get_departure_slot_group_id();
 	additional_base_waiting_time = src->get_additional_base_waiting_time();
@@ -241,11 +240,7 @@ void schedule_t::rdwr(loadsave_t *file)
 		file->rdwr_long(additional_base_waiting_time);
 	}
 
-	if( file->get_OTRP_version()>=41) {
-		file->rdwr_byte(flag2);
-	} else {
-		flag2 = NONE;
-	}
+
 
 	if(file->is_version_less(99, 12)) {
 		for(  uint8 i=0; i<size; i++  ) {

--- a/dataobj/schedule.cc
+++ b/dataobj/schedule.cc
@@ -617,7 +617,7 @@ void construct_schedule_entry_attributes(cbuffer_t& buf, schedule_entry_t const&
 		str[cnt] = 'R';
 		cnt++;
 	}
-	if(  entry.is_reverse_parent_children()  ) {
+	if(  entry.is_reverse_convoi_coupling()  ) {
 		str[cnt] = 'T';
 		cnt++;
 	}

--- a/dataobj/schedule.h
+++ b/dataobj/schedule.h
@@ -29,7 +29,6 @@ class schedule_t
 	uint8 current_stop;
 	
 	uint8 flags;
-	uint8 flag2;// uint flag for storing reversing information. which has the information of uint16 stop_flags&0xFF00. 
 	
 	// operational maximum speed of this schedule. 0 => no limit.
 	uint16 max_speed;

--- a/dataobj/schedule.h
+++ b/dataobj/schedule.h
@@ -133,7 +133,6 @@ public:
 	void start_editing() { editing_finished = false; }
 	
 	uint8 get_flags() const { return flags; }
-	uint8 get_flag2() const { return flag2; }
 	void set_flags(uint8 f) { flags = f; }
 	bool is_temporary() const { return (flags&TEMPORARY)>0; }
 	void set_temporary(bool y) { y ? flags |= TEMPORARY : flags &= ~TEMPORARY; }

--- a/dataobj/schedule.h
+++ b/dataobj/schedule.h
@@ -29,6 +29,7 @@ class schedule_t
 	uint8 current_stop;
 	
 	uint8 flags;
+	uint8 flag2;
 	
 	// operational maximum speed of this schedule. 0 => no limit.
 	uint16 max_speed;
@@ -132,6 +133,7 @@ public:
 	void start_editing() { editing_finished = false; }
 	
 	uint8 get_flags() const { return flags; }
+	uint8 get_flag2() const { return flag2; }
 	void set_flags(uint8 f) { flags = f; }
 	bool is_temporary() const { return (flags&TEMPORARY)>0; }
 	void set_temporary(bool y) { y ? flags |= TEMPORARY : flags &= ~TEMPORARY; }
@@ -169,12 +171,12 @@ public:
 	/**
 	 * Inserts a coordinate at current_stop into the schedule.
 	 */
-	bool insert(const grund_t* gr, uint8 minimum_loading = 0, uint16 waiting_time_shift = 0, uint8 coupling_point = 0);
+	bool insert(const grund_t* gr, uint8 minimum_loading = 0, uint16 waiting_time_shift = 0, uint8 coupling_point = 0, uint8 reverse_flag = 0);
 
 	/**
 	 * Appends a coordinate to the schedule.
 	 */
-	bool append(const grund_t* gr, uint8 minimum_loading = 0, uint16 waiting_time_shift = 0, uint8 coupling_point = 0);
+	bool append(const grund_t* gr, uint8 minimum_loading = 0, uint16 waiting_time_shift = 0, uint8 coupling_point = 0, uint8 reverse_flag = 0);
 
 	/**
 	 * Cleanup a schedule, removes double entries.

--- a/dataobj/schedule.h
+++ b/dataobj/schedule.h
@@ -29,7 +29,7 @@ class schedule_t
 	uint8 current_stop;
 	
 	uint8 flags;
-	uint8 flag2;
+	uint8 flag2;// uint flag for storing reversing information. which has the information of uint16 stop_flags&0xFF00. 
 	
 	// operational maximum speed of this schedule. 0 => no limit.
 	uint16 max_speed;

--- a/dataobj/schedule_entry.h
+++ b/dataobj/schedule_entry.h
@@ -47,10 +47,9 @@ public:
 		UNLOAD_ALL        = 1U << 5, // The convoy unloads all loads here.
 		LOAD_BEFORE_DEP   = 1U << 6, // The convoy loads just before the departure.
 		TRANSFER_INTERVAL = 1U << 7,
-		REVERSE_CONVOY	= 1U << 8,// The reverse order of vehicles in convoy
-		REVERSE_PARENT_CHILDREN		= 1U << 9,// The reverse order of connected convoys
-	}
-	;
+		REVERSE_CONVOY	= 1U << 8,// convoy reverses the order of its vehicles.
+		REVERSE_convoi_coupling		= 1U << 9,// The convoy reverse the parent-child relationship of the convoy coupling.
+	};
 
 	/**
 	 * target position
@@ -141,8 +140,8 @@ public:
 
 	bool is_reverse_convoy() const { return (stop_flags&REVERSE_CONVOY)>0; }
 	void set_reverse_convoy(bool y) { y ? stop_flags |= REVERSE_CONVOY : stop_flags&= ~REVERSE_CONVOY; }
-	bool is_reverse_parent_children() const { return (stop_flags&REVERSE_PARENT_CHILDREN)>0; } 
-	void set_reverse_parent_children(bool y) { y ? stop_flags |= REVERSE_PARENT_CHILDREN : stop_flags &= ~REVERSE_PARENT_CHILDREN; }
+	bool is_reverse_convoi_coupling() const { return (stop_flags&REVERSE_convoi_coupling)>0; } 
+	void set_reverse_convoi_coupling(bool y) { y ? stop_flags |= REVERSE_convoi_coupling : stop_flags &= ~REVERSE_convoi_coupling; }
 	uint8 get_stop_flag2() const { return stop_flags>>8; }
 	void set_stop_flag2(uint8 f) { stop_flags = (f<<8)+(stop_flags&0x00FF); }
 	

--- a/dataobj/schedule_entry.h
+++ b/dataobj/schedule_entry.h
@@ -48,7 +48,7 @@ public:
 		LOAD_BEFORE_DEP   = 1U << 6, // The convoy loads just before the departure.
 		TRANSFER_INTERVAL = 1U << 7,
 		REVERSE_CONVOY	= 1U << 8,// The reverse order of vehicles in convoy
-		REVERSE_parent_children		= 1U << 9,// The reverse order of connected convoys
+		REVERSE_PARENT_CHILDREN		= 1U << 9,// The reverse order of connected convoys
 	}
 	;
 
@@ -142,8 +142,8 @@ public:
 	bool is_reverse_convoy() const { return (stop_flags&REVERSE_CONVOY)>0; }
 	void set_reverse_convoy(bool y) { y ? stop_flags |= REVERSE_CONVOY : stop_flags&= ~REVERSE_CONVOY; }
 	uint16 get_coupling_reverse() const { return (stop_flags&0x0200); }
-	bool is_reverse_parent_children() const { return (stop_flags&REVERSE_parent_children)>0; } 
-	void set_reverse_parent_children(bool y) { y ? stop_flags |= REVERSE_parent_children : stop_flags &= ~REVERSE_parent_children; }
+	bool is_reverse_parent_children() const { return (stop_flags&REVERSE_PARENT_CHILDREN)>0; } 
+	void set_reverse_parent_children(bool y) { y ? stop_flags |= REVERSE_PARENT_CHILDREN : stop_flags &= ~REVERSE_PARENT_CHILDREN; }
 	uint8 get_stop_flag2() const { return stop_flags>>8; }
 	void set_stop_flag2(uint8 f) { stop_flags = (f<<8)+(stop_flags&0x00FF); }
 	

--- a/dataobj/schedule_entry.h
+++ b/dataobj/schedule_entry.h
@@ -24,12 +24,11 @@ public:
 		init_convoy_stopping_time();
 	}
 
-	schedule_entry_t(koord3d const& pos, uint const minimum_loading, uint16 const waiting_time_shift, uint8 const stop_flags, uint8 const stop_flag2) :
+	schedule_entry_t(koord3d const& pos, uint const minimum_loading, uint16 const waiting_time_shift, uint16 const stop_flags) :
 		pos(pos),
 		minimum_loading(minimum_loading),
 		waiting_time_shift(waiting_time_shift),
-		stop_flags(stop_flags),
-		stop_flag2(stop_flag2)
+		stop_flags(stop_flags)
 	{
 		spacing = 1;
 		spacing_shift = delay_tolerance = 0;
@@ -48,8 +47,8 @@ public:
 		UNLOAD_ALL        = 1U << 5, // The convoy unloads all loads here.
 		LOAD_BEFORE_DEP   = 1U << 6, // The convoy loads just before the departure.
 		TRANSFER_INTERVAL = 1U << 7,
-		REVERSE_CONVOY	= 1U << 0,// The reverse order of vehicles in convoy
-		REVERSE_p_c		= 1U << 1,// The reverse order of connected convoys
+		REVERSE_CONVOY	= 1U << 8,// The reverse order of vehicles in convoy
+		REVERSE_parent_children		= 1U << 9,// The reverse order of connected convoys
 	}
 	;
 
@@ -96,8 +95,7 @@ public:
 	uint8 cs_at_index; // which index of convoy_stopping_time should be overwritten next.
 	
 private:
-	uint8 stop_flags;
-	uint8 stop_flag2;
+	uint16 stop_flags;
 	
 	void init_journey_time() {
 		jt_at_index = 0;
@@ -121,7 +119,7 @@ private:
 	}
 	
 public:
-	uint8 get_coupling_point() const { return (stop_flags&0x03); }
+	uint16 get_coupling_point() const { return (stop_flags&0x0003); }
 	void set_wait_for_coupling() { stop_flags |= WAIT_FOR_COUPLING; stop_flags &= ~TRY_COUPLING; }
 	void set_try_coupling() { stop_flags |= TRY_COUPLING; stop_flags &= ~WAIT_FOR_COUPLING; }
 	void reset_coupling() { stop_flags &= ~TRY_COUPLING; stop_flags &= ~WAIT_FOR_COUPLING; }
@@ -137,17 +135,17 @@ public:
 	void set_load_before_departure(bool y) { y ? stop_flags |= LOAD_BEFORE_DEP : stop_flags &= ~LOAD_BEFORE_DEP; }
 	bool is_transfer_interval() const { return (stop_flags&TRANSFER_INTERVAL)>0; }
 	void set_transfer_interval(bool y) { y ? stop_flags |= TRANSFER_INTERVAL : stop_flags &= ~TRANSFER_INTERVAL; }
-	uint8 get_stop_flags() const { return stop_flags; }
-	void set_stop_flags(uint8 f) { stop_flags = f; }
+	uint16 get_stop_flags() const { return stop_flags; }
+	void set_stop_flags(uint8 f) { stop_flags = f+(stop_flags&0xFF00); }
 
 
-	bool is_reverse_convoy() const { return (stop_flag2&REVERSE_CONVOY)>0; }
-	void set_reverse_convoy(bool y) { y ? stop_flag2 |= REVERSE_CONVOY : stop_flag2&= ~REVERSE_CONVOY; }
-	uint8 get_coupling_reverse() const { return (stop_flag2&0x02); }
-	bool is_reverse_p_c() const { return (stop_flag2&REVERSE_p_c)>0; } 
-	void set_reverse_p_c(bool y) { y ? stop_flag2 |= REVERSE_p_c : stop_flag2 &= ~REVERSE_p_c; }
-	uint8 get_stop_flag2() const { return stop_flag2; }
-	void set_stop_flag2(uint8 f) { stop_flag2 = f; }
+	bool is_reverse_convoy() const { return (stop_flags&REVERSE_CONVOY)>0; }
+	void set_reverse_convoy(bool y) { y ? stop_flags |= REVERSE_CONVOY : stop_flags&= ~REVERSE_CONVOY; }
+	uint16 get_coupling_reverse() const { return (stop_flags&0x0200); }
+	bool is_reverse_parent_children() const { return (stop_flags&REVERSE_parent_children)>0; } 
+	void set_reverse_parent_children(bool y) { y ? stop_flags |= REVERSE_parent_children : stop_flags &= ~REVERSE_parent_children; }
+	uint8 get_stop_flag2() const { return stop_flags>>8; }
+	void set_stop_flag2(uint8 f) { stop_flags = (f<<8)+(stop_flags&0x00FF); }
 	
 	void set_spacing(uint16 a, uint16 b, uint16 c) {
 		spacing = a;
@@ -168,7 +166,6 @@ public:
 		  &&  a.minimum_loading    == this->minimum_loading
 			&&  a.waiting_time_shift == this->waiting_time_shift
 			&&  a.get_stop_flags()   == this->stop_flags
-			&&  a.get_stop_flag2()   == this->stop_flag2
 			&&  a.spacing            == this->spacing
 			&&  a.spacing_shift      == this->spacing_shift
 			&&  a.delay_tolerance    == this->delay_tolerance;

--- a/dataobj/schedule_entry.h
+++ b/dataobj/schedule_entry.h
@@ -141,7 +141,6 @@ public:
 
 	bool is_reverse_convoy() const { return (stop_flags&REVERSE_CONVOY)>0; }
 	void set_reverse_convoy(bool y) { y ? stop_flags |= REVERSE_CONVOY : stop_flags&= ~REVERSE_CONVOY; }
-	uint16 get_coupling_reverse() const { return (stop_flags&0x0200); }
 	bool is_reverse_parent_children() const { return (stop_flags&REVERSE_PARENT_CHILDREN)>0; } 
 	void set_reverse_parent_children(bool y) { y ? stop_flags |= REVERSE_PARENT_CHILDREN : stop_flags &= ~REVERSE_PARENT_CHILDREN; }
 	uint8 get_stop_flag2() const { return stop_flags>>8; }

--- a/dataobj/schedule_entry.h
+++ b/dataobj/schedule_entry.h
@@ -24,11 +24,12 @@ public:
 		init_convoy_stopping_time();
 	}
 
-	schedule_entry_t(koord3d const& pos, uint const minimum_loading, uint16 const waiting_time_shift, uint8 const stop_flags) :
+	schedule_entry_t(koord3d const& pos, uint const minimum_loading, uint16 const waiting_time_shift, uint8 const stop_flags, uint8 const stop_flag2) :
 		pos(pos),
 		minimum_loading(minimum_loading),
 		waiting_time_shift(waiting_time_shift),
-		stop_flags(stop_flags)
+		stop_flags(stop_flags),
+		stop_flag2(stop_flag2)
 	{
 		spacing = 1;
 		spacing_shift = delay_tolerance = 0;
@@ -47,7 +48,10 @@ public:
 		UNLOAD_ALL        = 1U << 5, // The convoy unloads all loads here.
 		LOAD_BEFORE_DEP   = 1U << 6, // The convoy loads just before the departure.
 		TRANSFER_INTERVAL = 1U << 7,
-	};
+		REVERSE_CONVOY	= 1U << 0,// The reverse order of vehicles in convoy
+		REVERSE_p_c		= 1U << 1,// The reverse order of connected convoys
+	}
+	;
 
 	/**
 	 * target position
@@ -93,6 +97,7 @@ public:
 	
 private:
 	uint8 stop_flags;
+	uint8 stop_flag2;
 	
 	void init_journey_time() {
 		jt_at_index = 0;
@@ -134,6 +139,15 @@ public:
 	void set_transfer_interval(bool y) { y ? stop_flags |= TRANSFER_INTERVAL : stop_flags &= ~TRANSFER_INTERVAL; }
 	uint8 get_stop_flags() const { return stop_flags; }
 	void set_stop_flags(uint8 f) { stop_flags = f; }
+
+
+	bool is_reverse_convoy() const { return (stop_flag2&REVERSE_CONVOY)>0; }
+	void set_reverse_convoy(bool y) { y ? stop_flag2 |= REVERSE_CONVOY : stop_flag2&= ~REVERSE_CONVOY; }
+	uint8 get_coupling_reverse() const { return (stop_flag2&0x02); }
+	bool is_reverse_p_c() const { return (stop_flag2&REVERSE_p_c)>0; } 
+	void set_reverse_p_c(bool y) { y ? stop_flag2 |= REVERSE_p_c : stop_flag2 &= ~REVERSE_p_c; }
+	uint8 get_stop_flag2() const { return stop_flag2; }
+	void set_stop_flag2(uint8 f) { stop_flag2 = f; }
 	
 	void set_spacing(uint16 a, uint16 b, uint16 c) {
 		spacing = a;
@@ -154,6 +168,7 @@ public:
 		  &&  a.minimum_loading    == this->minimum_loading
 			&&  a.waiting_time_shift == this->waiting_time_shift
 			&&  a.get_stop_flags()   == this->stop_flags
+			&&  a.get_stop_flag2()   == this->stop_flag2
 			&&  a.spacing            == this->spacing
 			&&  a.spacing_shift      == this->spacing_shift
 			&&  a.delay_tolerance    == this->delay_tolerance;

--- a/dataobj/settings.cc
+++ b/dataobj/settings.cc
@@ -30,7 +30,6 @@
 
 #define NEVER 0xFFFFU
 
-sint8 env_t::reverse_base_offsets[8][3];
 
 settings_t::settings_t() :
 	filename(""),
@@ -1080,34 +1079,6 @@ void settings_t::parse_simuconf( tabfile_t& simuconf, sint16& disp_width, sint16
 	env_t::player_finance_display_account = contents.get_int( "player_finance_display_account", env_t::player_finance_display_account ) != 0;
 
 	
-	// vector_tpl<int> offsets[8];
-	// offsets[0] = contents.get_ints("reverse_base_offset_south");
-	// offsets[1] = contents.get_ints("reverse_base_offset_west");
-	// offsets[2] = contents.get_ints("reverse_base_offset_southwest");
-	// offsets[3] = contents.get_ints("reverse_base_offset_southeast");
-	// offsets[4] = contents.get_ints("reverse_base_offset_north");
-	// offsets[5] = contents.get_ints("reverse_base_offset_east");
-	// offsets[6] = contents.get_ints("reverse_base_offset_northeast");
-	// offsets[7] = contents.get_ints("reverse_base_offset_northwest");
-
-
-	for (uint32 i = 0; i < 8; i++)
-	{
-		// if (offsets[i][0] >= 3)
-		// {
-		// 	for (uint32 j = 0; j < 3; j++)
-		// 	{
-		// 		env_t::reverse_base_offsets[i][j] = offsets[i][j+1];
-		// 	}
-		// }
-		// else
-		{
-			for (uint32 j = 0; j < 3; j++)
-			{
-				env_t::reverse_base_offsets[i][j] = 0;
-			}
-		}
-	}
 
 
 	// network stuff

--- a/dataobj/settings.cc
+++ b/dataobj/settings.cc
@@ -30,6 +30,7 @@
 
 #define NEVER 0xFFFFU
 
+sint8 env_t::reverse_base_offsets[8][3];
 
 settings_t::settings_t() :
 	filename(""),
@@ -1077,6 +1078,37 @@ void settings_t::parse_simuconf( tabfile_t& simuconf, sint16& disp_width, sint16
 	env_t::numpad_always_moves_map = contents.get_int( "numpad_always_moves_map", env_t::numpad_always_moves_map ) != 0;
 
 	env_t::player_finance_display_account = contents.get_int( "player_finance_display_account", env_t::player_finance_display_account ) != 0;
+
+	
+	// vector_tpl<int> offsets[8];
+	// offsets[0] = contents.get_ints("reverse_base_offset_south");
+	// offsets[1] = contents.get_ints("reverse_base_offset_west");
+	// offsets[2] = contents.get_ints("reverse_base_offset_southwest");
+	// offsets[3] = contents.get_ints("reverse_base_offset_southeast");
+	// offsets[4] = contents.get_ints("reverse_base_offset_north");
+	// offsets[5] = contents.get_ints("reverse_base_offset_east");
+	// offsets[6] = contents.get_ints("reverse_base_offset_northeast");
+	// offsets[7] = contents.get_ints("reverse_base_offset_northwest");
+
+
+	for (uint32 i = 0; i < 8; i++)
+	{
+		// if (offsets[i][0] >= 3)
+		// {
+		// 	for (uint32 j = 0; j < 3; j++)
+		// 	{
+		// 		env_t::reverse_base_offsets[i][j] = offsets[i][j+1];
+		// 	}
+		// }
+		// else
+		{
+			for (uint32 j = 0; j < 3; j++)
+			{
+				env_t::reverse_base_offsets[i][j] = 0;
+			}
+		}
+	}
+
 
 	// network stuff
 	env_t::server_frames_ahead              = contents.get_int_clamped( "server_frames_ahead",             env_t::server_frames_ahead,              0, INT_MAX );

--- a/gui/convoi_info_t.cc
+++ b/gui/convoi_info_t.cc
@@ -174,10 +174,10 @@ void convoi_info_t::init(convoihandle_t cnv)
 		next_stop_button.add_listener(this);
 		add_component(&next_stop_button);		
 		
-		reversing_button.init(button_t::roundbox | button_t::flexible, "Reverse");
-		reversing_button.set_tooltip("Reversing the convoy's direction.");
-		reversing_button.add_listener(this);
-		add_component(&reversing_button);
+		reversed_button.init(button_t::roundbox | button_t::flexible, "Reverse");
+		reversed_button.set_tooltip("reverse the convoy's direction.");
+		reversed_button.add_listener(this);
+		add_component(&reversed_button);
 
 		new_component<gui_fill_t>();
 		new_component<gui_fill_t>();
@@ -386,8 +386,8 @@ void convoi_info_t::draw(scr_coord pos, scr_size size)
 		set_recovery_button.pressed = cnv->is_in_delay_recovery();
 		set_recovery_button.enable();
 		next_stop_button.enable();
-		reversing_button.pressed = cnv->is_reversed();
-		reversing_button.enable();
+		reversed_button.pressed = cnv->is_reversed();
+		reversed_button.enable();
 	}
 	else {
 		if(  line_bound  ) {
@@ -401,7 +401,7 @@ void convoi_info_t::draw(scr_coord pos, scr_size size)
 		no_load_button.disable();
 		set_recovery_button.disable();
 		next_stop_button.disable();
-		reversing_button.disable();
+		reversed_button.disable();
 	}
 
 	// update button & labels
@@ -529,7 +529,7 @@ bool convoi_info_t::action_triggered( gui_action_creator_t *comp,value_t /* */)
 			return true;
 		}
 
-		if(  comp == &reversing_button  ) {
+		if(  comp == &reversed_button  ) {
 			cnv->call_convoi_tool( ' ', NULL );
 			cnv->reversing_immediately(true);
 			return true;

--- a/gui/convoi_info_t.cc
+++ b/gui/convoi_info_t.cc
@@ -172,7 +172,12 @@ void convoi_info_t::init(convoihandle_t cnv)
 		next_stop_button.init(button_t::roundbox | button_t::flexible, "next stop");
 		next_stop_button.set_tooltip("Go to the next station.");
 		next_stop_button.add_listener(this);
-		add_component(&next_stop_button);
+		add_component(&next_stop_button);		
+		
+		reversing_button.init(button_t::roundbox | button_t::flexible, "Reverse");
+		reversing_button.set_tooltip("Reversing the convoy's direction.");
+		reversing_button.add_listener(this);
+		add_component(&reversing_button);
 
 		new_component<gui_fill_t>();
 		new_component<gui_fill_t>();
@@ -381,6 +386,8 @@ void convoi_info_t::draw(scr_coord pos, scr_size size)
 		set_recovery_button.pressed = cnv->is_in_delay_recovery();
 		set_recovery_button.enable();
 		next_stop_button.enable();
+		reversing_button.pressed = cnv->is_reversed();
+		reversing_button.enable();
 	}
 	else {
 		if(  line_bound  ) {
@@ -394,6 +401,7 @@ void convoi_info_t::draw(scr_coord pos, scr_size size)
 		no_load_button.disable();
 		set_recovery_button.disable();
 		next_stop_button.disable();
+		reversing_button.disable();
 	}
 
 	// update button & labels
@@ -518,6 +526,12 @@ bool convoi_info_t::action_triggered( gui_action_creator_t *comp,value_t /* */)
 
 		if(  comp == &next_stop_button  ) {
 			cnv->call_convoi_tool( 't', NULL );
+			return true;
+		}
+
+		if(  comp == &reversing_button  ) {
+			cnv->call_convoi_tool( ' ', NULL );
+			cnv->reversing_immediately(true);
 			return true;
 		}
 	}

--- a/gui/convoi_info_t.cc
+++ b/gui/convoi_info_t.cc
@@ -530,8 +530,7 @@ bool convoi_info_t::action_triggered( gui_action_creator_t *comp,value_t /* */)
 		}
 
 		if(  comp == &reversed_button  ) {
-			cnv->call_convoi_tool( ' ', NULL );
-			cnv->reversing_immediately(true);
+			cnv->reverse_vehicles_while_driving();
 			return true;
 		}
 	}

--- a/gui/convoi_info_t.h
+++ b/gui/convoi_info_t.h
@@ -61,7 +61,7 @@ private:
 	button_t no_load_button;
 	button_t set_recovery_button;
 	button_t next_stop_button;
-	button_t reversing_button;
+	button_t reversed_button;
 
 	gui_tab_panel_t switch_mode;
 	gui_aligned_container_t container_freight, container_stats, container_line, *container_top, container_details;

--- a/gui/convoi_info_t.h
+++ b/gui/convoi_info_t.h
@@ -61,6 +61,7 @@ private:
 	button_t no_load_button;
 	button_t set_recovery_button;
 	button_t next_stop_button;
+	button_t reversing_button;
 
 	gui_tab_panel_t switch_mode;
 	gui_aligned_container_t container_freight, container_stats, container_line, *container_top, container_details;

--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -680,9 +680,8 @@ void schedule_gui_t::update_selection()
 			bt_transfer_interval.pressed = schedule->entries[current_stop].is_transfer_interval();
 			bt_reverse_convoy.enable();
 			bt_reverse_convoy.pressed = schedule->entries[current_stop].is_reverse_convoy();
-			const uint16 c2 = schedule->entries[current_stop].get_coupling_reverse();
 			bt_reverse_parents_children_order.enable();
-			bt_reverse_parents_children_order.pressed = c2==0x0200;
+			bt_reverse_parents_children_order.pressed = schedule->entries[current_stop].is_reverse_parent_children();
 
 			
 			// wait_for_time releated things
@@ -842,6 +841,7 @@ DBG_MESSAGE("schedule_gui_t::action_triggered()","comp=%p combo=%p",comp,&line_s
 				schedule->entries[schedule->get_current_stop()].set_try_coupling();
 			}
 			bt_wait_for_child.pressed = false;
+			schedule->entries[schedule->get_current_stop()].set_reverse_parent_children(false);
 			update_selection();
 		}
 	}
@@ -853,7 +853,7 @@ DBG_MESSAGE("schedule_gui_t::action_triggered()","comp=%p combo=%p",comp,&line_s
 				schedule->entries[schedule->get_current_stop()].set_wait_for_coupling();
 			}
 			bt_find_parent.pressed = false;
-			bt_reverse_parents_children_order.pressed = false;
+			schedule->entries[schedule->get_current_stop()].set_reverse_parent_children(false);
 			update_selection();
 		}
 	}
@@ -866,7 +866,12 @@ DBG_MESSAGE("schedule_gui_t::action_triggered()","comp=%p combo=%p",comp,&line_s
 	else if(comp == &bt_reverse_parents_children_order) {
 		if(!schedule->empty()) {
 			schedule->entries[schedule->get_current_stop()].set_reverse_parent_children(!bt_reverse_parents_children_order.pressed);
-			bt_wait_for_child.pressed = false;
+			if(  bt_wait_for_child.pressed  ) {
+				schedule->entries[schedule->get_current_stop()].reset_coupling();
+			} 
+			if(  bt_find_parent.pressed  ) {
+				schedule->entries[schedule->get_current_stop()].reset_coupling();
+			} 
 			update_selection();
 		}
 	}

--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -455,7 +455,26 @@ void schedule_gui_t::init(schedule_t* schedule_, player_t* player, convoihandle_
 		add_component(&bt_find_parent);
 	}	
 	end_table();
-	
+
+	// reverse setting
+	add_table(2,1);
+	{
+		bt_reverse_convoy.init(button_t::square_state, "reverse convoy");
+		bt_reverse_convoy.set_tooltip("Reverses the direction of convoy.");
+		bt_reverse_convoy.add_listener(this);
+		bt_reverse_convoy.disable();
+		add_component(&bt_reverse_convoy);
+
+		bt_reverse_parents_children_order.init(button_t::square_state, "reverse parents-children order");
+		bt_reverse_parents_children_order.set_tooltip("Reverses the order of connected convoys.");
+		bt_reverse_parents_children_order.add_listener(this);
+		bt_reverse_parents_children_order.disable();
+		add_component(&bt_reverse_parents_children_order);
+
+	}
+	end_table();
+
+
 	// for departure time settings
 	add_table(3,3);
 	{
@@ -637,6 +656,8 @@ void schedule_gui_t::update_selection()
 	numimp_delay_tolerance.disable();
 	bt_load_before_departure.disable();
 	bt_transfer_interval.disable();
+	bt_reverse_convoy.disable();
+	bt_reverse_parents_children_order.disable();
 
 	if(  !schedule->empty()  ) {
 		schedule->set_current_stop( min(schedule->get_count()-1,schedule->get_current_stop()) );
@@ -657,6 +678,12 @@ void schedule_gui_t::update_selection()
 			bt_load_before_departure.pressed = schedule->entries[current_stop].is_load_before_departure();
 			bt_transfer_interval.enable();
 			bt_transfer_interval.pressed = schedule->entries[current_stop].is_transfer_interval();
+			bt_reverse_convoy.enable();
+			bt_reverse_convoy.pressed = schedule->entries[current_stop].is_reverse_convoy();
+			const uint8 c2 = schedule->entries[current_stop].get_coupling_reverse();
+			bt_reverse_parents_children_order.enable();
+			bt_reverse_parents_children_order.pressed = c2==2;
+
 			
 			// wait_for_time releated things
 			const bool wft = schedule->entries[current_stop].get_wait_for_time();
@@ -826,6 +853,20 @@ DBG_MESSAGE("schedule_gui_t::action_triggered()","comp=%p combo=%p",comp,&line_s
 				schedule->entries[schedule->get_current_stop()].set_wait_for_coupling();
 			}
 			bt_find_parent.pressed = false;
+			bt_reverse_parents_children_order.pressed = false;
+			update_selection();
+		}
+	}
+	else if(comp == &bt_reverse_convoy) {
+		if(!schedule->empty()) {
+			schedule->entries[schedule->get_current_stop()].set_reverse_convoy(!bt_reverse_convoy.pressed);
+			update_selection();
+		}
+	}
+	else if(comp == &bt_reverse_parents_children_order) {
+		if(!schedule->empty()) {
+			schedule->entries[schedule->get_current_stop()].set_reverse_p_c(!bt_reverse_parents_children_order.pressed);
+			bt_wait_for_child.pressed = false;
 			update_selection();
 		}
 	}
@@ -1230,6 +1271,8 @@ void schedule_gui_t::extract_advanced_settings(bool yesno) {
 	const bool coupling_waytype = schedule->get_waytype()!=road_wt  &&  schedule->get_waytype()!=air_wt  &&  schedule->get_waytype()!=water_wt;
 	bt_wait_for_child.set_visible(coupling_waytype  &&  yesno);
 	bt_find_parent.set_visible(coupling_waytype  &&  yesno);
+	bt_reverse_convoy.set_visible(coupling_waytype  &&  yesno);
+	bt_reverse_parents_children_order.set_visible(coupling_waytype  &&  yesno);
 
 	const bool is_tbgr_enabled = world()->get_settings().get_goods_routing_policy() == goods_routing_policy_t::GRP_FIFO_ET;
 	lb_tbgr_waiting_time.set_visible(is_tbgr_enabled  &&  yesno);

--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -680,9 +680,9 @@ void schedule_gui_t::update_selection()
 			bt_transfer_interval.pressed = schedule->entries[current_stop].is_transfer_interval();
 			bt_reverse_convoy.enable();
 			bt_reverse_convoy.pressed = schedule->entries[current_stop].is_reverse_convoy();
-			const uint8 c2 = schedule->entries[current_stop].get_coupling_reverse();
+			const uint16 c2 = schedule->entries[current_stop].get_coupling_reverse();
 			bt_reverse_parents_children_order.enable();
-			bt_reverse_parents_children_order.pressed = c2==2;
+			bt_reverse_parents_children_order.pressed = c2==0x0200;
 
 			
 			// wait_for_time releated things
@@ -865,7 +865,7 @@ DBG_MESSAGE("schedule_gui_t::action_triggered()","comp=%p combo=%p",comp,&line_s
 	}
 	else if(comp == &bt_reverse_parents_children_order) {
 		if(!schedule->empty()) {
-			schedule->entries[schedule->get_current_stop()].set_reverse_p_c(!bt_reverse_parents_children_order.pressed);
+			schedule->entries[schedule->get_current_stop()].set_reverse_parent_children(!bt_reverse_parents_children_order.pressed);
 			bt_wait_for_child.pressed = false;
 			update_selection();
 		}

--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -681,7 +681,7 @@ void schedule_gui_t::update_selection()
 			bt_reverse_convoy.enable();
 			bt_reverse_convoy.pressed = schedule->entries[current_stop].is_reverse_convoy();
 			bt_reverse_parents_children_order.enable();
-			bt_reverse_parents_children_order.pressed = schedule->entries[current_stop].is_reverse_parent_children();
+			bt_reverse_parents_children_order.pressed = schedule->entries[current_stop].is_reverse_convoi_coupling();
 
 			
 			// wait_for_time releated things
@@ -841,7 +841,7 @@ DBG_MESSAGE("schedule_gui_t::action_triggered()","comp=%p combo=%p",comp,&line_s
 				schedule->entries[schedule->get_current_stop()].set_try_coupling();
 			}
 			bt_wait_for_child.pressed = false;
-			schedule->entries[schedule->get_current_stop()].set_reverse_parent_children(false);
+			schedule->entries[schedule->get_current_stop()].set_reverse_convoi_coupling(false);
 			update_selection();
 		}
 	}
@@ -853,7 +853,7 @@ DBG_MESSAGE("schedule_gui_t::action_triggered()","comp=%p combo=%p",comp,&line_s
 				schedule->entries[schedule->get_current_stop()].set_wait_for_coupling();
 			}
 			bt_find_parent.pressed = false;
-			schedule->entries[schedule->get_current_stop()].set_reverse_parent_children(false);
+			schedule->entries[schedule->get_current_stop()].set_reverse_convoi_coupling(false);
 			update_selection();
 		}
 	}
@@ -865,7 +865,7 @@ DBG_MESSAGE("schedule_gui_t::action_triggered()","comp=%p combo=%p",comp,&line_s
 	}
 	else if(comp == &bt_reverse_parents_children_order) {
 		if(!schedule->empty()) {
-			schedule->entries[schedule->get_current_stop()].set_reverse_parent_children(!bt_reverse_parents_children_order.pressed);
+			schedule->entries[schedule->get_current_stop()].set_reverse_convoi_coupling(!bt_reverse_parents_children_order.pressed);
 			if(  bt_wait_for_child.pressed  ) {
 				schedule->entries[schedule->get_current_stop()].reset_coupling();
 			} 

--- a/gui/schedule_gui.h
+++ b/gui/schedule_gui.h
@@ -65,7 +65,7 @@ class schedule_gui_t : public gui_frame_t, public action_listener_t
 	button_t bt_find_parent, bt_wait_for_child; // convoy coupling
 	button_t bt_no_load, bt_no_unload, bt_tmp_schedule, bt_wait_for_time, 
 		bt_same_dep_time, bt_full_load_acceleration, bt_full_load_time,bt_unload_all,bt_transfer_interval,
-		bt_load_before_departure;
+		bt_load_before_departure, bt_reverse_convoy, bt_reverse_parents_children_order;
 	gui_numberinput_t numimp_spacing, numimp_spacing_shift, 
 		numimp_delay_tolerance, numimp_max_speed, numimp_tbgr_waiting_time;
 	gui_label_t lb_spacing, lb_spacing_shift, lb_title1, lb_title2, lb_max_speed, lb_tbgr_waiting_time;

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -3797,11 +3797,11 @@ void convoi_t::hat_gehalten(halthandle_t halt, uint32 halt_length_in_vehicle_ste
 
 	// reverse convoi
 	if (self->get_schedule()->get_current_entry().is_reverse_convoy()){
-		reverse_vehicles_while_driving();
+		reverse_vehicles_at_halt();
 	}
 	// reverse order of coupling/coupled convois
 	bool reverse_convoy_coupling = self->get_schedule()->get_current_entry().is_reverse_convoi_coupling();
-	if (reverse_convoy_coupling&&(coupling_convoi.is_bound()&&!is_coupled())&&!is_waiting_for_coupling()) {
+	if (reverse_convoy_coupling&&((coupling_convoi.is_bound()&&!is_coupled())&&!is_waiting_for_coupling())) {
 		execute_reverse_convoy_coupling(self);
 	}
 

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -5245,10 +5245,25 @@ void convoi_t::calc_sum_friction_weight() {
 void convoi_t::reversing_immediately(bool rev)
 {
 	convoihandle_t c = self;
-	c->reverse_order(rev);
-	schedule_t *schedule = c->get_schedule()->copy();
-	c->set_schedule(schedule);
-
+	if (!c->get_schedule()->get_current_entry().get_coupling_point()==1){
+		execute_reverse_order(fahr, c->get_vehicle_count());
+		c->reversing = true;
+		convoihandle_t temp_parent=c;
+		while(temp_parent->is_coupled()){
+			FOR(vector_tpl<convoihandle_t>, const& temp_c, world()->convoys()) {
+				if(  temp_c->get_coupling_convoi()==temp_parent  ) {
+					temp_parent=temp_c->self;
+				}
+			}
+		}
+		schedule_t *schedule = temp_parent->get_schedule()->copy();
+		temp_parent->set_schedule(schedule);
+		c->reversing = false;
+		// if (!c->is_coupled()){
+		// 	schedule_t *schedule = c->get_schedule()->copy();
+		// 	c->set_schedule(schedule);
+		// }
+	}
 }
 
 void convoi_t::reverse_order(bool rev)

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -2373,7 +2373,7 @@ bool convoi_t::can_go_alte_richtung()
 	}
 
 	// reverse convoi 
-	if((reversed != fahr[0]->is_reversed()) || (coupling_convoi.is_bound() && self->get_schedule()->get_current_entry().is_reverse_p_c())){
+	if((reversed != fahr[0]->is_reversed()) || (coupling_convoi.is_bound() && self->get_schedule()->get_current_entry().is_reverse_parent_children())){
 		return false;
 	}
 
@@ -3737,9 +3737,9 @@ void convoi_t::hat_gehalten(halthandle_t halt, uint32 halt_length_in_vehicle_ste
 	}
 
 	// reverse order of coupling/coupled convois
-	reverse_p_c = self->get_schedule()->get_current_entry().is_reverse_p_c();
-	if (reverse_p_c&&(coupling_convoi.is_bound()&&!is_coupled())) {
-		execute_reverse_p_c(self);
+	reverse_parent_children = self->get_schedule()->get_current_entry().is_reverse_parent_children();
+	if (reverse_parent_children&&(coupling_convoi.is_bound()&&!is_coupled())) {
+		execute_reverse_parent_children(self);
 	}
 	// reverse convoi
 	reversed = self->get_schedule()->get_current_entry().is_reverse_convoy();
@@ -5223,16 +5223,16 @@ void convoi_t::execute_reverse_order(array_tpl<vehicle_t*> &vehicles, uint8 vehi
 	}
 
 }
-void convoi_t::execute_reverse_p_c(convoihandle_t self)
+void convoi_t::execute_reverse_parent_children(convoihandle_t self)
 {
-	convoihandle_t temp_p_c = self;
+	convoihandle_t temp_parent_children = self;
 	convoihandle_t temp_t_c = self->coupling_convoi; 
-	temp_p_c->uncouple_convoi();
+	temp_parent_children->uncouple_convoi();
 	if (temp_t_c->get_coupling_convoi().is_bound())
 	{
-		execute_reverse_p_c(temp_t_c);
+		execute_reverse_parent_children(temp_t_c);
 	}
 	
-	temp_t_c->couple_convoi(temp_p_c);
+	temp_t_c->couple_convoi(temp_parent_children);
 	
 }

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -499,16 +499,18 @@ private:
 	// Reverses the order of the convoy.
 	// @author: jamespetts
 	uint8 vehicle_count;
-	void reverse_order(bool rev);
 
 
 	bool reverse_parent_children;// Reverse the order of the coupling/coupled convois 
 public:
 
-	bool reversed;// Whether this convoy's vehicles are currently arranged in reverse order. The flag for calculation of position.
+	bool reversing;// Whether this convoy's vehicles are currently arranged in reverse order. The flag for calculation of position.
+	bool is_reversed() const;
 	// Reorder the vehicle array
 	// Can be executed even with a vehicle array that does not belong to convoy for UI
-	static void execute_reverse_order(array_tpl<vehicle_t*> &vehicles, uint8 vehicle_count, bool rev);
+	void reverse_order(bool rev);
+	void reversing_immediately(bool rev);
+	static void execute_reverse_order(array_tpl<vehicle_t*> &vehicles, uint8 vehicle_count);
 	// Reverse the order of the coupling/coupled convois
 	static void execute_reverse_parent_children(convoihandle_t self);
 	/**

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -503,13 +503,13 @@ private:
 
 	bool reversed;// Whether this convoy's vehicles are currently arranged in reverse order.
 
-	bool reverse_p_c;// Reverse the order of the coupling/coupled convois 
+	bool reverse_parent_children;// Reverse the order of the coupling/coupled convois 
 public:
 	// Reorder the vehicle array
 	// Can be executed even with a vehicle array that does not belong to convoy for UI
 	static void execute_reverse_order(array_tpl<vehicle_t*> &vehicles, uint8 vehicle_count, bool rev);
 	// Reverse the order of the coupling/coupled convois
-	static void execute_reverse_p_c(convoihandle_t self);
+	static void execute_reverse_parent_children(convoihandle_t self);
 	/**
 	* Convoi haelt an Haltestelle und setzt quote fuer Fracht
 	*/

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -506,8 +506,9 @@ public:
 	bool is_reversed() const;
 	// Reorder the vehicle array
 	// Can be executed even with a vehicle array that does not belong to convoy for UI
-	void reverse_order(bool rev);
-	void reversing_immediately(bool rev);
+	void reverse_vehicles_at_halt();
+	void reverse_vehicles_while_driving();
+	void reverse_vehicles_go_depot();
 	static void execute_reverse_order(array_tpl<vehicle_t*> &vehicles, uint8 vehicle_count);
 	// Reverse the order of the coupling/coupled convois
 	static void execute_reverse_convoy_coupling(convoihandle_t self);

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -86,7 +86,6 @@ public:
 		CAN_START_TWO_MONTHS,
 		LEAVING_DEPOT,
 		ENTERING_DEPOT,
-		REVERSING,
 		COUPLED,
 		COUPLED_LOADING,
 		WAITING_FOR_LEAVING_DEPOT,
@@ -496,14 +495,13 @@ private:
 	/// Pushes the convoy stopping time at the current halt to the schedule
 	void push_convoy_stopping_time();
 
+
+
+
+
+public:
 	// Reverses the order of the convoy.
 	// @author: jamespetts
-	uint8 vehicle_count;
-
-
-	bool reverse_parent_children;// Reverse the order of the coupling/coupled convois 
-public:
-
 	bool reversing;// Whether this convoy's vehicles are currently arranged in reverse order. The flag for calculation of position.
 	bool is_reversed() const;
 	// Reorder the vehicle array
@@ -512,7 +510,7 @@ public:
 	void reversing_immediately(bool rev);
 	static void execute_reverse_order(array_tpl<vehicle_t*> &vehicles, uint8 vehicle_count);
 	// Reverse the order of the coupling/coupled convois
-	static void execute_reverse_parent_children(convoihandle_t self);
+	static void execute_reverse_convoy_coupling(convoihandle_t self);
 	/**
 	* Convoi haelt an Haltestelle und setzt quote fuer Fracht
 	*/

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -501,10 +501,11 @@ private:
 	uint8 vehicle_count;
 	void reverse_order(bool rev);
 
-	bool reversed;// Whether this convoy's vehicles are currently arranged in reverse order.
 
 	bool reverse_parent_children;// Reverse the order of the coupling/coupled convois 
 public:
+
+	bool reversed;// Whether this convoy's vehicles are currently arranged in reverse order. The flag for calculation of position.
 	// Reorder the vehicle array
 	// Can be executed even with a vehicle array that does not belong to convoy for UI
 	static void execute_reverse_order(array_tpl<vehicle_t*> &vehicles, uint8 vehicle_count, bool rev);

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -86,6 +86,7 @@ public:
 		CAN_START_TWO_MONTHS,
 		LEAVING_DEPOT,
 		ENTERING_DEPOT,
+		REVERSING,
 		COUPLED,
 		COUPLED_LOADING,
 		WAITING_FOR_LEAVING_DEPOT,
@@ -495,7 +496,20 @@ private:
 	/// Pushes the convoy stopping time at the current halt to the schedule
 	void push_convoy_stopping_time();
 
+	// Reverses the order of the convoy.
+	// @author: jamespetts
+	uint8 vehicle_count;
+	void reverse_order(bool rev);
+
+	bool reversed;// Whether this convoy's vehicles are currently arranged in reverse order.
+
+	bool reverse_p_c;// Reverse the order of the coupling/coupled convois 
 public:
+	// Reorder the vehicle array
+	// Can be executed even with a vehicle array that does not belong to convoy for UI
+	static void execute_reverse_order(array_tpl<vehicle_t*> &vehicles, uint8 vehicle_count, bool rev);
+	// Reverse the order of the coupling/coupled convois
+	static void execute_reverse_p_c(convoihandle_t self);
 	/**
 	* Convoi haelt an Haltestelle und setzt quote fuer Fracht
 	*/

--- a/simversion.h
+++ b/simversion.h
@@ -27,8 +27,8 @@
 #define SIM_SERVER_MINOR    0
 // NOTE: increment before next release to enable save/load of new features
 
-#define OTRP_VERSION_MAJOR 40
-#define OTRP_VERSION_MINOR 1
+#define OTRP_VERSION_MAJOR 41
+#define OTRP_VERSION_MINOR 0
 #define OTRP_VERSION_PATCH 0
 // NOTE: increment OTRP_VERSION_MAJOR when the save data structure changes.
 

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -382,7 +382,6 @@ void vehicle_base_t::get_screen_offset( int &xoff, int &yoff, const sint16 raste
 	if (veh && veh->is_reversed())
 	{
 		display_steps += (VEHICLE_STEPS_PER_TILE / 2 - veh->get_desc()->get_length_in_steps());
-		display_steps += env_t::reverse_base_offsets[dir][2];
 	}
 	if(dx && dy) {
 		display_steps &= 0xFFFFFC00;
@@ -392,11 +391,7 @@ void vehicle_base_t::get_screen_offset( int &xoff, int &yoff, const sint16 raste
 	}
 	xoff += (display_steps*dx) >> 10;
 	yoff += ((display_steps*dy) >> 10) + (get_hoff(raster_width))/(4*16);
-	if (veh && veh->is_reversed())
-	{
-		xoff += tile_raster_scale_x(env_t::reverse_base_offsets[dir][0], raster_width);
-		yoff += tile_raster_scale_y(env_t::reverse_base_offsets[dir][1], raster_width);
-	}
+	
 }
 
 

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -377,6 +377,13 @@ void vehicle_base_t::get_screen_offset( int &xoff, int &yoff, const sint16 raste
 {
 	// vehicles needs finer steps to appear smoother
 	sint32 display_steps = (uint32)steps*(uint16)raster_width;
+	const vehicle_t* veh= obj_cast<vehicle_t>(this);
+	if (veh && veh->is_reversed())
+	{
+		display_steps += (VEHICLE_STEPS_PER_TILE / 2 - veh->get_desc()->get_length_in_steps());
+		//adjusted_steps += (sint32)(env_t::reverse_base_offsets[dir][2] * VEHICLE_STEPS_PER_TILE) / veh->get_desc()->get_length_in_steps();
+		// display_steps += env_t::reverse_base_offsets[dir][2];
+	}
 	if(dx && dy) {
 		display_steps &= 0xFFFFFC00;
 	}
@@ -993,6 +1000,7 @@ vehicle_t::vehicle_t(koord3d pos, const vehicle_desc_t* desc, player_t* player) 
 	purchase_time = welt->get_current_month();
 	cnv = NULL;
 	speed_limit = SPEED_UNLIMITED;
+	reversed = false;
 
 	route_index = 1;
 
@@ -1020,6 +1028,7 @@ vehicle_t::vehicle_t() :
 
 	desc = NULL;
 	cnv = NULL;
+	reversed = false;
 
 	route_index = 1;
 	current_friction = 4;
@@ -1466,10 +1475,10 @@ void vehicle_t::calc_image()
 {
 	image_id old_image=get_image();
 	if (fracht.empty()) {
-		set_image(desc->get_image_id(ribi_t::get_dir(get_direction()),NULL));
+		set_image(desc->get_image_id(ribi_t::get_dir(get_direction_of_travel()),NULL));
 	}
 	else {
-		set_image(desc->get_image_id(ribi_t::get_dir(get_direction()), fracht.front().get_desc()));
+		set_image(desc->get_image_id(ribi_t::get_dir(get_direction_of_travel()), fracht.front().get_desc()));
 	}
 	if(old_image!=get_image()) {
 		set_flag(obj_t::dirty);
@@ -1744,6 +1753,13 @@ DBG_MESSAGE("vehicle_t::rdwr_from_convoi()","bought at %i/%i.",(purchase_time%12
 			has_driven = false;
 		}
 	}
+
+	// reverse or not
+	if(file->get_OTRP_version()>=41) {
+		file->rdwr_bool(reversed);
+	} else {
+		reversed = false;
+	}
 }
 
 
@@ -1797,6 +1813,56 @@ vehicle_t::~vehicle_t()
 	minimap_t::get_instance()->calc_map_pixel(get_pos().get_2d());
 }
 
+
+ribi_t::ribi vehicle_t::get_direction_of_travel() const
+{
+	ribi_t::ribi dir = get_direction();
+	if(reversed)
+	{
+		switch(dir)
+		{
+		case ribi_t::north:
+			dir = ribi_t::south;
+			break;
+
+		case ribi_t::east:
+			dir = ribi_t::west;
+			break;
+
+		case ribi_t::northeast:
+			dir = ribi_t::southwest;
+			break;
+
+		case ribi_t::south:
+			dir = ribi_t::north;
+			break;
+
+		case ribi_t::southeast:
+			dir = ribi_t::northwest;
+			break;
+
+		case ribi_t::west:
+			dir = ribi_t::east;
+			break;
+
+		case ribi_t::northwest:
+			dir = ribi_t::southeast;
+			break;
+
+		case ribi_t::southwest:
+			dir = ribi_t::northeast;
+			break;
+		};
+	}
+	return dir;
+}
+
+void vehicle_t::set_reversed(bool value)
+{
+	
+	reversed = value;
+	
+}
 
 #ifdef MULTI_THREAD
 void vehicle_t::display_overlay(int xpos, int ypos) const

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -378,11 +378,11 @@ void vehicle_base_t::get_screen_offset( int &xoff, int &yoff, const sint16 raste
 	// vehicles needs finer steps to appear smoother
 	sint32 display_steps = (uint32)steps*(uint16)raster_width;
 	const vehicle_t* veh= obj_cast<vehicle_t>(this);
+	const int dir = ribi_t::get_dir(get_direction());
 	if (veh && veh->is_reversed())
 	{
 		display_steps += (VEHICLE_STEPS_PER_TILE / 2 - veh->get_desc()->get_length_in_steps());
-		//adjusted_steps += (sint32)(env_t::reverse_base_offsets[dir][2] * VEHICLE_STEPS_PER_TILE) / veh->get_desc()->get_length_in_steps();
-		// display_steps += env_t::reverse_base_offsets[dir][2];
+		display_steps += env_t::reverse_base_offsets[dir][2];
 	}
 	if(dx && dy) {
 		display_steps &= 0xFFFFFC00;
@@ -392,6 +392,11 @@ void vehicle_base_t::get_screen_offset( int &xoff, int &yoff, const sint16 raste
 	}
 	xoff += (display_steps*dx) >> 10;
 	yoff += ((display_steps*dy) >> 10) + (get_hoff(raster_width))/(4*16);
+	if (veh && veh->is_reversed())
+	{
+		xoff += tile_raster_scale_x(env_t::reverse_base_offsets[dir][0], raster_width);
+		yoff += tile_raster_scale_y(env_t::reverse_base_offsets[dir][1], raster_width);
+	}
 }
 
 

--- a/vehicle/simvehicle.h
+++ b/vehicle/simvehicle.h
@@ -222,6 +222,9 @@ private:
 
 	grund_t* hop_check() OVERRIDE;
 
+	// Whether this individual vehicle is reversed.
+	bool reversed;
+
 	static ptrhashtable_tpl<const vehicle_desc_t*, uint32> full_load_weights; // key: name of vehicle desc
 
 	/**
@@ -392,6 +395,10 @@ public:
 	* Get the maximum capacity
 	*/
 	uint16 get_cargo_max() const {return desc->get_capacity(); }
+
+	bool is_reversed() const { return reversed; }
+	void set_reversed(bool value);
+	ribi_t::ribi get_direction_of_travel() const;
 
 	ribi_t::ribi get_next_90direction() const;
 


### PR DESCRIPTION
Adding Reverse Convoy Direction and Reverse Orders of Coupling/Coupled Convoys.

〇 Changing source code  
1. **Change OTRP version**  
**OTRP version is set as 41** because the convoi schedule must store the flag of Reversing in savefile.

2. Add a flag of schedule  
The flag (stop_flag2) is added to check whether reversing or not.

3. Add some functions in convoi, vehicle, schedule and schedule_gui  
To reverse and change order, some functions are added.
Some convoi, vehicle and schedule_gui's functions are also changed.

〇 How to Reverse direction of convoy
If the reverse flag is on (stop_flag2&1U), the convoy's direction is reversed(if it is already reversed, the direction is not changed).   
If the convoy's direction after leave the stop is different from it before arrive the stop, the convoy call reverse_order function and change the vehicles' order and the direction of the images.  
If the convoy's next stop is depot, the vehicles' order and direction of the images are set to the original (usual way).  
Because of the troubles, the reverse function is not called if the convoi is set as wait_for_coupling.
(This method is originaly made for experimental/extended, but the reversing timing is different!)

〇 How to change the orders of the coupling/coupled convoys  
If the change_order flag of parent convoi is on (stop_flag2&(1U<<1)), the order of parent/children of coupling convoys are changed.  
The function of the changing is convoi_t::execute_reverse_p_c.  
The way of the changing order is,  
  1. The parent let us know the parent and first-child convoys
  2. The parent uncouple children
  3. If the first child convoi has children, the function is recalled to first-child convoi.
  4. The child couple the parent (set change the order of parent/children).
This changing order is independent from The reversing direction of vehicles.

〇 Some issues  
When reversing the orientation of the convoi, the position of the convoi warps. That seems to be the behavior of the previous version of OTRP's change-direction coupling.