### PR TITLE
Change timing of reversing_vehicles to after departure

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -1166,29 +1166,6 @@ koord3d convoi_t::calc_first_pos_of_route() const {
 	// So we use get_direction() and give up the judge when the obtained direction is not single. This judgement only affects visual jupming of the convoy.
 	const ribi_t::ribi front_vehicle_dir = front_vehicle->get_direction();
 	grund_t* ngr;
-	// reversing convoi
-	// reversed_at_current_halt does not mean the convoi's direction is opposite or not.
-	// if(  reversed_at_current_halt  ){
-	// 	route_t r;
-	// 	route_t::route_result_t res = r.calc_route(world(), front()->get_pos(), get_schedule()->get_current_entry().pos, front(), speed_to_kmh(get_min_top_speed()), 8888);
-	// 	ribi_t::ribi temp_next_initial_direction;
-	// 	if(  res==route_t::no_route  ||  r.get_count()<2  ) {
-	// 		// assume we do not turn here
-	// 		temp_next_initial_direction = front()->get_direction();
-	// 	} else {
-	// 		temp_next_initial_direction = ribi_type(r.at(0), r.at(1));
-	// 	}
-	// 	if (temp_next_initial_direction==front_vehicle_dir) {
-	// 		return front_vehicle->get_pos();
-	// 	} else {
-	// 		convoihandle_t c = self;
-	// 		while ( c->get_coupling_convoi().is_bound()){
-	// 			c = c->get_coupling_convoi();
-	// 		}
-	// 		return c->back()->get_pos();
-	// 	}
-	// }
-	// end reversing convoi
 	if(
 		!get_coupling_convoi().is_bound()
 		||  !gr

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -1347,13 +1347,6 @@ bool convoi_t::drive_to()
 			}
 
 			schedule->set_current_stop(current_stop);
-			convoihandle_t c = self;
-			while(  c.is_bound()  ) {
-				if (c->is_reversing_needed){
-					c->reverse_vehicles_at_halt_if_needed();
-				}
-				c = c->get_coupling_convoi();
-			}
 			if(  route_ok  ) {
 				vorfahren();
 				is_reversing_needed = false;
@@ -2428,6 +2421,13 @@ void convoi_t::vorfahren()
 	recalc_data_front = true;
 	recalc_data = true;
 	recalc_speed_limit = true;
+	convoihandle_t c = self;
+	while(  c.is_bound()  ) {
+		if (c->is_reversing_needed){
+			c->reverse_vehicles_at_halt_if_needed();
+		}
+		c = c->get_coupling_convoi();
+	}
 
 	koord3d k0 = route.front();
 	grund_t *gr = welt->lookup(k0);
@@ -3791,7 +3791,7 @@ void convoi_t::hat_gehalten(halthandle_t halt, uint32 halt_length_in_vehicle_ste
 			last_child_convoi = last_child_convoi->get_coupling_convoi();
 		}
 		// Avoid infinite loop for the case that the last child convoy also requests reversing the coupling.
-		if(  !child_convoi->get_schedule()->get_current_entry().is_reverse_convoi_coupling()  ){
+		if(  !last_child_convoi->get_schedule()->get_current_entry().is_reverse_convoi_coupling()  ){
 			reverse_convoy_coupling();
 		}
 	}

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -3786,13 +3786,13 @@ void convoi_t::hat_gehalten(halthandle_t halt, uint32 halt_length_in_vehicle_ste
 	if (  get_schedule()->get_current_entry().is_reverse_convoi_coupling()  &&
 		coupling_convoi.is_bound()  &&  !is_coupled()  &&  !is_waiting_for_coupling()
 	) {
-		// Do not loop. if the last child convoy's schedule is also is_reverse_convoi_coupling(), Don't do this function.
-		convoihandle_t child_convoi = self->get_coupling_convoi();
-		while (child_convoi->get_coupling_convoi().is_bound()){
-			child_convoi=child_convoi->get_coupling_convoi();
+		convoihandle_t last_child_convoi = self->get_coupling_convoi();
+		while (  last_child_convoi->get_coupling_convoi().is_bound()  ){
+			last_child_convoi = last_child_convoi->get_coupling_convoi();
 		}
-		if(!child_convoi->get_schedule()->get_current_entry().is_reverse_convoi_coupling()){
-		reverse_convoy_coupling();
+		// Avoid infinite loop for the case that the last child convoy also requests reversing the coupling.
+		if(  !child_convoi->get_schedule()->get_current_entry().is_reverse_convoi_coupling()  ){
+			reverse_convoy_coupling();
 		}
 	}
 

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -1055,7 +1055,6 @@ public:
 	// Returns the root parent convoi of this convoy. Returns this convoy if not coupled.
 	// Warning: The calculation cost is O(n) where n is the number of convoys in the world.
 	convoihandle_t find_most_parent_convoi() const;
-	convoihandle_t copy_convoi_if_reversed() const;
 };
 
 #endif

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -373,8 +373,7 @@ private:
 	char name_and_id[128];
 
 	bool reversed; // true when the vehicles are in the reversed order.
-	bool reversed_at_current_halt;// Whether this convoy's vehicles are currently arranged in reverse order. The flag for calculation of position.
-
+	bool is_reversing_needed;// Whether this convoy's vehicles will be arranged in reverse order.
 	/**
 	* Initialize all variables with default values.
 	* Each constructor must call this method first!
@@ -1056,6 +1055,7 @@ public:
 	// Returns the root parent convoi of this convoy. Returns this convoy if not coupled.
 	// Warning: The calculation cost is O(n) where n is the number of convoys in the world.
 	convoihandle_t find_most_parent_convoi() const;
+	convoihandle_t copy_convoi_if_reversed() const;
 };
 
 #endif

--- a/simdepot.cc
+++ b/simdepot.cc
@@ -351,8 +351,7 @@ convoihandle_t depot_t::copy_convoi(convoihandle_t old_cnv, bool local_execution
 		new_cnv->set_name(old_cnv->get_internal_name());
 		int vehicle_count = old_cnv->get_vehicle_count();
 		for (int i = 0; i<vehicle_count; i++) {
-			int i_cor = i;
-			if (old_cnv->is_reversed()){i_cor=vehicle_count-i-1;}
+			const int vehicle_index = old_cnv->is_reversed() ? vehicle_count - i - 1 : i; // Always copy in the normal order
 			const vehicle_desc_t * info = old_cnv->get_vehikel(i_cor)->get_desc();
 			if (info != NULL) {
 				// search in depot for an existing vehicle of correct type

--- a/simdepot.cc
+++ b/simdepot.cc
@@ -351,7 +351,9 @@ convoihandle_t depot_t::copy_convoi(convoihandle_t old_cnv, bool local_execution
 		new_cnv->set_name(old_cnv->get_internal_name());
 		int vehicle_count = old_cnv->get_vehicle_count();
 		for (int i = 0; i<vehicle_count; i++) {
-			const vehicle_desc_t * info = old_cnv->get_vehikel(i)->get_desc();
+			int i_cor = i;
+			if (old_cnv->is_reversed()){i_cor=vehicle_count-i-1;}
+			const vehicle_desc_t * info = old_cnv->get_vehikel(i_cor)->get_desc();
 			if (info != NULL) {
 				// search in depot for an existing vehicle of correct type
 				vehicle_t* oldest_vehicle = get_oldest_vehicle(info);

--- a/simdepot.cc
+++ b/simdepot.cc
@@ -352,7 +352,7 @@ convoihandle_t depot_t::copy_convoi(convoihandle_t old_cnv, bool local_execution
 		int vehicle_count = old_cnv->get_vehicle_count();
 		for (int i = 0; i<vehicle_count; i++) {
 			const int vehicle_index = old_cnv->is_reversed() ? vehicle_count - i - 1 : i; // Always copy in the normal order
-			const vehicle_desc_t * info = old_cnv->get_vehikel(i_cor)->get_desc();
+			const vehicle_desc_t * info = old_cnv->get_vehikel(vehicle_index)->get_desc();
 			if (info != NULL) {
 				// search in depot for an existing vehicle of correct type
 				vehicle_t* oldest_vehicle = get_oldest_vehicle(info);


### PR DESCRIPTION
Changed specifications as follows

- Call reverse_vehicles_at_halt_if_needed() in drive_to() after station departure
- Changed the meaning of “reversed_at_current_halt” from “vehicle direction reversing is done” to “vehicle direction change required at departure (=before change)”.