### PR TITLE
BUG FIX : Fix some bugs related to coupling

### DIFF
--- a/gui/convoi_info_t.cc
+++ b/gui/convoi_info_t.cc
@@ -385,7 +385,11 @@ void convoi_info_t::draw(scr_coord pos, scr_size size)
 		no_load_button.enable();
 		set_recovery_button.pressed = cnv->is_in_delay_recovery();
 		set_recovery_button.enable();
-		next_stop_button.enable();
+		if(  cnv->is_coupled() ){
+			next_stop_button.disable();
+		}else{
+			next_stop_button.enable();
+		}
 		const bool reversable_waytype = cnv->get_schedule()->get_waytype()!=road_wt  &&  cnv->get_schedule()->get_waytype()!=air_wt  &&  cnv->get_schedule()->get_waytype()!=water_wt;
 		if (reversable_waytype) {
 			reversed_button.pressed = cnv->is_reversed();

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -1897,15 +1897,15 @@ void convoi_t::ziel_erreicht()
 				}
 				// when the waiting couvoi is child of other convoi or the coupling convoi already has child convoi,
 				// to avoid duplication, the coupling convoi is set as a child of waiting convoi firstly.
-				if(v->get_convoi()->is_coupled()){
+				if(  v->get_convoi()->is_coupled()  ){
 					v->get_convoi()->couple_convoi(self);
 					// if the direction is different, reverse the parents_children order.
-					if(ribi_t::backward(front()->get_direction())==v->get_convoi()->get_next_initial_direction()){
+					if(  ribi_t::backward(front()->get_direction())==v->get_convoi()->get_next_initial_direction()  ){
 						find_most_parent_convoi()->reverse_convoy_coupling();
 					}
 				}
 				// when both convoi has child, the waiting convois are set as children, firstly.
-				else if(self->get_coupling_convoi().is_bound()){
+				else if(  self->get_coupling_convoi().is_bound() || v->get_convoi()->self->get_coupling_convoi().is_bound()  ){
 					reverse_convoy_coupling();
 					couple_convoi(v->get_convoi()->self);
 					// if the direction is different, change order
@@ -5298,11 +5298,13 @@ void convoi_t::reverse_vehicles()
 void convoi_t::reverse_convoy_coupling()
 {
 	convoihandle_t new_parent_convoy = coupling_convoi; 
-	uncouple_convoi();
-	if (new_parent_convoy->get_coupling_convoi().is_bound()) {
-		new_parent_convoy->reverse_convoy_coupling();
+	if (  new_parent_convoy.is_bound()  ) {
+		uncouple_convoi();
+		if (new_parent_convoy->get_coupling_convoi().is_bound()) {
+			new_parent_convoy->reverse_convoy_coupling();
+		}
+		new_parent_convoy->couple_convoi(self);
 	}
-	new_parent_convoy->couple_convoi(self);
 }
 
 

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -5390,9 +5390,6 @@ void convoi_t::next_stop_button_pressed() {
 	if(  self->is_coupled()  ) {
 		return;
 	}
-	if( self->is_coupling_done() ) {
-		self->set_coupling_done(false);
-	}
 	convoihandle_t c = self;
 	while( c.is_bound() ) {
 		schedule_t *schedule = c->get_schedule();
@@ -5407,6 +5404,9 @@ void convoi_t::next_stop_button_pressed() {
 		}
 		if( !c->is_coupled() ) {
 			c->set_schedule(schedule);
+		}
+		if( c->is_coupling_done() ) {
+			c->set_coupling_done(false);
 		}
 		c = temp_c;
 	}

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -92,7 +92,7 @@ static const char * state_names[convoi_t::MAX_STATES] =
 	"ENTERING_DEPOT",
 	"COUPLED",
 	"COUPLED_LOADING",
-	"WAITING_FOR_LEAVING_DEPOT"
+	"WAITING_FOR_LEAVING_DEPOT",
 };
 
 
@@ -1169,7 +1169,7 @@ koord3d convoi_t::calc_first_pos_of_route() const {
 	if(
 		!get_coupling_convoi().is_bound()
 		||  !gr
-		||  !ribi_t::is_single(front_vehicle_dir)
+		||  ( !ribi_t::is_single(front_vehicle_dir) && !ribi_t::is_bend(front_vehicle_dir) )
 		||  !gr->get_neighbour(ngr, front_vehicle->get_waytype(), front_vehicle_dir)
 	) {
 		// There is not the coupling convoy in front.
@@ -1181,7 +1181,7 @@ koord3d convoi_t::calc_first_pos_of_route() const {
 		return front_vehicle->get_pos();
 	}
 	// There is the child coupling convoy in front and we need to reverse the direction.
-	if(  heading_child_convoy_vehicle->get_direction()==ribi_t::backward(front_vehicle_dir)  ) {
+	if(  ( heading_child_convoy_vehicle->get_direction() & ribi_t::backward(front_vehicle_dir) ) > 0  ) {
 		// The child coupling convoy is already in reversed direction.
 		// Use the last vehicle pos of the child as the first pos of the new route.
 		convoihandle_t c = heading_child_convoy_vehicle->get_convoi()->self;
@@ -1399,6 +1399,7 @@ void convoi_t::step()
 			break;
 
 		case EDIT_SCHEDULE:
+			unset_coupling_now();
 			// schedule window closed?
 			if(schedule!=NULL  &&  schedule->is_editing_finished()) {
 
@@ -1483,6 +1484,7 @@ void convoi_t::step()
 			break;
 
 		case NO_ROUTE:
+			unset_coupling_now();
 			// stuck vehicles
 			if (schedule->empty()) {
 				// no entries => no route ...
@@ -1549,6 +1551,7 @@ void convoi_t::step()
 
 		// must be here; may otherwise confuse window management
 		case SELF_DESTRUCT:
+			unset_coupling_now();
 			welt->set_dirty();
 			destroy();
 			return; // must not continue method after deleting this object
@@ -1890,17 +1893,25 @@ void convoi_t::ziel_erreicht()
 				if(  !v  ||  !can_start_coupling(v->get_convoi())  ||  !v->get_convoi()->is_loading()  ) {
 					continue;
 				}
+				// if there are many convoys in the same tile, the coupled convoy is the front or end convoy!
+				if(  (   (v->get_direction()&self->front()->get_direction())==0  &&  v->get_convoi()->is_coupled()  )  ||  (  (v->get_direction()&self->front()->get_direction())!=0  &&  v->get_convoi()->get_coupling_convoi().is_bound()  )  ) {
+					continue;
+				}
 				// there is a suitable waiting convoy for coupling -> this is coupling point.
 				akt_speed = 0;
 				if(  halt.is_bound() &&  gr->get_weg_ribi(v->get_waytype())!=0  ) {
 					halt->book(1, HALT_CONVOIS_ARRIVED);
 				}
+				// the direction of the waiting vehicle is same? opposite?
+				// reference direction to detect leading or following
+				ribi_t::ribi ribi_reference_direction = (  ( v->get_convoi()->get_next_initial_direction()  &  v->get_convoi()->front()->get_direction() ) > 0  ) ? ribi_reference_direction = v->get_direction(): ribi_reference_direction = ribi_t::backward(v->get_direction());
+				bool coupling_is_leading = !( ( self->front()->get_direction() & ribi_reference_direction ) > 0 );
 				// when the waiting couvoi is child of other convoi or the coupling convoi already has child convoi,
 				// to avoid duplication, the coupling convoi is set as a child of waiting convoi firstly.
 				if(  v->get_convoi()->is_coupled()  ){
 					v->get_convoi()->couple_convoi(self);
 					// if the direction is different, reverse the parents_children order.
-					if(  ribi_t::backward(front()->get_direction())==v->get_convoi()->get_next_initial_direction()  ){
+					if(  coupling_is_leading  ){
 						find_most_parent_convoi()->reverse_convoy_coupling();
 					}
 				}
@@ -1909,12 +1920,12 @@ void convoi_t::ziel_erreicht()
 					reverse_convoy_coupling();
 					couple_convoi(v->get_convoi()->self);
 					// if the direction is different, change order
-					if(  ribi_t::backward(front()->get_direction())!=v->get_convoi()->get_next_initial_direction()  ){
+					if(  !coupling_is_leading  ){
 						find_most_parent_convoi()->reverse_convoy_coupling();
 					}
 				}
 				// the waiting convoi and coupling convoi are single convoi
-				else if(  ribi_t::backward(front()->get_direction())==v->get_convoi()->get_next_initial_direction()  ) {
+				else if(  coupling_is_leading  ) {
 					// this convoy leads the other.
 					couple_convoi(v->get_convoi()->self);
 				} else {
@@ -3127,6 +3138,11 @@ void convoi_t::rdwr(loadsave_t *file)
 		reserve_route();
 		recalc_catg_index();
 	}
+
+	
+	if(  file->get_OTRP_version()>=44  ) {
+		rdwr_convoihandle_t( file, will_coupling_convoi );
+	}
 }
 
 
@@ -3405,11 +3421,21 @@ sint32 subtract_ticks(uint32 v1, uint32 v2) {
  */
 bool can_depart(convoihandle_t cnv, halthandle_t halt, uint32 arrived_time, uint32 time_to_load, bool &coupling_cond, uint32 &go_on_ticks) {
 	convoihandle_t c = cnv;
+	bool now_coupling = false;
 	// First, check whether we have to wait for coupling at this stop.
 	coupling_cond = false;
 	while(  c.is_bound()  ) {
 		const schedule_entry_t e = c->get_schedule()->get_current_entry();
 		coupling_cond |= (e.get_coupling_point()==1  &&  !c->is_coupling_done()  &&  !(c->get_coupling_convoi().is_bound()  &&  c->is_coupled()));
+		now_coupling |= c->get_will_coupling_convoi().is_bound();
+		if (  c->is_coupling_done()  ||  !c->get_will_coupling_convoi().is_bound()  ||  c->get_will_coupling_convoi()->get_will_coupling_convoi()!=c  ) {
+			// This will_conpling_convoi() flag is too strong. 
+			// So if there are some happens such as
+			// coupling convoi is removed or
+			// forget to remove the flag after coupling done,
+			// this flag should be NONE! 
+			c->unset_coupling_now();
+		}
 		c = c->get_coupling_convoi();
 	}
 
@@ -3769,12 +3795,17 @@ void convoi_t::hat_gehalten(halthandle_t halt, uint32 halt_length_in_vehicle_ste
 	bool coupling_cond = (self->get_schedule()->get_current_entry().get_coupling_point()==1  &&  !self->is_coupling_done()  &&  !(self->get_coupling_convoi().is_bound()  &&  self->is_coupled()));
 	bool departure_cond = false;
 	scheduled_coupling_delay_tolerance = (uint64)self->get_schedule()->get_current_entry().delay_tolerance * world()->ticks_per_world_month / world()->get_settings().get_spacing_shift_divisor();
-
+	c = self;
+	bool now_coupling_so_wait = false;
+	while (  c.is_bound()  ) {
+		now_coupling_so_wait |= c->get_will_coupling_convoi().is_bound();
+		c = c->get_coupling_convoi();
+	}
 	if ( coupling_cond ){
-		departure_cond = scheduled_departure_time!=0  &&  is_first_ticks_bigger(welt->get_ticks(), scheduled_departure_time + scheduled_coupling_delay_tolerance - time);
+		departure_cond = (  scheduled_departure_time!=0  &&  is_first_ticks_bigger(welt->get_ticks(), scheduled_departure_time + scheduled_coupling_delay_tolerance - time)  )  &&  !now_coupling_so_wait;
 	}
 	else{
-		departure_cond = scheduled_departure_time!=0  &&  is_first_ticks_bigger(welt->get_ticks(), scheduled_departure_time - time);
+		departure_cond = (  scheduled_departure_time!=0  &&  is_first_ticks_bigger(welt->get_ticks(), scheduled_departure_time - time)  )  &&  !now_coupling_so_wait;
 	}
 
 	// reverse convoi
@@ -3823,7 +3854,6 @@ void convoi_t::hat_gehalten(halthandle_t halt, uint32 halt_length_in_vehicle_ste
 
 	// loading is finished => maybe drive on
 	if(  is_coupled()  ||  departure_cond  ) {
-
 		calc_speedbonus_kmh();
 
 		// add available capacity after loading(!) to statistics
@@ -5052,6 +5082,28 @@ void convoi_t::calc_crossing_reservation() {
 	}
 }
 
+void convoi_t::set_coupling_now(convoihandle_t coupling_now) {
+	if( coupling_now.is_bound() ) {
+		will_coupling_convoi=coupling_now;
+		dbg->message( "convoi_t::set_coupling_now()","%i and %i convoys will be coupling soon", self.get_id(), coupling_now->self.get_id() );
+		return;
+	} else {
+		dbg->message( "convoi_t::set_coupling_now()","%i cannot find the coupling convoi!", self.get_id());
+		return;
+	}
+}
+
+void convoi_t::unset_coupling_now() {
+	if (get_will_coupling_convoi().is_bound()) {
+		convoihandle_t c = get_will_coupling_convoi();
+		c->delete_will_coupling_convoi();
+		self->delete_will_coupling_convoi();
+		dbg->message( "convoi_t::unset_coupling_now()","%i and %i convoys are now coupling or canceling couple", self.get_id(), c->self.get_id() );
+		return;
+	} else {
+		return;
+	}
+}
 
 bool convoi_t::couple_convoi(convoihandle_t coupled) {
 	coupled->set_state(COUPLED_LOADING);
@@ -5062,6 +5114,7 @@ bool convoi_t::couple_convoi(convoihandle_t coupled) {
 	coupling_convoi->front()->set_leading(false);
 	back()->set_last(false);
 	must_recalc_min_top_speed();
+	unset_coupling_now();
 	return true;
 }
 
@@ -5108,6 +5161,7 @@ bool convoi_t::can_start_coupling(convoi_t* parent) const {
 	* 1) next schedule entries have the same position.
 	* 2) current schedule entries have the same position.
 	* 3) current schedule entry has appropriate coupling_point for both convoys.
+	* 4) check the coupled couvoi has a free coupler. if both front and back sides are already coupled, false.
 	*/
 	// Since current schedule entry of this convoy can be waypoint, we proceed to a genuine stop point.
 	sint16 t_idx = schedule->get_current_stop();
@@ -5136,6 +5190,11 @@ bool convoi_t::can_start_coupling(convoi_t* parent) const {
 	if(  t_c.pos!=p_c.pos  ||  t_n.pos!=p_n.pos  ) {
 		return false;
 	}
+	// If the coupled convoy cannot be coupled, return false.
+	// If the coupled convoy is already coupling with two convoy, this convoy cannot be coupled!
+	if(  parent->self->get_coupling_convoi().is_bound()  &&  parent->is_coupled()  ) {
+		return false;
+	}
 	return true;
 }
 
@@ -5143,7 +5202,7 @@ bool convoi_t::is_waiting_for_coupling() const {
 	convoihandle_t c = self;
 	bool waiting_for_coupling = false;
 	while(  c.is_bound()  ) {
-		waiting_for_coupling |= (!c->get_coupling_convoi().is_bound()  &&  c->get_schedule()->get_current_entry().get_coupling_point()==1);
+		waiting_for_coupling |= (  !(c->get_coupling_convoi().is_bound()&&c->is_coupled())  &&  c->get_schedule()->get_current_entry().get_coupling_point()==1);
 		c = c->get_coupling_convoi();
 	}
 	return waiting_for_coupling;

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -5390,6 +5390,9 @@ void convoi_t::next_stop_button_pressed() {
 	if(  self->is_coupled()  ) {
 		return;
 	}
+	if( self->is_coupling_done() ) {
+		self->set_coupling_done(false);
+	}
 	convoihandle_t c = self;
 	while( c.is_bound() ) {
 		schedule_t *schedule = c->get_schedule();

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -1399,7 +1399,7 @@ void convoi_t::step()
 			break;
 
 		case EDIT_SCHEDULE:
-			unset_coupling_now();
+			unset_will_coupling_convoi();
 			// schedule window closed?
 			if(schedule!=NULL  &&  schedule->is_editing_finished()) {
 
@@ -1484,7 +1484,7 @@ void convoi_t::step()
 			break;
 
 		case NO_ROUTE:
-			unset_coupling_now();
+			unset_will_coupling_convoi();
 			// stuck vehicles
 			if (schedule->empty()) {
 				// no entries => no route ...
@@ -1551,7 +1551,7 @@ void convoi_t::step()
 
 		// must be here; may otherwise confuse window management
 		case SELF_DESTRUCT:
-			unset_coupling_now();
+			unset_will_coupling_convoi();
 			welt->set_dirty();
 			destroy();
 			return; // must not continue method after deleting this object
@@ -3434,7 +3434,7 @@ bool can_depart(convoihandle_t cnv, halthandle_t halt, uint32 arrived_time, uint
 			// coupling convoi is removed or
 			// forget to remove the flag after coupling done,
 			// this flag should be NONE! 
-			c->unset_coupling_now();
+			c->unset_will_coupling_convoi();
 		}
 		c = c->get_coupling_convoi();
 	}
@@ -5082,23 +5082,23 @@ void convoi_t::calc_crossing_reservation() {
 	}
 }
 
-void convoi_t::set_coupling_now(convoihandle_t coupling_now) {
-	if( coupling_now.is_bound() ) {
-		will_coupling_convoi=coupling_now;
-		dbg->message( "convoi_t::set_coupling_now()","%i and %i convoys will be coupling soon", self.get_id(), coupling_now->self.get_id() );
+void convoi_t::set_will_coupling_convoi(convoihandle_t convoi_coupling_undergo) {
+	if( convoi_coupling_undergo.is_bound() ) {
+		will_coupling_convoi=convoi_coupling_undergo;
+		dbg->message( "convoi_t::set_will_coupling_convoi()","%i and %i convoys will be coupling soon", self.get_id(), will_coupling_convoi->self.get_id() );
 		return;
 	} else {
-		dbg->message( "convoi_t::set_coupling_now()","%i cannot find the coupling convoi!", self.get_id());
+		dbg->message( "convoi_t::set_will_coupling_convoi()","%i cannot find the coupling convoi!", self.get_id());
 		return;
 	}
 }
 
-void convoi_t::unset_coupling_now() {
+void convoi_t::unset_will_coupling_convoi() {
 	if (get_will_coupling_convoi().is_bound()) {
 		convoihandle_t c = get_will_coupling_convoi();
 		c->delete_will_coupling_convoi();
 		self->delete_will_coupling_convoi();
-		dbg->message( "convoi_t::unset_coupling_now()","%i and %i convoys are now coupling or canceling couple", self.get_id(), c->self.get_id() );
+		dbg->message( "convoi_t::unset_will_coupling_convoi()","%i and %i convoys are now coupling or canceling couple", self.get_id(), c->self.get_id() );
 		return;
 	} else {
 		return;
@@ -5114,7 +5114,7 @@ bool convoi_t::couple_convoi(convoihandle_t coupled) {
 	coupling_convoi->front()->set_leading(false);
 	back()->set_last(false);
 	must_recalc_min_top_speed();
-	unset_coupling_now();
+	unset_will_coupling_convoi();
 	return true;
 }
 
@@ -5384,4 +5384,27 @@ convoihandle_t convoi_t::find_most_parent_convoi() const {
 		}
 	}
 	return tc;
+}
+
+void convoi_t::next_stop_button_pressed() {
+	if(  self->is_coupled()  ) {
+		return;
+	}
+	convoihandle_t c = self;
+	while( c.is_bound() ) {
+		schedule_t *schedule = c->get_schedule();
+		convoihandle_t const temp_c = c->get_coupling_convoi();
+		if( !c->can_continue_coupling() ) {
+			c->uncouple_convoi();
+		}
+		if( schedule->get_current_stop() == schedule->entries.get_count() - 1 ) {
+			schedule->set_current_stop( 0 );
+		} else {
+			schedule->set_current_stop( schedule->get_current_stop() + 1 ); 
+		}
+		if( !c->is_coupled() ) {
+			c->set_schedule(schedule);
+		}
+		c = temp_c;
+	}
 }

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -230,6 +230,15 @@ private:
 	convoihandle_t coupling_convoi;
 
 	/**
+	* a convoy that is coupling now.
+	*/
+	convoihandle_t will_coupling_convoi;
+	/**
+	* delete currently coupling convoi information
+	*/
+	void delete_will_coupling_convoi() {will_coupling_convoi=convoihandle_t();}
+
+	/**
 	* Current map
 	*/
 	static karte_ptr_t welt;
@@ -1017,6 +1026,9 @@ public:
 
 	bool is_coupled() const { return state==COUPLED  ||  state==COUPLED_LOADING; }
 	bool is_waiting_for_coupling() const;
+	void set_coupling_now(convoihandle_t coupling_now);
+	convoihandle_t get_will_coupling_convoi() const { return will_coupling_convoi; }
+	void unset_coupling_now();
 
 	bool can_continue_coupling() const;
 	bool can_start_coupling(convoi_t* parent) const;

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -144,6 +144,9 @@ private:
 	sint32 akt_speed;         // current speed
 	// 64 bytes
 
+	// to calculate next_stop_button_pressed
+	// we store how many stops the convoi will skip
+	uint8 the_number_of_skip_stops;
 	/**
 	 * this give the index of the next signal or the end of the route
 	 * convois will slow down before it, if this is not a waypoint or the cannot pass
@@ -1026,9 +1029,9 @@ public:
 
 	bool is_coupled() const { return state==COUPLED  ||  state==COUPLED_LOADING; }
 	bool is_waiting_for_coupling() const;
-	void set_coupling_now(convoihandle_t coupling_now);
+	void set_will_coupling_convoi(convoihandle_t convoi_coupling_undergo);
 	convoihandle_t get_will_coupling_convoi() const { return will_coupling_convoi; }
-	void unset_coupling_now();
+	void unset_will_coupling_convoi();
 
 	bool can_continue_coupling() const;
 	bool can_start_coupling(convoi_t* parent) const;
@@ -1067,6 +1070,11 @@ public:
 	// Returns the root parent convoi of this convoy. Returns this convoy if not coupled.
 	// Warning: The calculation cost is O(n) where n is the number of convoys in the world.
 	convoihandle_t find_most_parent_convoi() const;
+
+	// go to next stop (skip one stops)
+	// only called by tool_change_convoi_t
+	void next_stop_button_pressed();
+
 };
 
 #endif

--- a/simtool.cc
+++ b/simtool.cc
@@ -8302,14 +8302,7 @@ bool tool_change_convoi_t::init( player_t *player )
 
 		case 't':
 		{
-			schedule_t *schedule = cnv->get_schedule();
-			if( schedule->get_current_stop() == schedule->entries.get_count()-1 ){
-				schedule->set_current_stop( 0 );
-			}
-			else{
-				schedule->set_current_stop( schedule->get_current_stop() + 1 );
-			}
-			cnv->set_schedule(schedule);
+			cnv->next_stop_button_pressed();
 		}
 		break;
 		

--- a/simversion.h
+++ b/simversion.h
@@ -27,7 +27,7 @@
 #define SIM_SERVER_MINOR    0
 // NOTE: increment before next release to enable save/load of new features
 
-#define OTRP_VERSION_MAJOR 43
+#define OTRP_VERSION_MAJOR 44
 #define OTRP_VERSION_MINOR 0
 #define OTRP_VERSION_PATCH 0
 // NOTE: increment OTRP_VERSION_MAJOR when the save data structure changes.

--- a/simversion.h
+++ b/simversion.h
@@ -27,7 +27,7 @@
 #define SIM_SERVER_MINOR    0
 // NOTE: increment before next release to enable save/load of new features
 
-#define OTRP_VERSION_MAJOR 44
+#define OTRP_VERSION_MAJOR 43
 #define OTRP_VERSION_MINOR 0
 #define OTRP_VERSION_PATCH 0
 // NOTE: increment OTRP_VERSION_MAJOR when the save data structure changes.

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -4170,10 +4170,12 @@ bool rail_vehicle_t::can_couple(const route_t* route, uint16 start_index, uint16
 	} while(  idx!=cnv->get_schedule()->get_current_stop()  );
 	if(  !stop_found  ||  cnv->get_schedule()->entries[idx].get_coupling_point()!=2  ) {
 		// all schedule entries are waypoint or the next stop point is not a coupling point.
+		cnv->unset_coupling_now();
 		return false;
 	}
 	// start_index can be invalid.
 	if(start_index>=route->get_count()) {
+		cnv->unset_coupling_now();
 		return false;
 	}
 
@@ -4184,6 +4186,7 @@ bool rail_vehicle_t::can_couple(const route_t* route, uint16 start_index, uint16
 		grund_t *gr = welt->lookup(route->at(i));
 		if(  !gr  ) {
 			// ground does not exist!?
+			cnv->unset_coupling_now();
 			return false;
 		}
 		const ribi_t::ribi dir = i==start_index ? ribi_t::none : ribi_type(route->at(i-1), route->at(i));
@@ -4199,6 +4202,18 @@ bool rail_vehicle_t::can_couple(const route_t* route, uint16 start_index, uint16
 						// direction is bad to couple.
 						continue;
 					}
+					// if v is only one car train, determine the direction based on the information of the coupling of v->get_convoi().
+					if(  i!=start_index  &&  ((v->get_convoi()->is_coupled()&&(v->get_direction()&dir)==0)  ||  (v->get_convoi()->get_coupling_convoi().is_bound()&&(v->get_direction()&dir)!=0))   ) {
+						// direction is bad to couple.
+						continue;
+					}
+					// the waiting convoi is currently coupling
+					if(  v->get_convoi()->get_will_coupling_convoi().is_bound()  &&  v->get_convoi()->get_will_coupling_convoi() != cnv->self  ) {
+						continue;
+					}
+					// set convoi as coupling now!
+					v->get_convoi()->self->set_coupling_now(cnv->self);
+					cnv->set_coupling_now(v->get_convoi()->self);
 					//reserve tiles
 					for(  uint16 h=start_index;  h<i;  h++  ) {
 						grund_t* grn = welt->lookup(route->at(h));
@@ -4210,7 +4225,7 @@ bool rail_vehicle_t::can_couple(const route_t* route, uint16 start_index, uint16
 					// set coupling index and step
 					// c_step can be negative, so it must be handled as sint16.
 					// TODO: in case that the vehicle length is over 16.
-					const sint16 c_step = v->get_steps() - VEHICLE_STEPS_PER_CARUNIT*v->get_desc()->get_length();
+					const sint16 c_step = ((v->get_direction()&dir)==0) ? v->get_steps() - VEHICLE_STEPS_PER_TILE /2 + env_t::reverse_base_offsets[dir][2] : v->get_steps() - VEHICLE_STEPS_PER_CARUNIT*v->get_desc()->get_length();
 					const bool is_diagonal_way = ribi_t::is_bend(gr->get_weg(get_waytype())->get_ribi_unmasked());
 					const sint16 tile_length = is_diagonal_way ? diagonal_vehicle_steps_per_tile : VEHICLE_STEPS_PER_TILE;
 					coupling_index = c_step<0 ? max(i-1,0) : i;
@@ -4218,7 +4233,7 @@ bool rail_vehicle_t::can_couple(const route_t* route, uint16 start_index, uint16
 					return true;
 				} else {
 					// other convoy exists.
-					return false;
+					continue;
 				}
 			}
 		}
@@ -4226,6 +4241,7 @@ bool rail_vehicle_t::can_couple(const route_t* route, uint16 start_index, uint16
 		schiene_t * sch = gr ? (schiene_t *)gr->get_weg(get_waytype()) : NULL;
 		if(  !sch  ||  (!ignore_signals  &&  sch->has_signal())  ||  !sch->can_reserve(cnv->self)  ) {
 			// end of truck or section. or unreachable for some reasons. anyway, convoy for coupling is not found.
+			cnv->unset_coupling_now();
 			return false;
 		}
 	}

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -4170,12 +4170,12 @@ bool rail_vehicle_t::can_couple(const route_t* route, uint16 start_index, uint16
 	} while(  idx!=cnv->get_schedule()->get_current_stop()  );
 	if(  !stop_found  ||  cnv->get_schedule()->entries[idx].get_coupling_point()!=2  ) {
 		// all schedule entries are waypoint or the next stop point is not a coupling point.
-		cnv->unset_coupling_now();
+		cnv->unset_will_coupling_convoi();
 		return false;
 	}
 	// start_index can be invalid.
 	if(start_index>=route->get_count()) {
-		cnv->unset_coupling_now();
+		cnv->unset_will_coupling_convoi();
 		return false;
 	}
 
@@ -4186,7 +4186,7 @@ bool rail_vehicle_t::can_couple(const route_t* route, uint16 start_index, uint16
 		grund_t *gr = welt->lookup(route->at(i));
 		if(  !gr  ) {
 			// ground does not exist!?
-			cnv->unset_coupling_now();
+			cnv->unset_will_coupling_convoi();
 			return false;
 		}
 		const ribi_t::ribi dir = i==start_index ? ribi_t::none : ribi_type(route->at(i-1), route->at(i));
@@ -4212,8 +4212,8 @@ bool rail_vehicle_t::can_couple(const route_t* route, uint16 start_index, uint16
 						continue;
 					}
 					// set convoi as coupling now!
-					v->get_convoi()->self->set_coupling_now(cnv->self);
-					cnv->set_coupling_now(v->get_convoi()->self);
+					v->get_convoi()->self->set_will_coupling_convoi(cnv->self);
+					cnv->set_will_coupling_convoi(v->get_convoi()->self);
 					//reserve tiles
 					for(  uint16 h=start_index;  h<i;  h++  ) {
 						grund_t* grn = welt->lookup(route->at(h));
@@ -4241,7 +4241,7 @@ bool rail_vehicle_t::can_couple(const route_t* route, uint16 start_index, uint16
 		schiene_t * sch = gr ? (schiene_t *)gr->get_weg(get_waytype()) : NULL;
 		if(  !sch  ||  (!ignore_signals  &&  sch->has_signal())  ||  !sch->can_reserve(cnv->self)  ) {
 			// end of truck or section. or unreachable for some reasons. anyway, convoy for coupling is not found.
-			cnv->unset_coupling_now();
+			cnv->unset_will_coupling_convoi();
 			return false;
 		}
 	}


### PR DESCRIPTION
・連結時のreverse_convoy_coupling使用時の条件分岐が不正確なため、連結済み編成に追加で連結する際に連結失敗するバグが起こる可能性があり、当該箇所を修正しました。
・reverse_convoy_coupling自体に存在しない編成への連結を避けるための関数を入れました。