### PR TITLE
Fix: Coupling bug when there are many waiting_for_coupling convoys in the same tile.

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -1890,6 +1890,10 @@ void convoi_t::ziel_erreicht()
 				if(  !v  ||  !can_start_coupling(v->get_convoi())  ||  !v->get_convoi()->is_loading()  ) {
 					continue;
 				}
+				// if there are many convoys in the same tile, the coupled convoy is the front or end convoy!
+				if(  (   (v->get_direction()&self->front()->get_direction())==0  &&  v->get_convoi()->is_coupled()  )  ||  (  (v->get_direction()&self->front()->get_direction())!=0  &&  v->get_convoi()->get_coupling_convoi().is_bound()  )  ) {
+					continue;
+				}
 				// there is a suitable waiting convoy for coupling -> this is coupling point.
 				akt_speed = 0;
 				if(  halt.is_bound() &&  gr->get_weg_ribi(v->get_waytype())!=0  ) {
@@ -5108,6 +5112,7 @@ bool convoi_t::can_start_coupling(convoi_t* parent) const {
 	* 1) next schedule entries have the same position.
 	* 2) current schedule entries have the same position.
 	* 3) current schedule entry has appropriate coupling_point for both convoys.
+	* 4) check the coupled couvoi has a free coupler. if both front and back sides are already coupled, false.
 	*/
 	// Since current schedule entry of this convoy can be waypoint, we proceed to a genuine stop point.
 	sint16 t_idx = schedule->get_current_stop();
@@ -5136,6 +5141,11 @@ bool convoi_t::can_start_coupling(convoi_t* parent) const {
 	if(  t_c.pos!=p_c.pos  ||  t_n.pos!=p_n.pos  ) {
 		return false;
 	}
+	// If the coupled convoy cannot be coupled, return false.
+	// If the coupled convoy is already coupling with two convoy, this convoy cannot be coupled!
+	if(  parent->self->get_coupling_convoi().is_bound()  &&  parent->is_coupled()  ) {
+		return false;
+	}
 	return true;
 }
 
@@ -5143,7 +5153,7 @@ bool convoi_t::is_waiting_for_coupling() const {
 	convoihandle_t c = self;
 	bool waiting_for_coupling = false;
 	while(  c.is_bound()  ) {
-		waiting_for_coupling |= (!c->get_coupling_convoi().is_bound()  &&  c->get_schedule()->get_current_entry().get_coupling_point()==1);
+		waiting_for_coupling |= (  !(c->get_coupling_convoi().is_bound()&&c->is_coupled())  &&  c->get_schedule()->get_current_entry().get_coupling_point()==1);
 		c = c->get_coupling_convoi();
 	}
 	return waiting_for_coupling;

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -1891,7 +1891,7 @@ void convoi_t::ziel_erreicht()
 					continue;
 				}
 				// if there are many convoys in the same tile, the coupled convoy is the front or end convoy!
-				if(  (   (v->get_direction()&self->front()->get_direction())==0  &&  v->get_convoi()->is_coupled()  )  ||  (  (v->get_direction()&self->front()->get_direction())!=0  &&  v->get_convoi()->get_coupling_convoi().is_bound()  )  ) {
+				if(  (   (v->get_direction()&front()->get_direction())==0  &&  v->get_convoi()->is_coupled()  )  ||  (  (v->get_direction()&self->front()->get_direction())!=0  &&  v->get_convoi()->get_coupling_convoi().is_bound()  )  ) {
 					continue;
 				}
 				// there is a suitable waiting convoy for coupling -> this is coupling point.

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -4199,6 +4199,18 @@ bool rail_vehicle_t::can_couple(const route_t* route, uint16 start_index, uint16
 						// direction is bad to couple.
 						continue;
 					}
+					// if v is only one car train, determine the direction based on the information of the coupling of v->get_convoi().
+					if(  i!=start_index  &&  ((v->get_convoi()->is_coupled()&&(v->get_direction()&dir)==0)  ||  (v->get_convoi()->get_coupling_convoi().is_bound()&&(v->get_direction()&dir)!=0))   ) {
+						// direction is bad to couple.
+						continue;
+					}
+					// the waiting convoi is currently coupling
+					if(  v->get_convoi()->get_will_coupling_convoi().is_bound()  &&  v->get_convoi()->get_will_coupling_convoi() != cnv->self  ) {
+						continue;
+					}
+					// set convoi as coupling now!
+					v->get_convoi()->self->set_coupling_now(cnv->self);
+					cnv->set_coupling_now(v->get_convoi()->self);
 					//reserve tiles
 					for(  uint16 h=start_index;  h<i;  h++  ) {
 						grund_t* grn = welt->lookup(route->at(h));
@@ -4210,7 +4222,7 @@ bool rail_vehicle_t::can_couple(const route_t* route, uint16 start_index, uint16
 					// set coupling index and step
 					// c_step can be negative, so it must be handled as sint16.
 					// TODO: in case that the vehicle length is over 16.
-					const sint16 c_step = v->get_steps() - VEHICLE_STEPS_PER_CARUNIT*v->get_desc()->get_length();
+					const sint16 c_step = ((v->get_direction()&dir)==0) ? v->get_steps() - VEHICLE_STEPS_PER_TILE /2 + env_t::reverse_base_offsets[dir][2] : v->get_steps() - VEHICLE_STEPS_PER_CARUNIT*v->get_desc()->get_length();
 					const bool is_diagonal_way = ribi_t::is_bend(gr->get_weg(get_waytype())->get_ribi_unmasked());
 					const sint16 tile_length = is_diagonal_way ? diagonal_vehicle_steps_per_tile : VEHICLE_STEPS_PER_TILE;
 					coupling_index = c_step<0 ? max(i-1,0) : i;
@@ -4218,7 +4230,7 @@ bool rail_vehicle_t::can_couple(const route_t* route, uint16 start_index, uint16
 					return true;
 				} else {
 					// other convoy exists.
-					return false;
+					continue;
 				}
 			}
 		}

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -4204,13 +4204,6 @@ bool rail_vehicle_t::can_couple(const route_t* route, uint16 start_index, uint16
 						// direction is bad to couple.
 						continue;
 					}
-					// the waiting convoi is currently coupling
-					if(  v->get_convoi()->get_will_coupling_convoi().is_bound()  &&  v->get_convoi()->get_will_coupling_convoi() != cnv->self  ) {
-						continue;
-					}
-					// set convoi as coupling now!
-					v->get_convoi()->self->set_coupling_now(cnv->self);
-					cnv->set_coupling_now(v->get_convoi()->self);
 					//reserve tiles
 					for(  uint16 h=start_index;  h<i;  h++  ) {
 						grund_t* grn = welt->lookup(route->at(h));


### PR DESCRIPTION
同じマスに複数の連結待ち編成がいる場合に連結失敗/連結開始しない問題を解消しました。
・同じ駅で多重連結するとき
・連結する編成がすべて編成長<7/16タイルのとき