### PR TITLE
Record convoy during coupling

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -1399,7 +1399,7 @@ void convoi_t::step()
 			break;
 
 		case EDIT_SCHEDULE:
-			unset_will_coupling_convoi();
+			unset_convoi_coupling_in_progress();
 			// schedule window closed?
 			if(schedule!=NULL  &&  schedule->is_editing_finished()) {
 
@@ -1484,7 +1484,7 @@ void convoi_t::step()
 			break;
 
 		case NO_ROUTE:
-			unset_will_coupling_convoi();
+			unset_convoi_coupling_in_progress();
 			// stuck vehicles
 			if (schedule->empty()) {
 				// no entries => no route ...
@@ -1551,7 +1551,7 @@ void convoi_t::step()
 
 		// must be here; may otherwise confuse window management
 		case SELF_DESTRUCT:
-			unset_will_coupling_convoi();
+			unset_convoi_coupling_in_progress();
 			welt->set_dirty();
 			destroy();
 			return; // must not continue method after deleting this object
@@ -3135,7 +3135,7 @@ void convoi_t::rdwr(loadsave_t *file)
 	}
 
 	if(  file->get_OTRP_version()>=44  ) {
-		rdwr_convoihandle_t( file, will_coupling_convoi );
+		rdwr_convoihandle_t( file, convoi_coupling_in_progress );
 	}
 
 	if(  file->is_loading()  ) {
@@ -3425,13 +3425,13 @@ bool can_depart(convoihandle_t cnv, halthandle_t halt, uint32 arrived_time, uint
 	while(  c.is_bound()  ) {
 		const schedule_entry_t e = c->get_schedule()->get_current_entry();
 		coupling_cond |= (e.get_coupling_point()==1  &&  !c->is_coupling_done()  &&  !(c->get_coupling_convoi().is_bound()  &&  c->is_coupled()));
-		if (  c->is_coupling_done()  ||  !c->get_will_coupling_convoi().is_bound()  ||  c->get_will_coupling_convoi()->get_will_coupling_convoi()!=c  ) {
+		if (  c->is_coupling_done()  ||  !c->get_convoi_coupling_in_progress().is_bound()  ||  c->get_convoi_coupling_in_progress()->get_convoi_coupling_in_progress()!=c  ) {
 			// This will_conpling_convoi() flag is too strong. 
 			// So if there are some happens such as
 			// coupling convoi is removed or
 			// forget to remove the flag after coupling done,
 			// this flag should be NONE! 
-			c->unset_will_coupling_convoi();
+			c->unset_convoi_coupling_in_progress();
 		}
 		c = c->get_coupling_convoi();
 	}
@@ -3794,16 +3794,16 @@ void convoi_t::hat_gehalten(halthandle_t halt, uint32 halt_length_in_vehicle_ste
 	scheduled_coupling_delay_tolerance = (uint64)self->get_schedule()->get_current_entry().delay_tolerance * world()->ticks_per_world_month / world()->get_settings().get_spacing_shift_divisor();
 
 	c = self;
-	bool now_coupling_so_wait = false;
+	bool is_coupling_in_progress = false;
 	while (  c.is_bound()  ) {
-		now_coupling_so_wait |= c->get_will_coupling_convoi().is_bound();
+		is_coupling_in_progress |= c->get_convoi_coupling_in_progress().is_bound();
 		c = c->get_coupling_convoi();
 	}
 	if ( coupling_cond ){
-		departure_cond = (  scheduled_departure_time!=0  &&  is_first_ticks_bigger(welt->get_ticks(), scheduled_departure_time + scheduled_coupling_delay_tolerance - time)  )  &&  !now_coupling_so_wait;
+		departure_cond = (  scheduled_departure_time!=0  &&  is_first_ticks_bigger(welt->get_ticks(), scheduled_departure_time + scheduled_coupling_delay_tolerance - time)  )  &&  !is_coupling_in_progress;
 	}
 	else{
-		departure_cond = (  scheduled_departure_time!=0  &&  is_first_ticks_bigger(welt->get_ticks(), scheduled_departure_time - time)  )  &&  !now_coupling_so_wait;
+		departure_cond = (  scheduled_departure_time!=0  &&  is_first_ticks_bigger(welt->get_ticks(), scheduled_departure_time - time)  )  &&  !is_coupling_in_progress;
 	}
 
 	// reverse convoi
@@ -5091,7 +5091,7 @@ bool convoi_t::couple_convoi(convoihandle_t coupled) {
 	coupling_convoi->front()->set_leading(false);
 	back()->set_last(false);
 	must_recalc_min_top_speed();
-	unset_will_coupling_convoi();
+	unset_convoi_coupling_in_progress();
 	return true;
 }
 
@@ -5395,25 +5395,24 @@ void convoi_t::next_stop_button_pressed() {
 	}
 }
 
-void convoi_t::set_will_coupling_convoi(convoihandle_t convoi_coupling_undergo) {
-	if( convoi_coupling_undergo.is_bound() ) {
-		will_coupling_convoi=convoi_coupling_undergo;
-		dbg->message( "convoi_t::set_will_coupling_convoi()","%i and %i convoys will be coupling soon", self.get_id(), will_coupling_convoi->self.get_id() );
+void convoi_t::set_convoi_coupling_in_progress(convoihandle_t convoi_coupling_undergo) {
+	if( !convoi_coupling_undergo.is_bound() ) {
+		dbg->warning( "convoi_t::set_convoi_coupling_in_progress()","%i cannot find the coupling convoi!", self.get_id());
 		return;
 	} else {
-		dbg->message( "convoi_t::set_will_coupling_convoi()","%i cannot find the coupling convoi!", self.get_id());
+		convoi_coupling_in_progress=convoi_coupling_undergo;
+		dbg->message( "convoi_t::set_convoi_coupling_in_progress()","%i and %i convoys will be coupling soon", self.get_id(), convoi_coupling_in_progress->self.get_id() );
 		return;
 	}
 }
 
-void convoi_t::unset_will_coupling_convoi() {
-	if (get_will_coupling_convoi().is_bound()) {
-		convoihandle_t c = get_will_coupling_convoi();
-		c->delete_will_coupling_convoi();
-		self->delete_will_coupling_convoi();
-		dbg->message( "convoi_t::unset_will_coupling_convoi()","%i and %i convoys are now coupling or canceling couple", self.get_id(), c->self.get_id() );
-		return;
-	} else {
+void convoi_t::unset_convoi_coupling_in_progress() {
+	if ( !get_convoi_coupling_in_progress().is_bound() ) {
 		return;
 	}
+	convoihandle_t c = get_convoi_coupling_in_progress();
+	c->delete_convoi_coupling_in_progress();
+	self->delete_convoi_coupling_in_progress();
+	dbg->message( "convoi_t::unset_convoi_coupling_in_progress()","%i and %i convoys are now coupling or canceling couple", self.get_id(), c->self.get_id() );
+	return;
 }

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -3426,11 +3426,8 @@ bool can_depart(convoihandle_t cnv, halthandle_t halt, uint32 arrived_time, uint
 		const schedule_entry_t e = c->get_schedule()->get_current_entry();
 		coupling_cond |= (e.get_coupling_point()==1  &&  !c->is_coupling_done()  &&  !(c->get_coupling_convoi().is_bound()  &&  c->is_coupled()));
 		if (  c->is_coupling_done()  ||  !c->get_convoi_coupling_in_progress().is_bound()  ||  c->get_convoi_coupling_in_progress()->get_convoi_coupling_in_progress()!=c  ) {
-			// This will_conpling_convoi() flag is too strong. 
-			// So if there are some happens such as
-			// coupling convoi is removed or
-			// forget to remove the flag after coupling done,
-			// this flag should be NONE! 
+			// The convoi_coupling_in_progress flag blocks the departure.
+			// Reset the flag if it is outdated to avoid blocking the departure forever.
 			c->unset_convoi_coupling_in_progress();
 		}
 		c = c->get_coupling_convoi();
@@ -5399,11 +5396,9 @@ void convoi_t::set_convoi_coupling_in_progress(convoihandle_t convoi_coupling_un
 	if( !convoi_coupling_undergo.is_bound() ) {
 		dbg->warning( "convoi_t::set_convoi_coupling_in_progress()","%i cannot find the coupling convoi!", self.get_id());
 		return;
-	} else {
-		convoi_coupling_in_progress=convoi_coupling_undergo;
-		dbg->message( "convoi_t::set_convoi_coupling_in_progress()","%i and %i convoys will be coupling soon", self.get_id(), convoi_coupling_in_progress->self.get_id() );
-		return;
 	}
+	convoi_coupling_in_progress=convoi_coupling_undergo;
+	dbg->message( "convoi_t::set_convoi_coupling_in_progress()","%i and %i convoys will be coupling soon", self.get_id(), convoi_coupling_in_progress->self.get_id() );
 }
 
 void convoi_t::unset_convoi_coupling_in_progress() {
@@ -5414,5 +5409,4 @@ void convoi_t::unset_convoi_coupling_in_progress() {
 	c->delete_convoi_coupling_in_progress();
 	self->delete_convoi_coupling_in_progress();
 	dbg->message( "convoi_t::unset_convoi_coupling_in_progress()","%i and %i convoys are now coupling or canceling couple", self.get_id(), c->self.get_id() );
-	return;
 }

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -1399,6 +1399,7 @@ void convoi_t::step()
 			break;
 
 		case EDIT_SCHEDULE:
+			unset_will_coupling_convoi();
 			// schedule window closed?
 			if(schedule!=NULL  &&  schedule->is_editing_finished()) {
 
@@ -1483,6 +1484,7 @@ void convoi_t::step()
 			break;
 
 		case NO_ROUTE:
+			unset_will_coupling_convoi();
 			// stuck vehicles
 			if (schedule->empty()) {
 				// no entries => no route ...
@@ -1549,6 +1551,7 @@ void convoi_t::step()
 
 		// must be here; may otherwise confuse window management
 		case SELF_DESTRUCT:
+			unset_will_coupling_convoi();
 			welt->set_dirty();
 			destroy();
 			return; // must not continue method after deleting this object
@@ -1901,7 +1904,7 @@ void convoi_t::ziel_erreicht()
 				}
 				// the direction of the waiting vehicle is same? opposite?
 				// reference direction to detect leading or following
-				ribi_t::ribi const const v_next_initial_direction = (  ( v->get_convoi()->get_next_initial_direction()  &  v->get_convoi()->front()->get_direction() ) > 0  ) ? v->get_direction(): ribi_t::backward(v->get_direction());
+				ribi_t::ribi const v_next_initial_direction = (  ( v->get_convoi()->get_next_initial_direction()  &  v->get_convoi()->front()->get_direction() ) > 0  ) ? v->get_direction(): ribi_t::backward(v->get_direction());
 				bool const should_this_convoy_be_parent = ( self->front()->get_direction() & v_next_initial_direction ) == 0 ;
 				// when the waiting couvoi is child of other convoi or the coupling convoi already has child convoi,
 				// to avoid duplication, the coupling convoi is set as a child of waiting convoi firstly.
@@ -3131,6 +3134,10 @@ void convoi_t::rdwr(loadsave_t *file)
 		file->rdwr_bool(is_reversing_needed);
 	}
 
+	if(  file->get_OTRP_version()>=44  ) {
+		rdwr_convoihandle_t( file, will_coupling_convoi );
+	}
+
 	if(  file->is_loading()  ) {
 		reserve_route();
 		recalc_catg_index();
@@ -3418,6 +3425,14 @@ bool can_depart(convoihandle_t cnv, halthandle_t halt, uint32 arrived_time, uint
 	while(  c.is_bound()  ) {
 		const schedule_entry_t e = c->get_schedule()->get_current_entry();
 		coupling_cond |= (e.get_coupling_point()==1  &&  !c->is_coupling_done()  &&  !(c->get_coupling_convoi().is_bound()  &&  c->is_coupled()));
+		if (  c->is_coupling_done()  ||  !c->get_will_coupling_convoi().is_bound()  ||  c->get_will_coupling_convoi()->get_will_coupling_convoi()!=c  ) {
+			// This will_conpling_convoi() flag is too strong. 
+			// So if there are some happens such as
+			// coupling convoi is removed or
+			// forget to remove the flag after coupling done,
+			// this flag should be NONE! 
+			c->unset_will_coupling_convoi();
+		}
 		c = c->get_coupling_convoi();
 	}
 
@@ -3778,11 +3793,17 @@ void convoi_t::hat_gehalten(halthandle_t halt, uint32 halt_length_in_vehicle_ste
 	bool departure_cond = false;
 	scheduled_coupling_delay_tolerance = (uint64)self->get_schedule()->get_current_entry().delay_tolerance * world()->ticks_per_world_month / world()->get_settings().get_spacing_shift_divisor();
 
+	c = self;
+	bool now_coupling_so_wait = false;
+	while (  c.is_bound()  ) {
+		now_coupling_so_wait |= c->get_will_coupling_convoi().is_bound();
+		c = c->get_coupling_convoi();
+	}
 	if ( coupling_cond ){
-		departure_cond = scheduled_departure_time!=0  &&  is_first_ticks_bigger(welt->get_ticks(), scheduled_departure_time + scheduled_coupling_delay_tolerance - time);
+		departure_cond = (  scheduled_departure_time!=0  &&  is_first_ticks_bigger(welt->get_ticks(), scheduled_departure_time + scheduled_coupling_delay_tolerance - time)  )  &&  !now_coupling_so_wait;
 	}
 	else{
-		departure_cond = scheduled_departure_time!=0  &&  is_first_ticks_bigger(welt->get_ticks(), scheduled_departure_time - time);
+		departure_cond = (  scheduled_departure_time!=0  &&  is_first_ticks_bigger(welt->get_ticks(), scheduled_departure_time - time)  )  &&  !now_coupling_so_wait;
 	}
 
 	// reverse convoi
@@ -5070,6 +5091,7 @@ bool convoi_t::couple_convoi(convoihandle_t coupled) {
 	coupling_convoi->front()->set_leading(false);
 	back()->set_last(false);
 	must_recalc_min_top_speed();
+	unset_will_coupling_convoi();
 	return true;
 }
 
@@ -5373,3 +5395,25 @@ void convoi_t::next_stop_button_pressed() {
 	}
 }
 
+void convoi_t::set_will_coupling_convoi(convoihandle_t convoi_coupling_undergo) {
+	if( convoi_coupling_undergo.is_bound() ) {
+		will_coupling_convoi=convoi_coupling_undergo;
+		dbg->message( "convoi_t::set_will_coupling_convoi()","%i and %i convoys will be coupling soon", self.get_id(), will_coupling_convoi->self.get_id() );
+		return;
+	} else {
+		dbg->message( "convoi_t::set_will_coupling_convoi()","%i cannot find the coupling convoi!", self.get_id());
+		return;
+	}
+}
+
+void convoi_t::unset_will_coupling_convoi() {
+	if (get_will_coupling_convoi().is_bound()) {
+		convoihandle_t c = get_will_coupling_convoi();
+		c->delete_will_coupling_convoi();
+		self->delete_will_coupling_convoi();
+		dbg->message( "convoi_t::unset_will_coupling_convoi()","%i and %i convoys are now coupling or canceling couple", self.get_id(), c->self.get_id() );
+		return;
+	} else {
+		return;
+	}
+}

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -232,11 +232,11 @@ private:
 	/**
 	* a convoy that is coupling now.
 	*/
-	convoihandle_t will_coupling_convoi;
+	convoihandle_t convoi_coupling_in_progress;
 	/**
 	* delete currently coupling convoi information
 	*/
-	void delete_will_coupling_convoi() {will_coupling_convoi=convoihandle_t();}
+	void delete_convoi_coupling_in_progress() {convoi_coupling_in_progress=convoihandle_t();}
 
 	/**
 	* Current map
@@ -1026,9 +1026,9 @@ public:
 
 	bool is_coupled() const { return state==COUPLED  ||  state==COUPLED_LOADING; }
 	bool is_waiting_for_coupling() const;
-	void set_will_coupling_convoi(convoihandle_t convoi_coupling_undergo);
-	convoihandle_t get_will_coupling_convoi() const { return will_coupling_convoi; }
-	void unset_will_coupling_convoi();
+	void set_convoi_coupling_in_progress(convoihandle_t);
+	convoihandle_t get_convoi_coupling_in_progress() const { return convoi_coupling_in_progress; }
+	void unset_convoi_coupling_in_progress();
 
 	bool can_continue_coupling() const;
 	bool can_start_coupling(convoi_t* parent) const;

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -230,6 +230,15 @@ private:
 	convoihandle_t coupling_convoi;
 
 	/**
+	* a convoy that is coupling now.
+	*/
+	convoihandle_t will_coupling_convoi;
+	/**
+	* delete currently coupling convoi information
+	*/
+	void delete_will_coupling_convoi() {will_coupling_convoi=convoihandle_t();}
+
+	/**
 	* Current map
 	*/
 	static karte_ptr_t welt;
@@ -1017,6 +1026,9 @@ public:
 
 	bool is_coupled() const { return state==COUPLED  ||  state==COUPLED_LOADING; }
 	bool is_waiting_for_coupling() const;
+	void set_will_coupling_convoi(convoihandle_t convoi_coupling_undergo);
+	convoihandle_t get_will_coupling_convoi() const { return will_coupling_convoi; }
+	void unset_will_coupling_convoi();
 
 	bool can_continue_coupling() const;
 	bool can_start_coupling(convoi_t* parent) const;

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -4207,8 +4207,8 @@ bool rail_vehicle_t::can_couple(const route_t* route, uint16 start_index, uint16
 						// direction is bad to couple.
 						continue;
 					}
-					// the waiting convoi is currently coupling
-					if(  v->get_convoi()->get_convoi_coupling_in_progress().is_bound()  &&  v->get_convoi()->get_convoi_coupling_in_progress() != cnv->self  ) {
+					// The waiting convoi is currently coupling with another convoy.
+					if(  v->get_convoi()->get_convoi_coupling_in_progress() != cnv->self  ) {
 						continue;
 					}
 					// set convoi as coupling now!

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -4170,10 +4170,12 @@ bool rail_vehicle_t::can_couple(const route_t* route, uint16 start_index, uint16
 	} while(  idx!=cnv->get_schedule()->get_current_stop()  );
 	if(  !stop_found  ||  cnv->get_schedule()->entries[idx].get_coupling_point()!=2  ) {
 		// all schedule entries are waypoint or the next stop point is not a coupling point.
+		cnv->unset_will_coupling_convoi();
 		return false;
 	}
 	// start_index can be invalid.
 	if(start_index>=route->get_count()) {
+		cnv->unset_will_coupling_convoi();
 		return false;
 	}
 
@@ -4184,6 +4186,7 @@ bool rail_vehicle_t::can_couple(const route_t* route, uint16 start_index, uint16
 		grund_t *gr = welt->lookup(route->at(i));
 		if(  !gr  ) {
 			// ground does not exist!?
+			cnv->unset_will_coupling_convoi();
 			return false;
 		}
 		const ribi_t::ribi dir = i==start_index ? ribi_t::none : ribi_type(route->at(i-1), route->at(i));
@@ -4204,6 +4207,13 @@ bool rail_vehicle_t::can_couple(const route_t* route, uint16 start_index, uint16
 						// direction is bad to couple.
 						continue;
 					}
+					// the waiting convoi is currently coupling
+					if(  v->get_convoi()->get_will_coupling_convoi().is_bound()  &&  v->get_convoi()->get_will_coupling_convoi() != cnv->self  ) {
+						continue;
+					}
+					// set convoi as coupling now!
+					v->get_convoi()->self->set_will_coupling_convoi(cnv->self);
+					cnv->set_will_coupling_convoi(v->get_convoi()->self);
 					//reserve tiles
 					for(  uint16 h=start_index;  h<i;  h++  ) {
 						grund_t* grn = welt->lookup(route->at(h));
@@ -4231,6 +4241,7 @@ bool rail_vehicle_t::can_couple(const route_t* route, uint16 start_index, uint16
 		schiene_t * sch = gr ? (schiene_t *)gr->get_weg(get_waytype()) : NULL;
 		if(  !sch  ||  (!ignore_signals  &&  sch->has_signal())  ||  !sch->can_reserve(cnv->self)  ) {
 			// end of truck or section. or unreachable for some reasons. anyway, convoy for coupling is not found.
+			cnv->unset_will_coupling_convoi();
 			return false;
 		}
 	}

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -4170,12 +4170,12 @@ bool rail_vehicle_t::can_couple(const route_t* route, uint16 start_index, uint16
 	} while(  idx!=cnv->get_schedule()->get_current_stop()  );
 	if(  !stop_found  ||  cnv->get_schedule()->entries[idx].get_coupling_point()!=2  ) {
 		// all schedule entries are waypoint or the next stop point is not a coupling point.
-		cnv->unset_will_coupling_convoi();
+		cnv->unset_convoi_coupling_in_progress();
 		return false;
 	}
 	// start_index can be invalid.
 	if(start_index>=route->get_count()) {
-		cnv->unset_will_coupling_convoi();
+		cnv->unset_convoi_coupling_in_progress();
 		return false;
 	}
 
@@ -4186,7 +4186,7 @@ bool rail_vehicle_t::can_couple(const route_t* route, uint16 start_index, uint16
 		grund_t *gr = welt->lookup(route->at(i));
 		if(  !gr  ) {
 			// ground does not exist!?
-			cnv->unset_will_coupling_convoi();
+			cnv->unset_convoi_coupling_in_progress();
 			return false;
 		}
 		const ribi_t::ribi dir = i==start_index ? ribi_t::none : ribi_type(route->at(i-1), route->at(i));
@@ -4208,12 +4208,12 @@ bool rail_vehicle_t::can_couple(const route_t* route, uint16 start_index, uint16
 						continue;
 					}
 					// the waiting convoi is currently coupling
-					if(  v->get_convoi()->get_will_coupling_convoi().is_bound()  &&  v->get_convoi()->get_will_coupling_convoi() != cnv->self  ) {
+					if(  v->get_convoi()->get_convoi_coupling_in_progress().is_bound()  &&  v->get_convoi()->get_convoi_coupling_in_progress() != cnv->self  ) {
 						continue;
 					}
 					// set convoi as coupling now!
-					v->get_convoi()->self->set_will_coupling_convoi(cnv->self);
-					cnv->set_will_coupling_convoi(v->get_convoi()->self);
+					v->get_convoi()->self->set_convoi_coupling_in_progress(cnv->self);
+					cnv->set_convoi_coupling_in_progress(v->get_convoi()->self);
 					//reserve tiles
 					for(  uint16 h=start_index;  h<i;  h++  ) {
 						grund_t* grn = welt->lookup(route->at(h));
@@ -4241,7 +4241,7 @@ bool rail_vehicle_t::can_couple(const route_t* route, uint16 start_index, uint16
 		schiene_t * sch = gr ? (schiene_t *)gr->get_weg(get_waytype()) : NULL;
 		if(  !sch  ||  (!ignore_signals  &&  sch->has_signal())  ||  !sch->can_reserve(cnv->self)  ) {
 			// end of truck or section. or unreachable for some reasons. anyway, convoy for coupling is not found.
-			cnv->unset_will_coupling_convoi();
+			cnv->unset_convoi_coupling_in_progress();
 			return false;
 		}
 	}


### PR DESCRIPTION
連結作業中の編成を記録します。

〇記録方法
・連結中の編成と、連結待ち編成の両方にお互いの編成番号を記録します
　　もし、連結相手が存在しない/連結相手の保存している編成が自分自身ではない場合、このフラグは即座にfalseになります。

〇利用方法
・連結作業中の場合、発車時刻が来ても発車しません(連結作業完了後に発車します)。
・連結作業中の編成がいる場合、他の編成は連結しようとしません(スケジュール変更や編成除去などによって連結をあきらめた場合、他の編成は連結を開始します)。