### PR TITLE
BUG FIX: FIX BUGS WHEN MANY CONVOYS COUPLING

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -5115,7 +5115,7 @@ bool convoi_t::couple_convoi(convoihandle_t coupled) {
 	convoihandle_t c = coupled;
 	while( c.is_bound() ) {
 		c->set_state(COUPLED_LOADING);
-		c = coupled->get_coupling_convoi();
+		c = c->get_coupling_convoi();
 	}
 	if(  !is_coupled()  ) {
 		set_state(LOADING);
@@ -5136,8 +5136,9 @@ convoihandle_t convoi_t::uncouple_convoi() {
 	coupling_convoi->set_state(is_loading() ? LOADING : ROUTING_1);
 	coupling_convoi->front()->set_leading(true);
 	back()->set_last(true);
-	must_recalc_min_top_speed();
-	must_recalc_friction_weight();
+	find_most_parent_convoi()->must_recalc_min_top_speed();
+	find_most_parent_convoi()->check_electrification();
+	find_most_parent_convoi()->must_recalc_friction_weight();
 	// for child convoy, recalculate is_electric and min_top_speed immediately.
 	coupling_convoi->check_electrification();
 	coupling_convoi->must_recalc_friction_weight();


### PR DESCRIPTION
複数連結を連結した編成に関する連結/解放プロセスのバグを修復しました
・convoi_t::couple_convoi()で、連結編成が複数編成連結済みのときに無限ループに入るバグを修正
・convoi_t::uncouple_convoi()で、親編成が複数編成連結済みのとき、電化設定が解放後の情報にアップデートされないバグを修正