### PR TITLE
BUG FIX: all_links updated before calling rebuild_linked_connections()

### DIFF
--- a/simhalt.cc
+++ b/simhalt.cc
@@ -1288,7 +1288,6 @@ sint32 haltestelle_t::rebuild_connections()
 	// HACK: When unload_all, no_load or no_unload is applied, is_transfer is true regardless of connections.
 	bool force_transfer_search = false;
 	while(  lines  ||  current_index < registered_convoys.get_count()  ) {
-
 		// Now, collect the "schedule", "owner" and "add_catg_index" from line resp. convoy.
 		if(  lines  ) {
 			if(  current_index >= registered_lines.get_count()  ) {
@@ -2753,6 +2752,11 @@ void haltestelle_t::change_owner( player_t *player, bool halt_only )
 	player_t* const prev_owner = owner;
 	owner = player;
 	rebuild_connections();
+	if ( staged_all_links ) {
+		delete[] all_links;
+		all_links = staged_all_links;
+		staged_all_links = NULL;
+	}
 	rebuild_linked_connections();
 	rebuild_connected_components();
 
@@ -2884,6 +2888,11 @@ void haltestelle_t::merge_halt( halthandle_t halt_merged )
 	// also rebuild our connections
 	recalc_station_type();
 	rebuild_connections();
+	if ( staged_all_links ) {
+		delete[] all_links;
+		all_links = staged_all_links;
+		staged_all_links = NULL;
+	}
 	rebuild_linked_connections();
 	rebuild_connected_components();
 }

--- a/simhalt.cc
+++ b/simhalt.cc
@@ -2754,7 +2754,7 @@ void haltestelle_t::change_owner( player_t *player, bool halt_only )
 	player_t* const prev_owner = owner;
 	owner = player;
 	rebuild_connections();
-	_connections();
+	rebuild_linked_connections();
 	rebuild_connected_components();
 
 	// tell the world of it ...
@@ -2885,7 +2885,7 @@ void haltestelle_t::merge_halt( halthandle_t halt_merged )
 	// also rebuild our connections
 	recalc_station_type();
 	rebuild_connections();
-	_connections();
+	rebuild_linked_connections();
 	rebuild_connected_components();
 }
 // [mod : shingoushori] mod : changes this to a private transfer exchange stop 3/3

--- a/simhalt.cc
+++ b/simhalt.cc
@@ -1453,6 +1453,7 @@ void haltestelle_t::rebuild_linked_connections()
 {
 	vector_tpl<halthandle_t> all; // all halts connected to this halt
 	for(  uint8 i=0;  i<goods_manager_t::get_max_catg_index();  i++  ){
+		// TODO: consider using staged_all_links, since this function is called after rebuild_connections() stores the connections to it.
 		vector_tpl<connection_t>& connections = all_links[i].connections;
 
 		FOR(vector_tpl<connection_t>, &c, connections) {

--- a/simhalt.cc
+++ b/simhalt.cc
@@ -1460,7 +1460,9 @@ void haltestelle_t::rebuild_linked_connections()
 		}
 	}
 	FOR(vector_tpl<halthandle_t>, h, all) {
-		h->rebuild_connections();
+		if(h.is_bound()) {
+			h->rebuild_connections();
+		}
 	}
 }
 
@@ -2752,12 +2754,7 @@ void haltestelle_t::change_owner( player_t *player, bool halt_only )
 	player_t* const prev_owner = owner;
 	owner = player;
 	rebuild_connections();
-	if ( staged_all_links ) {
-		delete[] all_links;
-		all_links = staged_all_links;
-		staged_all_links = NULL;
-	}
-	rebuild_linked_connections();
+	_connections();
 	rebuild_connected_components();
 
 	// tell the world of it ...
@@ -2888,12 +2885,7 @@ void haltestelle_t::merge_halt( halthandle_t halt_merged )
 	// also rebuild our connections
 	recalc_station_type();
 	rebuild_connections();
-	if ( staged_all_links ) {
-		delete[] all_links;
-		all_links = staged_all_links;
-		staged_all_links = NULL;
-	}
-	rebuild_linked_connections();
+	_connections();
 	rebuild_connected_components();
 }
 // [mod : shingoushori] mod : changes this to a private transfer exchange stop 3/3


### PR DESCRIPTION
haltestelle_t::rebuild_linked_connections()が呼ばれる直前にhaltestelle_t link_t::staged_all_links のみが修正され haltestelle_t link_t::all_links が上書きされていなかったため、ある路線上の2駅を公共化等により統合した際にクラッシュしていました。
当該箇所(2か所)を修正しました。