### PR TITLE
BUG FIX: update tool after any action in schedule_gui_t

### DIFF
--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -811,7 +811,7 @@ bool schedule_gui_t::action_triggered( gui_action_creator_t *comp, value_t p)
 {
 DBG_MESSAGE("schedule_gui_t::action_triggered()","comp=%p combo=%p",comp,&line_selector);
 	// for updating tool after any action happened
-	bool is_updating_tool = true;
+	bool should_set_schedule_tool = true;
 	if(comp == &bt_add) {
 		mode = adding;
 		bt_add.pressed = true;
@@ -829,7 +829,7 @@ DBG_MESSAGE("schedule_gui_t::action_triggered()","comp=%p combo=%p",comp,&line_s
 		bt_add.pressed = false;
 		bt_insert.pressed = false;
 		bt_remove.pressed = true;
-		is_updating_tool = false;
+		should_set_schedule_tool = false;
 	}
 	else if(comp == &bt_find_parent) {
 		if(!schedule->empty()) {
@@ -1076,7 +1076,7 @@ DBG_MESSAGE("schedule_gui_t::action_triggered()","comp=%p combo=%p",comp,&line_s
 			init_line_selector();
 		}
 	}
-	update_tool( is_updating_tool );
+	update_tool( should_set_schedule_tool );
 	return true;
 }
 

--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -810,27 +810,26 @@ bool schedule_gui_t::infowin_event(const event_t *ev)
 bool schedule_gui_t::action_triggered( gui_action_creator_t *comp, value_t p)
 {
 DBG_MESSAGE("schedule_gui_t::action_triggered()","comp=%p combo=%p",comp,&line_selector);
-
+	// for updating tool after any action happened
+	bool is_updating_tool = true;
 	if(comp == &bt_add) {
 		mode = adding;
 		bt_add.pressed = true;
 		bt_insert.pressed = false;
 		bt_remove.pressed = false;
-		update_tool( true );
 	}
 	else if(comp == &bt_insert) {
 		mode = inserting;
 		bt_add.pressed = false;
 		bt_insert.pressed = true;
 		bt_remove.pressed = false;
-		update_tool( true );
 	}
 	else if(comp == &bt_remove) {
 		mode = removing;
 		bt_add.pressed = false;
 		bt_insert.pressed = false;
 		bt_remove.pressed = true;
-		update_tool( false );
+		is_updating_tool = false;
 	}
 	else if(comp == &bt_find_parent) {
 		if(!schedule->empty()) {
@@ -1077,6 +1076,7 @@ DBG_MESSAGE("schedule_gui_t::action_triggered()","comp=%p combo=%p",comp,&line_s
 			init_line_selector();
 		}
 	}
+	update_tool( is_updating_tool );
 	return true;
 }
 


### PR DESCRIPTION
任意の```schedule_gui_t::action_triggered()```が発動した場合に、```schedule_gui_t::update_tool()```を呼び出しtoolをアップデートします。
これにより、一部のスケジュールウィンドウ由来のクラッシュ要因を解消できます。