### PR TITLE
using schedule->advance() in convoi_t::next_stop_button_pressed()

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -5505,11 +5505,7 @@ void convoi_t::next_stop_button_pressed() {
 		if( !c->can_continue_coupling() ) {
 			c->uncouple_convoi();
 		}
-		if( schedule->get_current_stop() == schedule->entries.get_count() - 1 ) {
-			schedule->set_current_stop( 0 );
-		} else {
-			schedule->set_current_stop( schedule->get_current_stop() + 1 ); 
-		}
+		schedule->advance();
 		// c->set_schedule() is change convoy status to "EDIT_SCHEDULE".
 		// So, if the convoy is leading, it can recalculate the schedule by calling this function.
 		// However, if the convoy is coupled convoy, calling c->set_schedule() destroy coupling information.


### PR DESCRIPTION
```convoi_t::next_stop_button_pressed()```において、スケジュールを進める処理の際に```schedule->advance()```を用いるよう変更しました