### PR TITLE
Do not remove entries in schedule_gui when MOUSE_WHEELUP or DOWN

### DIFF
--- a/gui/convoi_stops_list_t.cc
+++ b/gui/convoi_stops_list_t.cc
@@ -93,6 +93,9 @@ public:
 			// move to the entry tile.
 			view_stop();
 		}
+		else if( ev->ev_code == MOUSE_WHEELUP || ev->ev_code == MOUSE_WHEELDOWN ) {
+			return false;
+		} 
 		else {
 			halthandle_t h = haltestelle_t::get_stoppable_halt( entry.pos,player );
 			if (  h.is_bound()  ) {

--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -96,7 +96,9 @@ public:
 			if(  IS_RIGHTCLICK(ev)  ||  ev->mx < stop.get_pos().x) {
 				// just center on it
 				welt->get_viewport()->change_world_position( entry.pos );
-			}
+			} else if( ev->ev_code == MOUSE_WHEELUP || ev->ev_code == MOUSE_WHEELDOWN ) {
+				return false;
+			} 
 			else {
 				call_listeners(number);
 			}


### PR DESCRIPTION
schedule_guiにおいて、```mode==remove```のときにマウスホーイルの動作によって```entry```が削除されないようにします。また、convoi_stops_listにおいても、マウスホイールがクリック扱いとならず駅一覧のスクロールを行うようにします。