### PR TITLE
Hide schedule_t::entries from public

### DIFF
--- a/dataobj/schedule.cc
+++ b/dataobj/schedule.cc
@@ -372,7 +372,7 @@ bool schedule_t::matches(karte_t *welt, const schedule_t *schedule)
 	// we need to do this that complicated, because the last stop may make the difference
 	uint16 f1=0, f2=0;
 	while(  f1+f2<entries.get_count()+schedule->entries.get_count()  ) {
-		if(f1<entries.get_count()  &&  f2<schedule->entries.get_count()  &&  schedule->entries[(uint8)f2].pos == entries[(uint8)f1].pos
+		if(f1<entries.get_count()  &&  f2<schedule->entries.get_count()  &&  schedule->at((uint8)f2).pos == entries[(uint8)f1].pos
 		&&  schedule->entries[(uint8)f2].minimum_loading == entries[(uint8)f1].minimum_loading
 		&&  schedule->entries[(uint8)f2].waiting_time_shift == entries[(uint8)f1].waiting_time_shift
 	    &&  schedule->entries[(uint8)f2].get_stop_flags() == entries[(uint8)f1].get_stop_flags()

--- a/dataobj/schedule.h
+++ b/dataobj/schedule.h
@@ -43,6 +43,8 @@ class schedule_t
 
 	static schedule_entry_t dummy_entry;
 
+	minivec_tpl<schedule_entry_t> entries;
+
 	/**
 	 * Fix up current_stop value, which we may have made out of range
 	 */
@@ -80,8 +82,6 @@ public:
 		FULL_LOAD_TIME         = 1U << 3,
 	};
 
-	minivec_tpl<schedule_entry_t> entries;
-
 	/**
 	 * Returns error message if stops are not allowed
 	 */
@@ -96,6 +96,15 @@ public:
 	bool empty() const { return entries.empty(); }
 
 	uint8 get_count() const { return entries.get_count(); }
+
+	schedule_entry_t& at(uint8 index) { return entries[index]; }
+
+	const schedule_entry_t& at(uint8 index) const { return entries[index]; }
+
+	const schedule_entry_t* begin() const { return entries.begin(); }
+	const schedule_entry_t* end() const { return entries.end(); }
+	schedule_entry_t* begin() { return entries.begin(); }
+	schedule_entry_t* end() { return entries.end(); }
 
 	virtual schedule_type get_type() const = 0;
 
@@ -185,6 +194,11 @@ public:
 	 * Remove current_stop entry from the schedule.
 	 */
 	bool remove();
+
+	/**
+	 * Remove all entries from the schedule.
+	 */
+	void remove_all() { entries.clear(); }
 
 	void rdwr(loadsave_t *file);
 

--- a/dataobj/schedule.h
+++ b/dataobj/schedule.h
@@ -97,12 +97,10 @@ public:
 
 	uint8 get_count() const { return entries.get_count(); }
 
+	const minivec_tpl<schedule_entry_t> &get_entries() const { return entries; }
 	schedule_entry_t& at(uint8 index) { return entries[index]; }
-
 	const schedule_entry_t& at(uint8 index) const { return entries[index]; }
 
-	const schedule_entry_t* begin() const { return entries.begin(); }
-	const schedule_entry_t* end() const { return entries.end(); }
 	schedule_entry_t* begin() { return entries.begin(); }
 	schedule_entry_t* end() { return entries.end(); }
 

--- a/gui/convoi_stops_list_t.cc
+++ b/gui/convoi_stops_list_t.cc
@@ -140,8 +140,8 @@ void convoi_stops_list_t::update_schedule()
 		new_component<gui_textarea_t>(&buf);
 	}
 	else {
-		for(uint i=0; i<gui_schedule->entries.get_count(); i++) {
-			entries.append( new_component<convoi_stops_list_item_t>(player, gui_schedule->entries[i], i));
+		for(uint i=0; i<gui_schedule->get_count(); i++) {
+			entries.append( new_component<convoi_stops_list_item_t>(player, gui_schedule->at(i), i));
 			entries.back()->add_listener( this );
 		}
 		entries[ gui_schedule->get_current_stop() ]->set_active(true);

--- a/gui/depot_frame.cc
+++ b/gui/depot_frame.cc
@@ -1699,7 +1699,7 @@ void depot_frame_t::apply_line()
 			// sometimes the user might wish to remove convoy from line
 			// => we clear the schedule completely
 			schedule_t *dummy = cnv->create_schedule()->copy();
-			dummy->entries.clear();
+			dummy->remove_all();
 
 			cbuffer_t buf;
 			dummy->sprintf_schedule(buf);

--- a/gui/goods_waiting_time.cc
+++ b/gui/goods_waiting_time.cc
@@ -42,8 +42,8 @@ void gui_goods_waiting_time_stat_t::update()
     const scr_size size = get_size();
     remove_all();
     set_table_layout(NUM_WAITING_TIME_STORED+2,0);
-    for(uint8 index = 0; index < schedule->entries.get_count(); index++) {
-        const schedule_entry_t& entry = schedule->entries[index];
+    for(uint8 index = 0; index < schedule->get_count(); index++) {
+        const schedule_entry_t& entry = schedule->at(index);
         const halthandle_t halt = haltestelle_t::get_stoppable_halt(entry.pos, player);
         gui_label_buf_t *title_lb = new_component<gui_label_buf_t>(SYSCOL_TEXT, gui_label_t::left);
         if(  halt.is_bound()  ) {

--- a/gui/journey_time_info.cc
+++ b/gui/journey_time_info.cc
@@ -25,9 +25,9 @@ void gui_journey_time_stat_t::update(linehandle_t line, vector_tpl<uint32*>& jou
   uint32 journey_time_sum = 0;
   set_table_layout(NUM_ARRIVAL_TIME_STORED+2,0);
   uint8 depot_entry_count = 0;
-  for(uint8 idx=0; idx<schedule->entries.get_count(); idx++) {
-    const schedule_entry_t& e = schedule->entries[idx];
-    const uint8 prev_idx = idx > 0 ? idx - 1 : schedule->entries.get_count() - 1;
+  for(uint8 idx=0; idx<schedule->get_count(); idx++) {
+    const schedule_entry_t& e = schedule->at(idx);
+    const uint8 prev_idx = idx > 0 ? idx - 1 : schedule->get_count() - 1;
 
     // journey time between the previous halt
     gui_label_buf_t *lb = new_component<gui_label_buf_t>(SYSCOL_TEXT, gui_label_t::left); // empty
@@ -101,8 +101,9 @@ void gui_journey_time_stat_t::update(linehandle_t line, vector_tpl<uint32*>& jou
 
 void copy_stations_to_clipboard(schedule_t* schedule, player_t* player, bool name_only) {
   cbuffer_t clipboard;
-  FOR(minivec_tpl<schedule_entry_t>, const& e, schedule->entries) {
-    halthandle_t const halt = haltestelle_t::get_stoppable_halt(e.pos, player);
+  for (const schedule_entry_t *e = schedule->begin(); e != schedule->end(); e++)
+  {
+    halthandle_t const halt = haltestelle_t::get_stoppable_halt(e->pos, player);
     if(  !halt.is_bound()  ) {
       // do not export waypoint
       continue;
@@ -110,7 +111,7 @@ void copy_stations_to_clipboard(schedule_t* schedule, player_t* player, bool nam
     clipboard.append(halt->get_name());
     if(  !name_only  ) {
       clipboard.append(",");
-      clipboard.append(e.pos.get_str());
+      clipboard.append(e->pos.get_str());
     }
     clipboard.append("\n");
   }
@@ -127,8 +128,8 @@ void copy_csv_format(schedule_t* schedule, player_t* player, vector_tpl<uint32*>
   // copy in csv format. separator is \t.
   cbuffer_t clipboard;
   clipboard.append("Station Name\tAverage\t1st\t2nd\t3rd\t4th\t5th\n");
-  for(uint8 i=0; i<schedule->entries.get_count(); i++) {
-    halthandle_t const halt = haltestelle_t::get_stoppable_halt(schedule->entries[i].pos, player);
+  for(uint8 i=0; i<schedule->get_count(); i++) {
+    halthandle_t const halt = haltestelle_t::get_stoppable_halt(schedule->at(i).pos, player);
     if(  halt.is_bound()  ) {
       clipboard.append(halt->get_name());
     } else {
@@ -235,21 +236,21 @@ gui_journey_time_info_t::~gui_journey_time_info_t() {
 
 void gui_journey_time_info_t::update() {
   // append journey_times entries if required.
-  for(uint8 i=journey_times.get_count(); i<schedule->entries.get_count(); i++) {
+  for(uint8 i=journey_times.get_count(); i<schedule->get_count(); i++) {
     journey_times.append(new uint32[NUM_ARRIVAL_TIME_STORED+1]);
   }
-  for(uint8 i=stopping_times.get_count(); i<schedule->entries.get_count(); i++) {
+  for(uint8 i=stopping_times.get_count(); i<schedule->get_count(); i++) {
     stopping_times.append(new uint32[NUM_STOPPING_TIME_STORED+1]);
   }
   
   // calculate journey time and average time
   journey_time_sum = 0;
-  for(uint8 i=0; i<schedule->entries.get_count(); i++) {
+  for(uint8 i=0; i<schedule->get_count(); i++) {
     uint32 sum = 0;
     uint8 cnt = 0;
-    const uint8 kc = (schedule->entries[i].jt_at_index + NUM_ARRIVAL_TIME_STORED - 1) % NUM_ARRIVAL_TIME_STORED;
+    const uint8 kc = (schedule->at(i).jt_at_index + NUM_ARRIVAL_TIME_STORED - 1) % NUM_ARRIVAL_TIME_STORED;
     for(uint8 k=0; k<NUM_ARRIVAL_TIME_STORED; k++) {
-      uint32* ca = schedule->entries[i].journey_time;
+      uint32* ca = schedule->at(i).journey_time;
       uint8 ica = (kc + NUM_ARRIVAL_TIME_STORED - k) % NUM_ARRIVAL_TIME_STORED;
       if(  ca[ica]>0  ) {
         journey_times[i][k+1] = world()->tick_to_divided_time(ca[ica]);
@@ -269,12 +270,12 @@ void gui_journey_time_info_t::update() {
   }
 
   // calculate stopping time
-  for(uint8 i=0; i<schedule->entries.get_count(); i++) {
+  for(uint8 i=0; i<schedule->get_count(); i++) {
     uint32 sum = 0;
     uint8 cnt = 0;
-    const uint8 kc = (schedule->entries[i].cs_at_index + NUM_STOPPING_TIME_STORED - 1) % NUM_STOPPING_TIME_STORED;
+    const uint8 kc = (schedule->at(i).cs_at_index + NUM_STOPPING_TIME_STORED - 1) % NUM_STOPPING_TIME_STORED;
     for(uint8 k=0; k<NUM_STOPPING_TIME_STORED; k++) {
-      uint32* ca = schedule->entries[i].convoy_stopping_time;
+      uint32* ca = schedule->at(i).convoy_stopping_time;
       uint8 ica = (kc + NUM_STOPPING_TIME_STORED - k) % NUM_STOPPING_TIME_STORED;
       if(  ca[ica]>0  ) {
         stopping_times[i][k+1] = world()->tick_to_divided_time(ca[ica]);
@@ -288,9 +289,9 @@ void gui_journey_time_info_t::update() {
   }
   
   // disable copy buttons if schedule is empty
-  bt_copy_names.enable(!schedule->entries.empty());
-  bt_copy_stations.enable(!schedule->entries.empty());
-  bt_copy_csv.enable(!schedule->entries.empty());
+  bt_copy_names.enable(!schedule->empty());
+  bt_copy_stations.enable(!schedule->empty());
+  bt_copy_csv.enable(!schedule->empty());
   
   // update stat
   bool empty_slot_exists = false;

--- a/gui/journey_time_info.cc
+++ b/gui/journey_time_info.cc
@@ -101,9 +101,8 @@ void gui_journey_time_stat_t::update(linehandle_t line, vector_tpl<uint32*>& jou
 
 void copy_stations_to_clipboard(schedule_t* schedule, player_t* player, bool name_only) {
   cbuffer_t clipboard;
-  for (const schedule_entry_t *e = schedule->begin(); e != schedule->end(); e++)
-  {
-    halthandle_t const halt = haltestelle_t::get_stoppable_halt(e->pos, player);
+  FOR(minivec_tpl<schedule_entry_t>, const& e, schedule->get_entries()) {
+    halthandle_t const halt = haltestelle_t::get_stoppable_halt(e.pos, player);
     if(  !halt.is_bound()  ) {
       // do not export waypoint
       continue;
@@ -111,7 +110,7 @@ void copy_stations_to_clipboard(schedule_t* schedule, player_t* player, bool nam
     clipboard.append(halt->get_name());
     if(  !name_only  ) {
       clipboard.append(",");
-      clipboard.append(e->pos.get_str());
+      clipboard.append(e.pos.get_str());
     }
     clipboard.append("\n");
   }

--- a/gui/minimap.cc
+++ b/gui/minimap.cc
@@ -231,18 +231,18 @@ void minimap_t::add_to_schedule_cache( convoihandle_t cnv, bool with_waypoints )
 	bool last_diagonal = false;
 	const bool add_schedule = schedule->get_waytype() != air_wt;
 
-	for (const schedule_entry_t *cur = schedule->begin();  cur != schedule->end();  ++cur) {
+	FOR(  minivec_tpl<schedule_entry_t>, cur, schedule->get_entries()  ){
 
 		//cycle on stops
 		//try to read station's coordinates if there's a station at this schedule stop
-		halthandle_t station = haltestelle_t::get_stoppable_halt( cur->pos, cnv->get_owner() );
+		halthandle_t station = haltestelle_t::get_stoppable_halt( cur.pos, cnv->get_owner() );
 		if(  station.is_bound()  ) {
 			stop_cache.append_unique( station );
 			temp_stop = station->get_basis_pos();
 			stops ++;
 		}
 		else if(  with_waypoints  ) {
-			temp_stop = cur->pos.get_2d();
+			temp_stop = cur.pos.get_2d();
 			stops ++;
 		}
 		else {

--- a/gui/minimap.cc
+++ b/gui/minimap.cc
@@ -231,18 +231,18 @@ void minimap_t::add_to_schedule_cache( convoihandle_t cnv, bool with_waypoints )
 	bool last_diagonal = false;
 	const bool add_schedule = schedule->get_waytype() != air_wt;
 
-	FOR(  minivec_tpl<schedule_entry_t>, cur, schedule->entries  ) {
+	for (const schedule_entry_t *cur = schedule->begin();  cur != schedule->end();  ++cur) {
 
 		//cycle on stops
 		//try to read station's coordinates if there's a station at this schedule stop
-		halthandle_t station = haltestelle_t::get_stoppable_halt( cur.pos, cnv->get_owner() );
+		halthandle_t station = haltestelle_t::get_stoppable_halt( cur->pos, cnv->get_owner() );
 		if(  station.is_bound()  ) {
 			stop_cache.append_unique( station );
 			temp_stop = station->get_basis_pos();
 			stops ++;
 		}
 		else if(  with_waypoints  ) {
-			temp_stop = cur.pos.get_2d();
+			temp_stop = cur->pos.get_2d();
 			stops ++;
 		}
 		else {

--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -131,8 +131,8 @@ schedule_gui_stats_t::~schedule_gui_stats_t()
 void schedule_gui_stats_t::highlight_schedule(bool marking)
 {
 	marking &= env_t::visualize_schedule;
-	for(const schedule_entry_t* i = schedule->begin(); i != schedule->end(); ++i) {
-		if (grund_t* const gr = welt->lookup(i->pos)) {
+	FOR(minivec_tpl<schedule_entry_t>, const& i, schedule->get_entries()) {
+		if (grund_t* const gr = welt->lookup(i.pos)) {
 			for(  uint idx=0;  idx<gr->get_top();  idx++  ) {
 				obj_t *obj = gr->obj_bei(idx);
 				if(  marking  ) {

--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -131,8 +131,8 @@ schedule_gui_stats_t::~schedule_gui_stats_t()
 void schedule_gui_stats_t::highlight_schedule(bool marking)
 {
 	marking &= env_t::visualize_schedule;
-	FOR(minivec_tpl<schedule_entry_t>, const& i, schedule->entries) {
-		if (grund_t* const gr = welt->lookup(i.pos)) {
+	for(const schedule_entry_t* i = schedule->begin(); i != schedule->end(); ++i) {
+		if (grund_t* const gr = welt->lookup(i->pos)) {
 			for(  uint idx=0;  idx<gr->get_top();  idx++  ) {
 				obj_t *obj = gr->obj_bei(idx);
 				if(  marking  ) {
@@ -166,7 +166,7 @@ void schedule_gui_stats_t::highlight_schedule(bool marking)
 	}
 	// add if required
 	if(  marking  &&  schedule->get_current_stop() < schedule->get_count() ) {
-		current_stop_mark->set_pos( schedule->entries[schedule->get_current_stop()].pos );
+		current_stop_mark->set_pos( schedule->at(schedule->get_current_stop()).pos );
 		if(  grund_t *gr = welt->lookup(current_stop_mark->get_pos())  ) {
 			gr->obj_add( current_stop_mark );
 			current_stop_mark->set_flag( obj_t::dirty );
@@ -179,9 +179,9 @@ void schedule_gui_stats_t::highlight_schedule(bool marking)
 void schedule_gui_stats_t::update_schedule()
 {
 	// compare schedules
-	bool ok = (last_schedule != NULL)  &&  last_schedule->entries.get_count() == schedule->entries.get_count();
-	for(uint i=0; ok  &&  i<last_schedule->entries.get_count(); i++) {
-		ok = last_schedule->entries[i] == schedule->entries[i];
+	bool ok = (last_schedule != NULL)  &&  last_schedule->get_count() == schedule->get_count();
+	for(uint i=0; ok  &&  i<last_schedule->get_count(); i++) {
+		ok = last_schedule->at(i) == schedule->at(i);
 	}
 	if (ok) {
 		if (!last_schedule->empty()) {
@@ -199,8 +199,8 @@ void schedule_gui_stats_t::update_schedule()
 			new_component<gui_textarea_t>(&buf);
 		}
 		else {
-			for(uint i=0; i<schedule->entries.get_count(); i++) {
-				entries.append( new_component<gui_schedule_entry_t>(player, schedule->entries[i], i));
+			for(uint i=0; i<schedule->get_count(); i++) {
+				entries.append( new_component<gui_schedule_entry_t>(player, schedule->at(i), i));
 				entries.back()->add_listener( this );
 			}
 			entries[ schedule->get_current_stop() ]->set_active(true);
@@ -663,44 +663,44 @@ void schedule_gui_t::update_selection()
 	if(  !schedule->empty()  ) {
 		schedule->set_current_stop( min(schedule->get_count()-1,schedule->get_current_stop()) );
 		const uint8 current_stop = schedule->get_current_stop();
-		if(  haltestelle_t::get_stoppable_halt(schedule->entries[current_stop].pos, player).is_bound()  ) {
+		if(  haltestelle_t::get_stoppable_halt(schedule->at(current_stop).pos, player).is_bound()  ) {
 			
-			const uint8 c = schedule->entries[current_stop].get_coupling_point();
+			const uint8 c = schedule->at(current_stop).get_coupling_point();
 			bt_find_parent.enable();
 			bt_find_parent.pressed = c==2;
 			bt_wait_for_child.enable();
 			bt_wait_for_child.pressed = c==1;
 			bt_no_load.enable();
-			bt_no_load.pressed = schedule->entries[current_stop].is_no_load();
+			bt_no_load.pressed = schedule->at(current_stop).is_no_load();
 			bt_no_unload.enable();
-			bt_no_unload.pressed = schedule->entries[current_stop].is_no_unload();
+			bt_no_unload.pressed = schedule->at(current_stop).is_no_unload();
 			bt_unload_all.enable();
-			bt_unload_all.pressed = schedule->entries[current_stop].is_unload_all();
-			bt_load_before_departure.pressed = schedule->entries[current_stop].is_load_before_departure();
+			bt_unload_all.pressed = schedule->at(current_stop).is_unload_all();
+			bt_load_before_departure.pressed = schedule->at(current_stop).is_load_before_departure();
 			bt_transfer_interval.enable();
-			bt_transfer_interval.pressed = schedule->entries[current_stop].is_transfer_interval();
+			bt_transfer_interval.pressed = schedule->at(current_stop).is_transfer_interval();
 			bt_reverse_convoy.enable();
-			bt_reverse_convoy.pressed = schedule->entries[current_stop].is_reverse_convoy();
+			bt_reverse_convoy.pressed = schedule->at(current_stop).is_reverse_convoy();
 			bt_reverse_coupling.enable();
-			bt_reverse_coupling.pressed = schedule->entries[current_stop].is_reverse_convoi_coupling();
+			bt_reverse_coupling.pressed = schedule->at(current_stop).is_reverse_convoi_coupling();
 
 			
 			// wait_for_time releated things
-			const bool wft = schedule->entries[current_stop].get_wait_for_time();
+			const bool wft = schedule->at(current_stop).get_wait_for_time();
 			bt_wait_for_time.enable();
 			bt_wait_for_time.pressed = wft;
 			if(  wft  ) {
 				// enable departure time settings only
-				//schedule->entries[current_stop].spacing cannot be zero.
+				//schedule->at(current_stop).spacing cannot be zero.
 				const uint16 divisor = world()->get_settings().get_spacing_shift_divisor();
 				const uint16 month_ratio_second = 86400/divisor;
-				uint32 second = (86400/schedule->entries[current_stop].spacing)/month_ratio_second*month_ratio_second;
+				uint32 second = (86400/schedule->at(current_stop).spacing)/month_ratio_second*month_ratio_second;
 				uint8 hour = second/3600;
 				uint8 minute = (second - hour * 3600)/60;
 				second = second % 60;
-				sprintf(lb_spacing_str, "%d (%02d:%02d:%02d)", divisor/schedule->entries[current_stop].spacing,hour,minute,second);
+				sprintf(lb_spacing_str, "%d (%02d:%02d:%02d)", divisor/schedule->at(current_stop).spacing,hour,minute,second);
 
-				uint32 second_shift = schedule->entries[current_stop].spacing_shift * month_ratio_second;
+				uint32 second_shift = schedule->at(current_stop).spacing_shift * month_ratio_second;
 				uint8 hour_shift = second_shift/3600;
 				uint8 minute_shift = (second_shift - hour_shift * 3600)/60;
 				second_shift = second_shift % 60;
@@ -714,14 +714,14 @@ void schedule_gui_t::update_selection()
 				// disable departure time settings and enable minimum loading
 				lb_load.set_color( SYSCOL_TEXT );
 				numimp_load.enable();
-				if(  schedule->entries[current_stop].minimum_loading>0  ||  schedule->entries[current_stop].get_coupling_point()!=0  ) {
+				if(  schedule->at(current_stop).minimum_loading>0  ||  schedule->at(current_stop).get_coupling_point()!=0  ) {
 					bt_wait_load.enable();
-					uint16 wait = schedule->entries[current_stop].waiting_time_shift;
+					uint16 wait = schedule->at(current_stop).waiting_time_shift;
 					bt_wait_load.pressed = wait>0;
 					if(  wait>0  ) {
 						lb_wait.set_color( SYSCOL_TEXT );
 						numimp_wait_load.enable();
-						if(  schedule->entries[current_stop].minimum_loading  ==  200  ){
+						if(  schedule->at(current_stop).minimum_loading  ==  200  ){
 							bt_load_before_departure.enable();
 						}
 					}
@@ -730,11 +730,11 @@ void schedule_gui_t::update_selection()
 				sprintf(lb_spacing_shift_str,"");
 			}
 			
-			numimp_load.set_value( schedule->entries[current_stop].minimum_loading );
-			numimp_wait_load.set_value( max(1, schedule->entries[current_stop].waiting_time_shift) );
-			numimp_spacing.set_value( schedule->entries[current_stop].spacing );
-			numimp_spacing_shift.set_value( schedule->entries[current_stop].spacing_shift );
-			numimp_delay_tolerance.set_value( schedule->entries[current_stop].delay_tolerance );
+			numimp_load.set_value( schedule->at(current_stop).minimum_loading );
+			numimp_wait_load.set_value( max(1, schedule->at(current_stop).waiting_time_shift) );
+			numimp_spacing.set_value( schedule->at(current_stop).spacing );
+			numimp_spacing_shift.set_value( schedule->at(current_stop).spacing_shift );
+			numimp_delay_tolerance.set_value( schedule->at(current_stop).delay_tolerance );
 		}
 	}
 }
@@ -836,60 +836,60 @@ DBG_MESSAGE("schedule_gui_t::action_triggered()","comp=%p combo=%p",comp,&line_s
 	else if(comp == &bt_find_parent) {
 		if(!schedule->empty()) {
 			if(  bt_find_parent.pressed  ) {
-				schedule->entries[schedule->get_current_stop()].reset_coupling();
+				schedule->at(schedule->get_current_stop()).reset_coupling();
 			} else {
-				schedule->entries[schedule->get_current_stop()].set_try_coupling();
+				schedule->at(schedule->get_current_stop()).set_try_coupling();
 			}
 			bt_wait_for_child.pressed = false;
-			schedule->entries[schedule->get_current_stop()].set_reverse_convoi_coupling(false);
+			schedule->at(schedule->get_current_stop()).set_reverse_convoi_coupling(false);
 			update_selection();
 		}
 	}
 	else if(comp == &bt_wait_for_child) {
 		if(!schedule->empty()) {
 			if(  bt_wait_for_child.pressed  ) {
-				schedule->entries[schedule->get_current_stop()].reset_coupling();
+				schedule->at(schedule->get_current_stop()).reset_coupling();
 			} else {
-				schedule->entries[schedule->get_current_stop()].set_wait_for_coupling();
+				schedule->at(schedule->get_current_stop()).set_wait_for_coupling();
 			}
 			bt_find_parent.pressed = false;
-			schedule->entries[schedule->get_current_stop()].set_reverse_convoi_coupling(false);
+			schedule->at(schedule->get_current_stop()).set_reverse_convoi_coupling(false);
 			update_selection();
 		}
 	}
 	else if(comp == &bt_reverse_convoy) {
 		if(!schedule->empty()) {
-			schedule->entries[schedule->get_current_stop()].set_reverse_convoy(!bt_reverse_convoy.pressed);
+			schedule->at(schedule->get_current_stop()).set_reverse_convoy(!bt_reverse_convoy.pressed);
 			update_selection();
 		}
 	}
 	else if(comp == &bt_reverse_coupling) {
 		if(!schedule->empty()) {
-			schedule->entries[schedule->get_current_stop()].set_reverse_convoi_coupling(!bt_reverse_coupling.pressed);
+			schedule->at(schedule->get_current_stop()).set_reverse_convoi_coupling(!bt_reverse_coupling.pressed);
 			if(  bt_wait_for_child.pressed  ) {
-				schedule->entries[schedule->get_current_stop()].reset_coupling();
+				schedule->at(schedule->get_current_stop()).reset_coupling();
 			} 
 			if(  bt_find_parent.pressed  ) {
-				schedule->entries[schedule->get_current_stop()].reset_coupling();
+				schedule->at(schedule->get_current_stop()).reset_coupling();
 			} 
 			update_selection();
 		}
 	}
 	else if(comp == &numimp_load) {
 		if (!schedule->empty()) {
-			schedule->entries[schedule->get_current_stop()].minimum_loading = (uint8)p.i;
+			schedule->at(schedule->get_current_stop()).minimum_loading = (uint8)p.i;
 			update_selection();
 		}
 	}
 	else if(comp == &bt_wait_load) {
 		if (!schedule->empty()) {
-			schedule->entries[schedule->get_current_stop()].waiting_time_shift = !bt_wait_load.pressed;
+			schedule->at(schedule->get_current_stop()).waiting_time_shift = !bt_wait_load.pressed;
 			update_selection();
 		}
 	}
 	else if(comp == &numimp_wait_load) {
 		if(!schedule->empty()) {
-			schedule->entries[schedule->get_current_stop()].waiting_time_shift = (uint16)p.i;
+			schedule->at(schedule->get_current_stop()).waiting_time_shift = (uint16)p.i;
 			update_selection();
 		}
 	}
@@ -943,19 +943,19 @@ DBG_MESSAGE("schedule_gui_t::action_triggered()","comp=%p combo=%p",comp,&line_s
 	}
 	else if(comp == &bt_no_load) {
 		if (!schedule->empty()) {
-			schedule->entries[schedule->get_current_stop()].set_no_load(!bt_no_load.pressed);
+			schedule->at(schedule->get_current_stop()).set_no_load(!bt_no_load.pressed);
 			update_selection();
 		}
 	}
 	else if(comp == &bt_no_unload) {
 		if (!schedule->empty()) {
-			schedule->entries[schedule->get_current_stop()].set_no_unload(!bt_no_unload.pressed);
+			schedule->at(schedule->get_current_stop()).set_no_unload(!bt_no_unload.pressed);
 			update_selection();
 		}
 	}
 	else if(comp == &bt_unload_all) {
 		if (!schedule->empty()) {
-			schedule->entries[schedule->get_current_stop()].set_unload_all(!bt_unload_all.pressed);
+			schedule->at(schedule->get_current_stop()).set_unload_all(!bt_unload_all.pressed);
 			update_selection();
 		}
 	}
@@ -965,7 +965,7 @@ DBG_MESSAGE("schedule_gui_t::action_triggered()","comp=%p combo=%p",comp,&line_s
 	}
 	else if(comp == &bt_wait_for_time) {
 		if (!schedule->empty()) {
-			schedule->entries[schedule->get_current_stop()].set_wait_for_time(!bt_wait_for_time.pressed);
+			schedule->at(schedule->get_current_stop()).set_wait_for_time(!bt_wait_for_time.pressed);
 			update_selection();
 		}
 	}
@@ -974,7 +974,7 @@ DBG_MESSAGE("schedule_gui_t::action_triggered()","comp=%p combo=%p",comp,&line_s
 			if(  schedule->is_same_dep_time()  ) {
 				schedule->set_spacing_for_all((uint16)p.i);
 			} else {
-				schedule->entries[schedule->get_current_stop()].spacing = (uint16)p.i;
+				schedule->at(schedule->get_current_stop()).spacing = (uint16)p.i;
 			}
 			update_selection();
 		}
@@ -984,7 +984,7 @@ DBG_MESSAGE("schedule_gui_t::action_triggered()","comp=%p combo=%p",comp,&line_s
 			if(  schedule->is_same_dep_time()  ) {
 				schedule->set_spacing_shift_for_all((uint16)p.i);
 			} else {
-				schedule->entries[schedule->get_current_stop()].spacing_shift = (uint16)p.i;
+				schedule->at(schedule->get_current_stop()).spacing_shift = (uint16)p.i;
 			}
 			update_selection();
 		}
@@ -994,14 +994,14 @@ DBG_MESSAGE("schedule_gui_t::action_triggered()","comp=%p combo=%p",comp,&line_s
 			if(  schedule->is_same_dep_time()  ) {
 				schedule->set_delay_tolerance_for_all((uint16)p.i);
 			} else {
-				schedule->entries[schedule->get_current_stop()].delay_tolerance = (uint16)p.i;
+				schedule->at(schedule->get_current_stop()).delay_tolerance = (uint16)p.i;
 			}
 			update_selection();
 		}
 	}
 	else if(comp == &bt_load_before_departure) {
 		if (!schedule->empty()) {
-			schedule->entries[schedule->get_current_stop()].set_load_before_departure(bt_load_before_departure.pressed);
+			schedule->at(schedule->get_current_stop()).set_load_before_departure(bt_load_before_departure.pressed);
 			update_selection();
 		}
 	}
@@ -1021,7 +1021,7 @@ DBG_MESSAGE("schedule_gui_t::action_triggered()","comp=%p combo=%p",comp,&line_s
 	}
 	else if(comp == &bt_transfer_interval) {
 		if (!schedule->empty()) {
-			schedule->entries[schedule->get_current_stop()].set_transfer_interval(!bt_transfer_interval.pressed);
+			schedule->at(schedule->get_current_stop()).set_transfer_interval(!bt_transfer_interval.pressed);
 			update_selection();
 		}
 	}

--- a/gui/schedule_list.cc
+++ b/gui/schedule_list.cc
@@ -748,8 +748,8 @@ void schedule_list_gui_t::update_lineinfo(linehandle_t new_line)
 
 		// fill haltestellen container with info of stops of the line
 		scrolly_haltestellen.clear_elements();
-		FOR(minivec_tpl<schedule_entry_t>, const& i, new_line->get_schedule()->entries) {
-			halthandle_t const halt = haltestelle_t::get_stoppable_halt(i.pos, player);
+		for(const schedule_entry_t* i = new_line->get_schedule()->begin(); i != new_line->get_schedule()->end(); ++i) {
+			halthandle_t const halt = haltestelle_t::get_stoppable_halt(i->pos, player);
 			if(  halt.is_bound()  ) {
 				scrolly_haltestellen.new_component<halt_list_stats_t>(halt);
 			}

--- a/gui/schedule_list.cc
+++ b/gui/schedule_list.cc
@@ -748,8 +748,8 @@ void schedule_list_gui_t::update_lineinfo(linehandle_t new_line)
 
 		// fill haltestellen container with info of stops of the line
 		scrolly_haltestellen.clear_elements();
-		for(const schedule_entry_t* i = new_line->get_schedule()->begin(); i != new_line->get_schedule()->end(); ++i) {
-			halthandle_t const halt = haltestelle_t::get_stoppable_halt(i->pos, player);
+		FOR(minivec_tpl<schedule_entry_t>, const& i, new_line->get_schedule()->get_entries()) {
+			halthandle_t const halt = haltestelle_t::get_stoppable_halt(i.pos, player);
 			if(  halt.is_bound()  ) {
 				scrolly_haltestellen.new_component<halt_list_stats_t>(halt);
 			}

--- a/player/ai_goods.cc
+++ b/player/ai_goods.cc
@@ -1145,7 +1145,7 @@ DBG_MESSAGE("ai_goods_t::step()","remove already constructed rail between %i,%i 
 					if(!lines.empty()) {
 						linehandle_t line = lines.back();
 						schedule_t *schedule=line->get_schedule();
-						if(schedule->get_count()>1  &&  haltestelle_t::get_halt(schedule->entries[0].pos,this)==start_halt) {
+						if(schedule->get_count()>1  &&  haltestelle_t::get_halt(schedule->at(0).pos,this)==start_halt) {
 							while(line->count_convoys()>0) {
 								convoihandle_t cnv = line->get_convoy(0);
 								cnv->self_destruct();
@@ -1245,8 +1245,8 @@ DBG_MESSAGE("ai_goods_t::step()","remove already constructed rail between %i,%i 
 					koord3d start_pos, end_pos;
 					schedule_t *schedule = cnv->get_schedule();
 					if(schedule  &&  schedule->get_count()>1) {
-						start_pos = schedule->entries[0].pos;
-						end_pos = schedule->entries[1].pos;
+						start_pos = schedule->at(0).pos;
+						end_pos = schedule->at(1).pos;
 					}
 
 					cnv->self_destruct();
@@ -1265,8 +1265,8 @@ DBG_MESSAGE("ai_goods_t::step()","remove already constructed rail between %i,%i 
 							simlinemgmt.get_lines( simline_t::shipline, &lines );
 							FOR(vector_tpl<linehandle_t>, const line, lines) {
 								schedule_t *schedule=line->get_schedule();
-								if(schedule->get_count()>1  &&  haltestelle_t::get_halt(schedule->entries[0].pos,this)==start_halt) {
-									water_stop = koord( (start_pos.x+schedule->entries[0].pos.x)/2, (start_pos.y+schedule->entries[0].pos.y)/2 );
+								if(schedule->get_count()>1  &&  haltestelle_t::get_halt(schedule->at(0).pos,this)==start_halt) {
+									water_stop = koord( (start_pos.x+schedule->at(0).pos.x)/2, (start_pos.y+schedule->at(0).pos.y)/2 );
 									while(line->count_convoys()>0) {
 										convoihandle_t cnv = line->get_convoy(0);
 										cnv->self_destruct();

--- a/player/ai_passenger.cc
+++ b/player/ai_passenger.cc
@@ -1318,7 +1318,7 @@ DBG_MESSAGE("ai_passenger_t::do_passenger_ki()","using %s on %s",road_vehicle->g
 										// too many convois => cannot do anything about this ...
 										break;
 									}
-									vehicle_t* v = vehicle_builder_t::build( line->get_schedule()->entries[0].pos, this, NULL, v_desc  );
+									vehicle_t* v = vehicle_builder_t::build( line->get_schedule()->at(0).pos, this, NULL, v_desc  );
 									convoi_t* new_cnv = new convoi_t(this);
 									new_cnv->set_name( v->get_desc()->get_name() );
 									new_cnv->add_vehikel( v );
@@ -1348,15 +1348,15 @@ DBG_MESSAGE("ai_passenger_t::do_passenger_ki()","using %s on %s",road_vehicle->g
 				// next: check for overflowing lines, i.e. running with 3/4 of the capacity
 				if(  ratio<10  &&  !convoihandle_t::is_exhausted()  ) {
 					// else add the first convoi again
-					vehicle_t* const v = vehicle_builder_t::build(line->get_schedule()->entries[0].pos, this, NULL, line->get_convoy(0)->front()->get_desc());
+					vehicle_t* const v = vehicle_builder_t::build(line->get_schedule()->at(0).pos, this, NULL, line->get_convoy(0)->front()->get_desc());
 					convoi_t* new_cnv = new convoi_t(this);
 					new_cnv->set_name( v->get_desc()->get_name() );
 					new_cnv->add_vehikel( v );
 					new_cnv->set_line( line );
 					// on waiting line, wait at alternating stations for load balancing
-					if(  line->get_schedule()->entries[1].minimum_loading==90  &&  line->get_linetype()!=simline_t::truckline  &&  (line->count_convoys()&1)==0  ) {
-						new_cnv->get_schedule()->entries[0].minimum_loading = 90;
-						new_cnv->get_schedule()->entries[1].minimum_loading = 0;
+					if(  line->get_schedule()->at(1).minimum_loading==90  &&  line->get_linetype()!=simline_t::truckline  &&  (line->count_convoys()&1)==0  ) {
+						new_cnv->get_schedule()->at(0).minimum_loading = 90;
+						new_cnv->get_schedule()->at(1).minimum_loading = 0;
 					}
 					new_cnv->start();
 					return;

--- a/script/api/api_schedule.cc
+++ b/script/api/api_schedule.cc
@@ -82,7 +82,7 @@ schedule_t* script_api::param<schedule_t*>::get(HSQUIRRELVM vm, SQInteger index)
 	// get instance pointer
 	schedule_t* sched = get_attached_instance<schedule_t>(vm, index, param<schedule_t*>::tag());
 	if (sched) {
-		sched->entries.clear();
+		sched->remove_all();
 		// now read the entries
 		sq_pushstring(vm, "entries", -1);
 		SQInteger new_index = index > 0 ? index : index-1;

--- a/script/api_param.cc
+++ b/script/api_param.cc
@@ -579,7 +579,11 @@ namespace script_api {
 	SQInteger param<const schedule_t*>::push(HSQUIRRELVM vm, const schedule_t* const& v)
 	{
 		if (v) {
-			return push_instance(vm, "schedule_x", v->get_waytype(), v->entries);
+			minivec_tpl<schedule_entry_t> entries;
+			for(const schedule_entry_t* e = v->begin(); e != v->end(); e++) {
+				entries.append(*e);
+			}
+			return push_instance(vm, "schedule_x", v->get_waytype(), entries);
 		}
 		else {
 			sq_pushnull(vm); return 1;

--- a/script/api_param.cc
+++ b/script/api_param.cc
@@ -579,11 +579,7 @@ namespace script_api {
 	SQInteger param<const schedule_t*>::push(HSQUIRRELVM vm, const schedule_t* const& v)
 	{
 		if (v) {
-			minivec_tpl<schedule_entry_t> entries;
-			for(const schedule_entry_t* e = v->begin(); e != v->end(); e++) {
-				entries.append(*e);
-			}
-			return push_instance(vm, "schedule_x", v->get_waytype(), entries);
+			return push_instance(vm, "schedule_x", v->get_waytype(), v->get_entries());
 		}
 		else {
 			sq_pushnull(vm); return 1;

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -4505,8 +4505,8 @@ void convoi_t::check_pending_updates()
 void convoi_t::register_stops()
 {
 	if(  schedule  ) {
-		for(const schedule_entry_t* i = schedule->begin(); i != schedule->end(); ++i) {
-			halthandle_t const halt = haltestelle_t::get_stoppable_halt(i->pos, get_owner());
+		FOR(minivec_tpl<schedule_entry_t>, const& i, schedule->get_entries()) {
+			halthandle_t const halt = haltestelle_t::get_stoppable_halt(i.pos, get_owner());
 			if(  halt.is_bound()  ) {
 				halt->add_convoy(self);
 			}
@@ -4521,8 +4521,8 @@ void convoi_t::register_stops()
 void convoi_t::unregister_stops()
 {
 	if(  schedule  ) {
-		for(const schedule_entry_t* i = schedule->begin(); i != schedule->end(); ++i) {
-			halthandle_t const halt = haltestelle_t::get_stoppable_halt(i->pos, get_owner());
+		FOR(minivec_tpl<schedule_entry_t>, const& i, schedule->get_entries()) {
+			halthandle_t const halt = haltestelle_t::get_stoppable_halt(i.pos, get_owner());
 			if(  halt.is_bound()  ) {
 				halt->remove_convoy(self);
 			}

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -3684,7 +3684,7 @@ void calc_reachable_halts(vector_tpl<haltestelle_t::reachable_halt_t>& reachable
 	sint16 first_depot_entry_offset = -1;
 	for(  uint8 i=1;  i<schedule_count;  i++  ) {
 		const uint8 wrap_i = (i + schedule->get_current_stop()) % schedule_count;
-		grund_t *gr = world()->lookup(schedule->entries[wrap_i].pos);
+		grund_t *gr = world()->lookup(schedule->at(wrap_i).pos);
 		if(  gr  &&  gr->has_depot()  ) {
 			first_depot_entry_offset = i;
 			break;
@@ -3707,23 +3707,23 @@ void calc_reachable_halts(vector_tpl<haltestelle_t::reachable_halt_t>& reachable
 	// The estimated journey time from the current stop
 	// The convoy stopping time at the starting point is subtracted because the journey time of
 	// the first entry contains the stopping time at the starting point, which should be excluded.
-	sint32 journey_time = -line_schedule->entries[line_schedule_current_index].get_median_convoy_stopping_time(); 
+	sint32 journey_time = -line_schedule->at(line_schedule_current_index).get_median_convoy_stopping_time(); 
 
 	const uint8 line_schedule_count = line_schedule->get_count();
 	uint8 interval = 0;
 	for(  uint8 i=1;  i<line_schedule_count;  i++  ) {
 		const uint8 wrap_i = (i + line_schedule_current_index) % line_schedule_count;
 
-		const halthandle_t plan_halt = haltestelle_t::get_stoppable_halt(line_schedule->entries[wrap_i].pos, owner);
+		const halthandle_t plan_halt = haltestelle_t::get_stoppable_halt(line_schedule->at(wrap_i).pos, owner);
 		if(plan_halt == current_halt) {
 			// we will come later here again ...
 			break;
 		}
-		else if(  !plan_halt.is_bound()  ||  line_schedule->entries[wrap_i].is_no_unload()  ) {
+		else if(  !plan_halt.is_bound()  ||  line_schedule->at(wrap_i).is_no_unload()  ) {
 			// not a halt or set no_unload. no_unload -> we cannot unload the cargo there.
 			continue;
 		}
-		const grund_t* gr = world()->lookup(line_schedule->entries[wrap_i].pos);
+		const grund_t* gr = world()->lookup(line_schedule->at(wrap_i).pos);
 		if(  gr  &&  gr->has_depot()  ) {
 			// Just ignore the depot entry of the line schedule.
 			continue;
@@ -3732,7 +3732,7 @@ void calc_reachable_halts(vector_tpl<haltestelle_t::reachable_halt_t>& reachable
 		// when something irregular happens on a single convoy.
 		journey_time += line_schedule->get_median_journey_time(wrap_i, cnv->get_speedbonus_kmh());
 		reachable_halts.append(haltestelle_t::reachable_halt_t(plan_halt, (uint32)max(journey_time, 0)));
-		if(  line_schedule->entries[wrap_i].is_unload_all()  ) {
+		if(  line_schedule->at(wrap_i).is_unload_all()  ) {
 			// passengers/cargos cannot keep boarding beyond this stop.
 			break;
 		}
@@ -3740,7 +3740,7 @@ void calc_reachable_halts(vector_tpl<haltestelle_t::reachable_halt_t>& reachable
 			// This is the last schedule entry which the convoy allows to reach.
 			break;
 		}
-		else if( line_schedule->entries[wrap_i].is_transfer_interval() ){
+		else if( line_schedule->at(wrap_i).is_transfer_interval() ){
 			if(interval == 1){
 				break;
 			}
@@ -4055,7 +4055,7 @@ void convoi_t::push_goods_waiting_time_if_needed() {
 	uint32 average_waiting_time = weighed_sum_waiting_time / total_goods_amount;
 	const linehandle_t line = get_line();
 	schedule_t* schedule_to_push = line.is_bound() ? line->get_schedule() : schedule;
-	schedule_to_push->entries[schedule->get_current_stop()].push_waiting_time(average_waiting_time);
+	schedule_to_push->at(schedule->get_current_stop()).push_waiting_time(average_waiting_time);
 
 	// update journey time window
 	gui_goods_waiting_time_t* window = dynamic_cast<gui_goods_waiting_time_t*>(win_get_magic((ptrdiff_t)line.get_rep()));
@@ -4076,7 +4076,7 @@ void convoi_t::push_convoy_stopping_time() {
 	schedule_t* line_schedule = line.is_bound() ? line->get_schedule() : schedule;
 	const sint16 current_index_on_line_schedule = line_schedule->get_corresponding_entry_index(schedule, schedule->get_current_stop());
 	if(  current_index_on_line_schedule>=0  ) {
-		line_schedule->entries[current_index_on_line_schedule].push_convoy_stopping_time(stopping_time);
+		line_schedule->at(current_index_on_line_schedule).push_convoy_stopping_time(stopping_time);
 	}
 }
 
@@ -4392,7 +4392,7 @@ void convoi_t::check_pending_updates()
 			// something to check for ...
 			current = schedule->get_current_entry().pos;
 
-			if(  current_stop<new_schedule->get_count() &&  current==new_schedule->entries[current_stop].pos  ) {
+			if(  current_stop<new_schedule->get_count() &&  current==new_schedule->at(current_stop).pos  ) {
 				// next pos is the same => keep the convoi state
 				is_same = true;
 			}
@@ -4413,30 +4413,30 @@ void convoi_t::check_pending_updates()
 				 * (To detect also places, where only the platform
 				 *  changed, we also compare the halthandle)
 				 */
-				const koord3d next = schedule->get_count()==0 ? koord3d::invalid : schedule->entries[(current_stop+1)%schedule->get_count()].pos;
-				const koord3d nextnext = schedule->get_count()==0 ? koord3d::invalid : schedule->entries[(current_stop+2)%schedule->get_count()].pos;
-				const koord3d nextnextnext = schedule->get_count()==0 ? koord3d::invalid : schedule->entries[(current_stop+3)%schedule->get_count()].pos;
+				const koord3d next = schedule->get_count()==0 ? koord3d::invalid : schedule->at((current_stop+1)%schedule->get_count()).pos;
+				const koord3d nextnext = schedule->get_count()==0 ? koord3d::invalid : schedule->at((current_stop+2)%schedule->get_count()).pos;
+				const koord3d nextnextnext = schedule->get_count()==0 ? koord3d::invalid : schedule->at((current_stop+3)%schedule->get_count()).pos;
 				int how_good_matching = 0;
 				const uint8 new_count = new_schedule->get_count();
 
 				for(  uint8 i=0;  i<new_count;  i++  ) {
 					int quality =
-						matches_halt(current,new_schedule->entries[i].pos)*3 +
-						matches_halt(next,new_schedule->entries[(i+1)%new_count].pos)*4 +
-						matches_halt(nextnext,new_schedule->entries[(i+2)%new_count].pos)*2 +
-						matches_halt(nextnextnext,new_schedule->entries[(i+3)%new_count].pos);
+						matches_halt(current,new_schedule->at(i).pos)*3 +
+						matches_halt(next,new_schedule->at((i+1)%new_count).pos)*4 +
+						matches_halt(nextnext,new_schedule->at((i+2)%new_count).pos)*2 +
+						matches_halt(nextnextnext,new_schedule->at((i+3)%new_count).pos);
 					if(  quality>how_good_matching  ) {
 						// better match than previous: but depending of distance, the next number will be different
-						if(  matches_halt(current,new_schedule->entries[i].pos)  ) {
+						if(  matches_halt(current,new_schedule->at(i).pos)  ) {
 							current_stop = i;
 						}
-						else if(  matches_halt(next,new_schedule->entries[(i+1)%new_count].pos)  ) {
+						else if(  matches_halt(next,new_schedule->at((i+1)%new_count).pos)  ) {
 							current_stop = i+1;
 						}
-						else if(  matches_halt(nextnext,new_schedule->entries[(i+2)%new_count].pos)  ) {
+						else if(  matches_halt(nextnext,new_schedule->at((i+2)%new_count).pos)  ) {
 							current_stop = i+2;
 						}
-						else if(  matches_halt(nextnextnext,new_schedule->entries[(i+3)%new_count].pos)  ) {
+						else if(  matches_halt(nextnextnext,new_schedule->at((i+3)%new_count).pos)  ) {
 							current_stop = i+3;
 						}
 						current_stop %= new_count;
@@ -4449,7 +4449,7 @@ void convoi_t::check_pending_updates()
 					current_stop = new_schedule->get_current_stop();
 				}
 				// if we go to same, then we do not need route recalculation ...
-				is_same = matches_halt(current,new_schedule->entries[current_stop].pos);
+				is_same = matches_halt(current,new_schedule->at(current_stop).pos);
 			}
 		}
 
@@ -4505,8 +4505,8 @@ void convoi_t::check_pending_updates()
 void convoi_t::register_stops()
 {
 	if(  schedule  ) {
-		FOR(minivec_tpl<schedule_entry_t>, const& i, schedule->entries) {
-			halthandle_t const halt = haltestelle_t::get_stoppable_halt(i.pos, get_owner());
+		for(const schedule_entry_t* i = schedule->begin(); i != schedule->end(); ++i) {
+			halthandle_t const halt = haltestelle_t::get_stoppable_halt(i->pos, get_owner());
 			if(  halt.is_bound()  ) {
 				halt->add_convoy(self);
 			}
@@ -4521,8 +4521,8 @@ void convoi_t::register_stops()
 void convoi_t::unregister_stops()
 {
 	if(  schedule  ) {
-		FOR(minivec_tpl<schedule_entry_t>, const& i, schedule->entries) {
-			halthandle_t const halt = haltestelle_t::get_stoppable_halt(i.pos, get_owner());
+		for(const schedule_entry_t* i = schedule->begin(); i != schedule->end(); ++i) {
+			halthandle_t const halt = haltestelle_t::get_stoppable_halt(i->pos, get_owner());
 			if(  halt.is_bound()  ) {
 				halt->remove_convoy(self);
 			}
@@ -5320,7 +5320,7 @@ bool convoi_t::can_start_coupling(convoi_t* parent) const {
 	sint16 t_idx = schedule->get_current_stop();
 	bool stop_found = false;
 	do {
-		if(  !is_waypoint(schedule->entries[t_idx].pos)  ) {
+		if(  !is_waypoint(schedule->at(t_idx).pos)  ) {
 			stop_found = true;
 			break;
 		}
@@ -5330,8 +5330,8 @@ bool convoi_t::can_start_coupling(convoi_t* parent) const {
 		// all schedule entries are waypoint.
 		return false;
 	}
-	const schedule_entry_t t_c = schedule->entries[t_idx];
-	const schedule_entry_t t_n = schedule->entries[(t_idx+1)%schedule->get_count()];
+	const schedule_entry_t t_c = schedule->at(t_idx);
+	const schedule_entry_t t_n = schedule->at((t_idx+1)%schedule->get_count());
 	const schedule_entry_t p_c = parent->get_schedule()->get_current_entry();
 	const schedule_entry_t p_n = parent->get_schedule()->get_next_entry();
 
@@ -5398,7 +5398,7 @@ void convoi_t::register_journey_time() {
 		const sint16 current_index_on_line_schedule = line_schedule->get_corresponding_entry_index(c->get_schedule(), c->get_schedule()->get_current_stop());
 		if(  current_index_on_line_schedule>=0  ) {
 			// register journey time
-			line_schedule->entries[current_index_on_line_schedule].push_journey_time(journey_time);
+			line_schedule->at(current_index_on_line_schedule).push_journey_time(journey_time);
 		}
 		if(  c->get_line().is_bound()  ) {
 			// update journey time window

--- a/simdepot.cc
+++ b/simdepot.cc
@@ -184,8 +184,8 @@ void depot_t::convoi_arrived(convoihandle_t acnv, bool schedule_adjust)
 		schedule_t *schedule = acnv->get_schedule();
 		for(  int i=0;  i<schedule->get_count();  i++  ) {
 			// only if convoi found
-			if(schedule->entries[i].pos==get_pos()) {
-				const bool is_last = i==schedule->entries.get_count()-1;
+			if(schedule->at(i).pos==get_pos()) {
+				const bool is_last = i==schedule->get_count()-1;
 				schedule->set_current_stop( i );
 				schedule->remove();
 				if(  is_last  ) {

--- a/simhalt.cc
+++ b/simhalt.cc
@@ -3788,7 +3788,7 @@ bool haltestelle_t::add_grund(grund_t *gr, bool relink_factories)
 		// only check lineless convoys which have matching ownership and which are not yet registered
 		if(  !cnv->get_line().is_bound()  &&  (public_halt  ||  cnv->get_owner()==get_owner())  &&  !registered_convoys.is_contained(cnv)  ) {
 			if(  const schedule_t *const schedule = cnv->get_schedule()  ) {
-				FOR(  minivec_tpl<schedule_entry_t>, const& k, cnv->get_schedule()->get_entries()  ) {
+				FOR(  minivec_tpl<schedule_entry_t>, const& k, schedule->get_entries()  ) {
 					if (get_stoppable_halt(k.pos, cnv->get_owner()) == self) {
 						registered_convoys.append(cnv);
 						break;
@@ -3913,7 +3913,7 @@ bool haltestelle_t::rem_grund(grund_t *gr)
 	// remove registered lineless convoys as well
 	for(  size_t j = registered_convoys.get_count();  j-- != 0;  ) {
 		bool ok = false;
-		FOR(  minivec_tpl<schedule_entry_t>, const& k, registered_lines[j]->get_schedule()->get_entries()  ) {
+		FOR(  minivec_tpl<schedule_entry_t>, const& k, registered_convoys[j]->get_schedule()->get_entries()  ) {
 			if(  get_stoppable_halt(k.pos, registered_convoys[j]->get_owner()) == self  ) {
 				ok = true;
 				break;

--- a/simhalt.cc
+++ b/simhalt.cc
@@ -3773,8 +3773,8 @@ bool haltestelle_t::add_grund(grund_t *gr, bool relink_factories)
 			FOR(  vector_tpl<linehandle_t>, const j, check_line  ) {
 				// only add unknown lines
 				if(  !registered_lines.is_contained(j)  &&  j->count_convoys() > 0  ) {
-					for(const schedule_entry_t* k = j->get_schedule()->begin(); k != j->get_schedule()->end(); ++k) {
-						if(  get_stoppable_halt(k->pos, player) == self  ) {
+					FOR(  minivec_tpl<schedule_entry_t>, const& k, j->get_schedule()->get_entries()  ) {
+						if(  get_stoppable_halt(k.pos, player) == self  ) {
 							registered_lines.append(j);
 							break;
 						}
@@ -3788,8 +3788,8 @@ bool haltestelle_t::add_grund(grund_t *gr, bool relink_factories)
 		// only check lineless convoys which have matching ownership and which are not yet registered
 		if(  !cnv->get_line().is_bound()  &&  (public_halt  ||  cnv->get_owner()==get_owner())  &&  !registered_convoys.is_contained(cnv)  ) {
 			if(  const schedule_t *const schedule = cnv->get_schedule()  ) {
-				for(const schedule_entry_t* k = schedule->begin(); k != schedule->end(); ++k) {
-					if (get_stoppable_halt(k->pos, cnv->get_owner()) == self) {
+				FOR(  minivec_tpl<schedule_entry_t>, const& k, cnv->get_schedule()->get_entries()  ) {
+					if (get_stoppable_halt(k.pos, cnv->get_owner()) == self) {
 						registered_convoys.append(cnv);
 						break;
 					}
@@ -3897,9 +3897,8 @@ bool haltestelle_t::rem_grund(grund_t *gr)
 	// remove lines eventually
 	for(  size_t j = registered_lines.get_count();  j-- != 0;  ) {
 		bool ok = false;
-		const schedule_t* schedule = registered_lines[j]->get_schedule();
-		for(const schedule_entry_t* k = schedule->begin(); k != schedule->end(); ++k) {
-			if(  get_stoppable_halt(k->pos, registered_lines[j]->get_owner()) == self  ) {
+		FOR(  minivec_tpl<schedule_entry_t>, const& k, registered_lines[j]->get_schedule()->get_entries()  ) {
+			if(  get_stoppable_halt(k.pos, registered_lines[j]->get_owner()) == self  ) {
 				ok = true;
 				break;
 			}
@@ -3914,9 +3913,8 @@ bool haltestelle_t::rem_grund(grund_t *gr)
 	// remove registered lineless convoys as well
 	for(  size_t j = registered_convoys.get_count();  j-- != 0;  ) {
 		bool ok = false;
-		const schedule_t* schedule = registered_convoys[j]->get_schedule();
-		for(const schedule_entry_t* k = schedule->begin(); k != schedule->end(); ++k) {
-			if(  get_stoppable_halt(k->pos, registered_convoys[j]->get_owner()) == self  ) {
+		FOR(  minivec_tpl<schedule_entry_t>, const& k, registered_lines[j]->get_schedule()->get_entries()  ) {
+			if(  get_stoppable_halt(k.pos, registered_convoys[j]->get_owner()) == self  ) {
 				ok = true;
 				break;
 			}

--- a/simhalt.cc
+++ b/simhalt.cc
@@ -1227,7 +1227,7 @@ void haltestelle_t::remove_fabriken(fabrik_t *fab)
 // Returns the estimated waiting time for the given schedule, for the given index halt.
 // The base waiting ticks is added as a waiting time.
 uint32 estimated_waiting_ticks(const schedule_t* schedule, uint8 index) {
-	const schedule_entry_t schedule_entry = schedule->entries[index];
+	const schedule_entry_t schedule_entry = schedule->at(index);
 	const uint32 average_waiting_time = schedule_entry.get_average_waiting_time();
 	const uint32 base_waiting_ticks = world()->get_settings().get_base_waiting_ticks(schedule->get_waytype());
 	const uint32 additional_ticks_by_schedule = (uint64)schedule->get_additional_base_waiting_time() * world()->ticks_per_world_month / world()->get_settings().get_spacing_shift_divisor();
@@ -1342,7 +1342,7 @@ sint32 haltestelle_t::rebuild_connections()
 
 		// find the index from which to start processing
 		uint8 start_index = 0;
-		while(  start_index < schedule->get_count()  &&  get_stoppable_halt( schedule->entries[start_index].pos, owner ) != self  ) {
+		while(  start_index < schedule->get_count()  &&  get_stoppable_halt( schedule->at(start_index).pos, owner ) != self  ) {
 			++start_index;
 		}
 		if(  start_index==schedule->get_count()  ) {
@@ -1370,7 +1370,7 @@ sint32 haltestelle_t::rebuild_connections()
 		INT_CHECK("simhalt.cc 612");
 
 		// now we add the schedule to the connection array
-		const schedule_entry_t start_entry = schedule->entries[start_index-1];
+		const schedule_entry_t start_entry = schedule->at(start_index-1);
 
 		// We calculate the connection weight by both route cost and journey time,
 		// because it depends on the routing configuration for the goods category.
@@ -1386,7 +1386,7 @@ sint32 haltestelle_t::rebuild_connections()
 		uint8 interval = 0;
 		for(  uint8 j=0;  j<schedule->get_count();  ++j  ) {
 			const uint8 current_entry_index = (start_index+j)%schedule->get_count();
-			const schedule_entry_t current_entry = schedule->entries[current_entry_index];
+			const schedule_entry_t current_entry = schedule->at(current_entry_index);
 			halthandle_t current_halt = get_stoppable_halt(current_entry.pos, owner );
 			if(  !current_halt.is_bound()  ) {
 				// ignore way points.
@@ -3773,8 +3773,8 @@ bool haltestelle_t::add_grund(grund_t *gr, bool relink_factories)
 			FOR(  vector_tpl<linehandle_t>, const j, check_line  ) {
 				// only add unknown lines
 				if(  !registered_lines.is_contained(j)  &&  j->count_convoys() > 0  ) {
-					FOR(  minivec_tpl<schedule_entry_t>, const& k, j->get_schedule()->entries  ) {
-						if(  get_stoppable_halt(k.pos, player) == self  ) {
+					for(const schedule_entry_t* k = j->get_schedule()->begin(); k != j->get_schedule()->end(); ++k) {
+						if(  get_stoppable_halt(k->pos, player) == self  ) {
 							registered_lines.append(j);
 							break;
 						}
@@ -3788,8 +3788,8 @@ bool haltestelle_t::add_grund(grund_t *gr, bool relink_factories)
 		// only check lineless convoys which have matching ownership and which are not yet registered
 		if(  !cnv->get_line().is_bound()  &&  (public_halt  ||  cnv->get_owner()==get_owner())  &&  !registered_convoys.is_contained(cnv)  ) {
 			if(  const schedule_t *const schedule = cnv->get_schedule()  ) {
-				FOR(minivec_tpl<schedule_entry_t>, const& k, schedule->entries) {
-					if (get_stoppable_halt(k.pos, cnv->get_owner()) == self) {
+				for(const schedule_entry_t* k = schedule->begin(); k != schedule->end(); ++k) {
+					if (get_stoppable_halt(k->pos, cnv->get_owner()) == self) {
 						registered_convoys.append(cnv);
 						break;
 					}
@@ -3897,8 +3897,9 @@ bool haltestelle_t::rem_grund(grund_t *gr)
 	// remove lines eventually
 	for(  size_t j = registered_lines.get_count();  j-- != 0;  ) {
 		bool ok = false;
-		FOR(  minivec_tpl<schedule_entry_t>, const& k, registered_lines[j]->get_schedule()->entries  ) {
-			if(  get_stoppable_halt(k.pos, registered_lines[j]->get_owner()) == self  ) {
+		const schedule_t* schedule = registered_lines[j]->get_schedule();
+		for(const schedule_entry_t* k = schedule->begin(); k != schedule->end(); ++k) {
+			if(  get_stoppable_halt(k->pos, registered_lines[j]->get_owner()) == self  ) {
 				ok = true;
 				break;
 			}
@@ -3913,8 +3914,9 @@ bool haltestelle_t::rem_grund(grund_t *gr)
 	// remove registered lineless convoys as well
 	for(  size_t j = registered_convoys.get_count();  j-- != 0;  ) {
 		bool ok = false;
-		FOR(  minivec_tpl<schedule_entry_t>, const& k, registered_convoys[j]->get_schedule()->entries  ) {
-			if(  get_stoppable_halt(k.pos, registered_convoys[j]->get_owner()) == self  ) {
+		const schedule_t* schedule = registered_convoys[j]->get_schedule();
+		for(const schedule_entry_t* k = schedule->begin(); k != schedule->end(); ++k) {
+			if(  get_stoppable_halt(k->pos, registered_convoys[j]->get_owner()) == self  ) {
 				ok = true;
 				break;
 			}
@@ -4242,8 +4244,8 @@ bool haltestelle_t::is_departure_booked(uint32 dep_tick, uint8 stop_index, lineh
 // Returns if the schedule entry whose journey time is not registered exists.
 bool unregistered_journey_time_exists(const schedule_t* schedule, player_t* player) {
 	for(uint8 i=1; i<schedule->get_count()+1; i++) {
-		const schedule_entry_t& this_entry = schedule->entries[i%schedule->get_count()];
-		const schedule_entry_t& prev_entry = schedule->entries[i-1];
+		const schedule_entry_t& this_entry = schedule->at(i%schedule->get_count());
+		const schedule_entry_t& prev_entry = schedule->at(i-1);
 		if(  
 			this_entry.get_median_journey_time()>0  || // valid record exists
 			this_entry.pos==prev_entry.pos  ||

--- a/simline.cc
+++ b/simline.cc
@@ -341,8 +341,8 @@ void simline_t::finish_rd()
 void simline_t::register_stops(schedule_t * schedule)
 {
 DBG_DEBUG("simline_t::register_stops()", "%d schedule entries in schedule %p", schedule->get_count(),schedule);
-	for(const schedule_entry_t* i = schedule->begin(); i != schedule->end(); ++i) {
-		halthandle_t const halt = haltestelle_t::get_stoppable_halt(i->pos, player);
+	FOR(minivec_tpl<schedule_entry_t>, const& i, schedule->get_entries()) {
+		halthandle_t const halt = haltestelle_t::get_stoppable_halt(i.pos, player);
 		if(halt.is_bound()) {
 //DBG_DEBUG("simline_t::register_stops()", "halt not null");
 			halt->add_line(self);
@@ -363,8 +363,8 @@ void simline_t::unregister_stops()
 
 void simline_t::unregister_stops(schedule_t * schedule)
 {
-	for(const schedule_entry_t* i = schedule->begin(); i != schedule->end(); ++i) {
-		halthandle_t const halt = haltestelle_t::get_stoppable_halt(i->pos, player);
+	FOR(minivec_tpl<schedule_entry_t>, const& i, schedule->get_entries()) {
+		halthandle_t const halt = haltestelle_t::get_stoppable_halt(i.pos, player);
 		if(halt.is_bound()) {
 			halt->remove_line(self);
 		}

--- a/simline.cc
+++ b/simline.cc
@@ -341,8 +341,8 @@ void simline_t::finish_rd()
 void simline_t::register_stops(schedule_t * schedule)
 {
 DBG_DEBUG("simline_t::register_stops()", "%d schedule entries in schedule %p", schedule->get_count(),schedule);
-	FOR(minivec_tpl<schedule_entry_t>, const& i, schedule->entries) {
-		halthandle_t const halt = haltestelle_t::get_stoppable_halt(i.pos, player);
+	for(const schedule_entry_t* i = schedule->begin(); i != schedule->end(); ++i) {
+		halthandle_t const halt = haltestelle_t::get_stoppable_halt(i->pos, player);
 		if(halt.is_bound()) {
 //DBG_DEBUG("simline_t::register_stops()", "halt not null");
 			halt->add_line(self);
@@ -363,8 +363,8 @@ void simline_t::unregister_stops()
 
 void simline_t::unregister_stops(schedule_t * schedule)
 {
-	FOR(minivec_tpl<schedule_entry_t>, const& i, schedule->entries) {
-		halthandle_t const halt = haltestelle_t::get_stoppable_halt(i.pos, player);
+	for(const schedule_entry_t* i = schedule->begin(); i != schedule->end(); ++i) {
+		halthandle_t const halt = haltestelle_t::get_stoppable_halt(i->pos, player);
 		if(halt.is_bound()) {
 			halt->remove_line(self);
 		}

--- a/simtool.cc
+++ b/simtool.cc
@@ -7092,10 +7092,11 @@ const char *tool_stop_mover_t::do_work( player_t *player, const koord3d &last_po
 					// check waytype
 					if(schedule  &&  schedule->is_stop_allowed(bd)) {
 						bool updated = false;
-						FOR(minivec_tpl<schedule_entry_t>, & k, schedule->entries) {
-							if ((catch_all_halt && haltestelle_t::get_stoppable_halt( k.pos, cnv->get_owner()) == last_halt) ||
-									old_platform.is_contained(k.pos)) {
-								k.pos   = pos;
+						for (schedule_entry_t *k = schedule->begin(); k != schedule->end(); k++) {
+							if ((catch_all_halt && haltestelle_t::get_stoppable_halt(k->pos, cnv->get_owner()) == last_halt) ||
+								old_platform.is_contained(k->pos))
+							{
+								k->pos = pos;
 								updated = true;
 							}
 						}
@@ -7127,11 +7128,11 @@ const char *tool_stop_mover_t::do_work( player_t *player, const koord3d &last_po
 				// check waytype
 				if(schedule->is_stop_allowed(bd)) {
 					bool updated = false;
-					FOR(minivec_tpl<schedule_entry_t>, & k, schedule->entries) {
+					for(schedule_entry_t* k = schedule->begin(); k != schedule->end(); k++) {
 						// ok!
-						if ((catch_all_halt && haltestelle_t::get_stoppable_halt( k.pos, line->get_owner()) == last_halt) ||
-								old_platform.is_contained(k.pos)) {
-							k.pos   = pos;
+						if ((catch_all_halt && haltestelle_t::get_stoppable_halt( k->pos, line->get_owner()) == last_halt) ||
+								old_platform.is_contained(k->pos)) {
+							k->pos   = pos;
 							updated = true;
 						}
 					}

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -867,8 +867,8 @@ void vehicle_t::remove_stale_cargo()
 
 			if(  tmp.get_zwischenziel().is_bound()  ) {
 				// the original halt exists, but does we still go there?
-				for(const schedule_entry_t* i = cnv->get_schedule()->begin(); i != cnv->get_schedule()->end(); ++i) {
-					if(  haltestelle_t::get_stoppable_halt( i->pos, cnv->get_owner()) == tmp.get_zwischenziel()  ) {
+				FOR(minivec_tpl<schedule_entry_t>, const& i, cnv->get_schedule()->get_entries()) {
+					if(  haltestelle_t::get_stoppable_halt( i.pos, cnv->get_owner()) == tmp.get_zwischenziel()  ) {
 						found = true;
 						break;
 					}

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -867,8 +867,8 @@ void vehicle_t::remove_stale_cargo()
 
 			if(  tmp.get_zwischenziel().is_bound()  ) {
 				// the original halt exists, but does we still go there?
-				FOR(minivec_tpl<schedule_entry_t>, const& i, cnv->get_schedule()->entries) {
-					if(  haltestelle_t::get_stoppable_halt( i.pos, cnv->get_owner()) == tmp.get_zwischenziel()  ) {
+				for(const schedule_entry_t* i = cnv->get_schedule()->begin(); i != cnv->get_schedule()->end(); ++i) {
+					if(  haltestelle_t::get_stoppable_halt( i->pos, cnv->get_owner()) == tmp.get_zwischenziel()  ) {
 						found = true;
 						break;
 					}
@@ -877,10 +877,10 @@ void vehicle_t::remove_stale_cargo()
 			if(  !found  ) {
 				// the target halt may have been joined or there is a closer one now, thus our original target is no longer valid
 				const int offset = cnv->get_schedule()->get_current_stop();
-				const int max_count = cnv->get_schedule()->entries.get_count();
+				const int max_count = cnv->get_schedule()->get_count();
 				for(  int i=0;  i<max_count;  i++  ) {
 					// try to unload on next stop
-					halthandle_t halt = haltestelle_t::get_stoppable_halt( cnv->get_schedule()->entries[ (i+offset)%max_count ].pos, cnv->get_owner() );
+					halthandle_t halt = haltestelle_t::get_stoppable_halt( cnv->get_schedule()->at( (i+offset)%max_count ).pos, cnv->get_owner() );
 					if(  halt.is_bound()  ) {
 						if(  halt->is_enabled(tmp.get_index())  ) {
 							// ok, lets change here, since goods are accepted here
@@ -3552,7 +3552,7 @@ bool rail_vehicle_t::check_longblock_signal(signal_t *sig, uint16 next_block, si
 		// now search
 		// search for route
 		uint16 len = welt->get_settings().get_advance_to_end() ? 8888 : cnv->get_tile_length();
-		bool success = target_rt.calc_route( welt, cur_pos, cnv->get_schedule()->entries[schedule_index].pos, this, speed_to_kmh(cnv->get_min_top_speed()), len );
+		bool success = target_rt.calc_route( welt, cur_pos, cnv->get_schedule()->at(schedule_index).pos, this, speed_to_kmh(cnv->get_min_top_speed()), len );
 		if(  target_rt.is_contained(get_pos())  ) {
 			// do not reserve route going through my current stop&
 			break;
@@ -4182,13 +4182,13 @@ bool rail_vehicle_t::can_couple(const route_t* route, uint16 start_index, uint16
 	sint16 idx = cnv->get_schedule()->get_current_stop();
 	bool stop_found = false;
 	do {
-		if(  !cnv->is_waypoint(cnv->get_schedule()->entries[idx].pos)  ) {
+		if(  !cnv->is_waypoint(cnv->get_schedule()->at(idx).pos)  ) {
 			stop_found = true;
 			break;
 		}
 		idx = (idx+1)%cnv->get_schedule()->get_count();
 	} while(  idx!=cnv->get_schedule()->get_current_stop()  );
-	if(  !stop_found  ||  cnv->get_schedule()->entries[idx].get_coupling_point()!=2  ) {
+	if(  !stop_found  ||  cnv->get_schedule()->at(idx).get_coupling_point()!=2  ) {
 		// all schedule entries are waypoint or the next stop point is not a coupling point.
 		cnv->unset_convoi_coupling_in_progress();
 		return false;


### PR DESCRIPTION
This PR makes `schedule_t::entries` private and adds the access methods, for improving the debuggability and make it easy to expand.

<s>TODO: check if the change on `script/api_param.cc` works.</s>