### PR TITLE
no_load and no_unload action update

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -3715,9 +3715,14 @@ void calc_reachable_halts(vector_tpl<haltestelle_t::reachable_halt_t>& reachable
 		const uint8 wrap_i = (i + line_schedule_current_index) % line_schedule_count;
 
 		const halthandle_t plan_halt = haltestelle_t::get_stoppable_halt(line_schedule->at(wrap_i).pos, owner);
-		if(plan_halt == current_halt) {
-			// we will come later here again ...
-			break;
+		if(  plan_halt == current_halt  ) {
+			if(  !line_schedule->at(wrap_i).is_no_load()  ) {
+				// we will come later here again ...
+				break;
+			} else {
+				// we will stop here again, but not load at that time.
+				continue;
+			}
 		}
 		else if(  !plan_halt.is_bound()  ||  line_schedule->at(wrap_i).is_no_unload()  ) {
 			// not a halt or set no_unload. no_unload -> we cannot unload the cargo there.
@@ -3821,7 +3826,12 @@ void convoi_t::hat_gehalten(halthandle_t halt, uint32 halt_length_in_vehicle_ste
 		}
 
 		// The total amount of goods which are loaded and unloaded
-		uint16 amount = v->unload_cargo(halt, next_depot  );
+		uint16 amount;
+		if(  !schedule->get_current_entry().is_no_unload() ) {
+			amount = v->unload_cargo(halt, next_depot  ||  schedule->get_current_entry().is_unload_all()  );
+		} else {
+			amount = 0;
+		}
 
 		const uint16 capacity_left = v->get_cargo_max() - v->get_total_cargo();
 

--- a/simhalt.cc
+++ b/simhalt.cc
@@ -1403,7 +1403,7 @@ sint32 haltestelle_t::rebuild_connections()
 						previous_halt[catg_index] = self;
 					}
 				}
-				// reset aggregate weight and no_load_section
+				// reset aggregate weight
 				aggregate_weight_jt = estimated_waiting_ticks(schedule, current_entry_index) - current_entry.get_median_convoy_stopping_time();
 				aggregate_weight_rc = WEIGHT_WAIT;
 			 	force_transfer_search |= (current_entry.is_unload_all()  ||  current_entry.is_no_load()  ||  current_entry.is_no_unload());

--- a/simhalt.cc
+++ b/simhalt.cc
@@ -1407,7 +1407,6 @@ sint32 haltestelle_t::rebuild_connections()
 				aggregate_weight_jt = estimated_waiting_ticks(schedule, current_entry_index) - current_entry.get_median_convoy_stopping_time();
 				aggregate_weight_rc = WEIGHT_WAIT;
 			 	force_transfer_search |= (current_entry.is_unload_all()  ||  current_entry.is_no_load()  ||  current_entry.is_no_unload());
-				no_load_section = current_entry.is_no_load();
 				interval = 0;
 				continue;
 			}


### PR DESCRIPTION
スケジュールにおいてno_load、no_unload、unload_allを押した際の挙動を改善しました
・同じ駅に複数回停車するスケジュールにおいて、一度no_loadではない状態で駅に停車していた場合、別の停車時にno_loadでも旅客経路が生成されるよう修正
・同じ駅に複数回停車する編成において、次のその駅の停車時にno_loadが設定されていた場合はさらにその先の駅まで乗車するように変更(次のその駅の停車時がno_loadではない場合は従来通りそれ以降の駅へ行く客は乗車しない)
・停車駅がno_unloadの場合、車両から下車しないように修正
・停車駅がunload_allの場合、車両から全員下車するように修正