### PR TITLE
tram_wt can be laid over other tracks

### DIFF
--- a/bauer/brueckenbauer.cc
+++ b/bauer/brueckenbauer.cc
@@ -189,7 +189,7 @@ const char *check_tile( const grund_t *gr, const player_t *player, waytype_t wt,
 				// not our way
 				return "Das Feld gehoert\neinem anderen Spieler\n";
 			}
-			if(  !gr->ist_uebergang()  ) {
+			if(  !gr->get_crossing()  ) {
 				// If road and tram, we have to check both ribis.
 				ribi = gr->get_weg_nr(0)->get_ribi_unmasked() | gr->get_weg_nr(1)->get_ribi_unmasked();
 			}

--- a/bauer/wegbauer.cc
+++ b/bauer/wegbauer.cc
@@ -320,9 +320,9 @@ void way_builder_t::fill_menu(tool_selector_t *tool_selector, const waytype_t wt
 
 /** allow for railroad crossing
  */
-bool way_builder_t::check_crossing(const koord zv, const grund_t *bd, waytype_t wtyp0, const player_t *player) const
+bool way_builder_t::check_crossing(const koord zv, const grund_t *bd, const way_desc_t *desc, const player_t *player) const
 {
-	const waytype_t wtyp = wtyp0==tram_wt ? track_wt : wtyp0;
+	const waytype_t wtyp = desc->get_waytype();
 	// nothing to cross here
 	if (!bd->hat_wege()) {
 		return true;
@@ -343,8 +343,7 @@ bool way_builder_t::check_crossing(const koord zv, const grund_t *bd, waytype_t 
 		}
 	}
 	// special case: tram track on road
-	if ( (wtyp==road_wt  &&  w->get_waytype()==track_wt  &&  w->get_desc()->get_styp()==type_tram)  ||
-		     (wtyp0==tram_wt  &&  w->get_waytype()==road_wt) ) {
+	if(!w->needs_crossing(desc)) {
 		return true;
 	}
 	// right owner of the other way
@@ -674,7 +673,7 @@ bool way_builder_t::is_allowed_step(const grund_t *from, const grund_t *to, sint
 	// universal check for crossings
 	if (to!=from  &&  (bautyp&bautyp_mask)!=leitung) {
 		waytype_t const wtyp = (bautyp == river) ? water_wt : (waytype_t)(bautyp & bautyp_mask);
-		if(!check_crossing(zv,to,wtyp,player_builder)  ||  !check_crossing(-zv,from,wtyp,player_builder)) {
+		if(!check_crossing(zv,to,desc,player_builder)  ||  !check_crossing(-zv,from, desc,player_builder)) {
 			return false;
 		}
 	}
@@ -759,20 +758,22 @@ bool way_builder_t::is_allowed_step(const grund_t *from, const grund_t *to, sint
 			// tram track allowed in road tunnels, but only along existing roads / tracks
 			if(from!=to) {
 				if(from->ist_tunnel()) {
-					const ribi_t::ribi ribi = from->get_weg_ribi_unmasked(road_wt)  |  from->get_weg_ribi_unmasked(track_wt)  |  ribi_t::doubles(ribi_type(from->get_grund_hang()));
+					dbg->message("way_builder_t::is_allowed_step()","%i,%i,%i is in the tunnel",from->get_pos().x,from->get_pos().y,from->get_pos().z);
+					const ribi_t::ribi ribi = from->get_weg_ribi_unmasked(road_wt)  |  from->get_weg_ribi_unmasked(track_wt)  |  from->get_weg_ribi_unmasked(monorail_wt)  |  from->get_weg_ribi_unmasked(maglev_wt)  |  from->get_weg_ribi_unmasked(narrowgauge_wt)  |  ribi_t::doubles(ribi_type(from->get_grund_hang()));
 					ok = ok && ((ribi & ribi_type(zv))==ribi_type(zv));
 				}
 				if(to->ist_tunnel()) {
-					const ribi_t::ribi ribi = to->get_weg_ribi_unmasked(road_wt)  |  to->get_weg_ribi_unmasked(track_wt)  |  ribi_t::doubles(ribi_type(to->get_grund_hang()));
+					dbg->message("way_builder_t::is_allowed_step()","%i,%i,%i is in the tunnel",to->get_pos().x,to->get_pos().y,to->get_pos().z);
+					const ribi_t::ribi ribi = to->get_weg_ribi_unmasked(road_wt)  |  to->get_weg_ribi_unmasked(track_wt)  |  to->get_weg_ribi_unmasked(monorail_wt)  |  to->get_weg_ribi_unmasked(maglev_wt)  |  to->get_weg_ribi_unmasked(narrowgauge_wt)  |  ribi_t::doubles(ribi_type(to->get_grund_hang()));
 					ok = ok && ((ribi & ribi_type(-zv))==ribi_type(-zv));
 				}
 			}
 			if(ok) {
 				// calculate costs
 				*costs = s.way_count_straight;
-				if (!to->hat_weg(track_wt)) *costs += 1; // only prefer existing rails a little
+				if (!to->hat_weg(track_wt)) { *costs += 1; } // only prefer existing rails a little
 				// prefer own track
-				if(to->hat_weg(road_wt)) {
+				else {
 					*costs += s.way_count_straight;
 				}
 				if(to->get_weg_hang()!=0  &&  !to_flat) {
@@ -2667,7 +2668,9 @@ void way_builder_t::build_road()
 				str->set_gehweg(add_sidewalk);
 				player_t::add_maintenance( player_builder, str->get_desc()->get_maintenance(), str->get_desc()->get_finance_waytype());
 				str->set_owner(player_builder);
-				upgrade_crossing_if_needed(gr);
+				if (crossing_t* crossing = gr->get_crossing()) {
+					crossing->finish_rd();
+				}
 			}
 		}
 		else {
@@ -2735,8 +2738,8 @@ void way_builder_t::build_track()
 				}
 
 				// build tram track over crossing -> remove crossing
-				if(  gr->has_two_ways()  &&  desc->get_styp()==type_tram  &&  weg->get_desc()->get_styp() != type_tram  &&  gr->hat_weg(waytype_t::road_wt)  ) {
-					if(  crossing_t *cr = gr->find<crossing_t>(2)  ) {
+				if(  gr->has_two_ways()  &&  (desc->get_styp() == type_tram  ||  weg->get_desc()->get_styp() == type_tram)  ) {
+					if(  crossing_t *cr = gr->get_crossing()  ) {
 						// change to tram track
 						cr->mark_image_dirty( cr->get_image(), 0);
 						cr->cleanup(player_builder);
@@ -2769,7 +2772,9 @@ void way_builder_t::build_track()
 					weg->set_owner(player_builder);
 					// respect speed limit of crossing
 					weg->count_sign();
-					upgrade_crossing_if_needed(gr);
+					if (crossing_t* crossing = gr->get_crossing()) {
+						crossing->finish_rd();
+					}
 				}
 			}
 			else {
@@ -3152,12 +3157,3 @@ void way_builder_t::update_ribi_mask_oneway(strasse_t* str, uint32 i) {
 }
 
 
-void way_builder_t::upgrade_crossing_if_needed( const grund_t* gr )
-{
-	crossing_t* crossing = gr->find<crossing_t>();
-	if(  !gr->ist_uebergang()  ||  !crossing  ) {
-		// A crossing does not exist on the given tile.
-		return;
-	}
-	crossing->finish_rd();
-}

--- a/bauer/wegbauer.cc
+++ b/bauer/wegbauer.cc
@@ -758,12 +758,10 @@ bool way_builder_t::is_allowed_step(const grund_t *from, const grund_t *to, sint
 			// tram track allowed in road tunnels, but only along existing roads / tracks
 			if(from!=to) {
 				if(from->ist_tunnel()) {
-					dbg->message("way_builder_t::is_allowed_step()","%i,%i,%i is in the tunnel",from->get_pos().x,from->get_pos().y,from->get_pos().z);
 					const ribi_t::ribi ribi = from->get_weg_ribi_unmasked(road_wt)  |  from->get_weg_ribi_unmasked(track_wt)  |  from->get_weg_ribi_unmasked(monorail_wt)  |  from->get_weg_ribi_unmasked(maglev_wt)  |  from->get_weg_ribi_unmasked(narrowgauge_wt)  |  ribi_t::doubles(ribi_type(from->get_grund_hang()));
 					ok = ok && ((ribi & ribi_type(zv))==ribi_type(zv));
 				}
 				if(to->ist_tunnel()) {
-					dbg->message("way_builder_t::is_allowed_step()","%i,%i,%i is in the tunnel",to->get_pos().x,to->get_pos().y,to->get_pos().z);
 					const ribi_t::ribi ribi = to->get_weg_ribi_unmasked(road_wt)  |  to->get_weg_ribi_unmasked(track_wt)  |  to->get_weg_ribi_unmasked(monorail_wt)  |  to->get_weg_ribi_unmasked(maglev_wt)  |  to->get_weg_ribi_unmasked(narrowgauge_wt)  |  ribi_t::doubles(ribi_type(to->get_grund_hang()));
 					ok = ok && ((ribi & ribi_type(-zv))==ribi_type(-zv));
 				}

--- a/bauer/wegbauer.h
+++ b/bauer/wegbauer.h
@@ -184,8 +184,6 @@ private:
 	void build_powerline();
 	void build_river();
 
-	void upgrade_crossing_if_needed(const grund_t*);
-
 	uint32 calc_distance( const koord3d &pos, const koord3d &mini, const koord3d &maxi );
 
 	void update_ribi_mask_oneway(strasse_t* str, uint32 i);
@@ -232,7 +230,7 @@ public:
 	*/
 	sint64 calc_costs();
 
-	bool check_crossing(const koord zv, const grund_t *bd,waytype_t wtyp, const player_t *player) const;
+	bool check_crossing(const koord zv, const grund_t *bd, const way_desc_t *desc, const player_t *player) const;
 	bool check_powerline(const koord zv, const grund_t *bd) const;
 	// allowed owner?
 	bool check_owner( const player_t *player1, const player_t *player2 ) const;

--- a/boden/boden.cc
+++ b/boden/boden.cc
@@ -108,7 +108,7 @@ void boden_t::rdwr(loadsave_t *file)
 
 const char *boden_t::get_name() const
 {
-	if(  ist_uebergang()  ) {
+	if(  get_crossing()  ) {
 		return "Kreuzung";
 	}
 	else if(  hat_wege()  ) {

--- a/boden/grund.cc
+++ b/boden/grund.cc
@@ -448,19 +448,34 @@ void grund_t::rdwr(loadsave_t *file)
 	// all objects on this tile
 	objlist.rdwr(file, get_pos());
 
-	// need to add a crossing for old games ...
-	if (file->is_loading()  &&  ist_uebergang()  &&  !find<crossing_t>(2)) {
-		const crossing_desc_t *cr_desc = crossing_logic_t::get_crossing( ((weg_t *)obj_bei(0))->get_waytype(), ((weg_t *)obj_bei(1))->get_waytype(), ((weg_t *)obj_bei(0))->get_max_speed(), ((weg_t *)obj_bei(1))->get_max_speed(), 0 );
-		if(cr_desc==NULL) {
-			dbg->warning("crossing_t::rdwr()","requested for waytypes %i and %i not available, try to load object without timeline", ((weg_t *)obj_bei(0))->get_waytype(), ((weg_t *)obj_bei(1))->get_waytype() );
-			cr_desc = crossing_logic_t::get_crossing( ((weg_t *)obj_bei(0))->get_waytype(), ((weg_t *)obj_bei(1))->get_waytype(), 0, 0, 0);
+	// need to add/remove crossing for old games and init logic ...
+	if (file->is_loading()  &&  has_two_ways()) {
+		const weg_t* w1 = ((weg_t*)obj_bei(0));
+		const weg_t* w2 = ((weg_t*)obj_bei(1));
+		if(w1->needs_crossing(w2->get_desc())){
+			if (crossing_t* cr = get_crossing()) {
+				cr->finish_rd();
+			}
+			else {
+				const crossing_desc_t* cr_desc = crossing_logic_t::get_crossing(w1->get_waytype(), w2->get_waytype(), w1->get_max_speed(), w2->get_max_speed(), 0);
+				if (cr_desc == NULL) {
+					dbg->warning("crossing_t::rdwr()", "requested for waytypes %i and %i not available, try to load object without timeline", w1->get_waytype(), w2->get_waytype());
+					cr_desc = crossing_logic_t::get_crossing(w1->get_waytype(), w2->get_waytype(), 0, 0, 0);
+				}
+				if (cr_desc == 0) {
+					dbg->fatal("crossing_t::crossing_t()", "requested for waytypes %i and %i but nothing defined!", w1->get_waytype(), w2->get_waytype());
+				}
+				cr = new crossing_t(w1->get_owner(), pos, cr_desc, ribi_t::is_straight_ns(get_weg(cr_desc->get_waytype(1))->get_ribi_unmasked()));
+				objlist.add(cr);
+				cr->finish_rd(); // or else not multithred safe!
+			}
 		}
-		if(cr_desc==0) {
-			dbg->fatal("crossing_t::crossing_t()","requested for waytypes %i and %i but nothing defined!", ((weg_t *)obj_bei(0))->get_waytype(), ((weg_t *)obj_bei(1))->get_waytype() );
+		else {
+			if (crossing_t* cr = get_crossing()) {
+				objlist.remove(cr);
+				delete cr;
+			}
 		}
-		crossing_t *cr = new crossing_t(obj_bei(0)->get_owner(), pos, cr_desc, ribi_t::is_straight_ns(get_weg(cr_desc->get_waytype(1))->get_ribi_unmasked()) );
-		objlist.add( cr );
-		crossing_logic_t::add( cr, crossing_logic_t::CROSSING_INVALID );
 	}
 }
 
@@ -625,8 +640,7 @@ void grund_t::info(cbuffer_t& buf) const
 				buf.append("\n");
 				obj_bei(1)->info(buf);
 				buf.append("\n");
-				if(ist_uebergang()) {
-					crossing_t* crossing = find<crossing_t>(2);
+				if(crossing_t* crossing = get_crossing()) {
 					crossing->info(buf);
 				}
 			}
@@ -1905,8 +1919,8 @@ sint64 grund_t::neuen_weg_bauen(weg_t *weg, ribi_t::ribi ribi, player_t *player)
 			weg->set_ribi(ribi);
 			weg->set_pos(pos);
 			flags |= has_way2;
-			if(ist_uebergang()) {
-				// no tram => crossing needed!
+			if (weg->needs_crossing(other->get_desc())) {
+				//crossing needed!
 				waytype_t w2 =  other->get_waytype();
 				const crossing_desc_t *cr_desc = crossing_logic_t::get_crossing( weg->get_waytype(), w2, weg->get_max_speed(), other->get_max_speed(), welt->get_timeline_year_month() );
 				if(cr_desc==0) {
@@ -1914,6 +1928,7 @@ sint64 grund_t::neuen_weg_bauen(weg_t *weg, ribi_t::ribi ribi, player_t *player)
 				}
 				crossing_t *cr = new crossing_t(obj_bei(0)->get_owner(), pos, cr_desc, ribi_t::is_straight_ns(get_weg(cr_desc->get_waytype(1))->get_ribi_unmasked()) );
 				objlist.add( cr );
+				crossing_logic_t::add(cr, crossing_logic_t::CROSSING_INVALID);
 				cr->finish_rd();
 			}
 		}

--- a/boden/grund.h
+++ b/boden/grund.h
@@ -15,6 +15,7 @@
 #include "../dataobj/objlist.h"
 #include "../display/clip_num.h"
 #include "wege/weg.h"
+#include "../obj/crossing.h"
 
 
 class player_t;
@@ -645,10 +646,10 @@ public:
 	weg_t *get_weg(waytype_t typ) const {
 		if (weg_t* const w = get_weg_nr(0)) {
 			const waytype_t wt = w->get_waytype();
-			if (wt > typ) {
-				// ways are ordered wrt to waytype
-				return NULL;
-			}
+			// if (wt > typ) {
+			// 	// ways are ordered wrt to waytype
+			// 	return NULL;
+			// }
 			if(wt == typ || (typ == any_wt && wt > 0)) {
 				return w;
 			}
@@ -710,10 +711,19 @@ public:
 	inline bool hat_wege() const { return (flags&(has_way1|has_way2))!=0;}
 
 	/**
-	* Kreuzen sich hier 2 verschiedene Wege?
-	* Strassenbahnschienen duerfen nicht als Kreuzung erkannt werden!
+	* Are two ways crossing here?
+	* To not discover trams, we look for the crossing object
 	*/
-	inline bool ist_uebergang() const { return (flags&has_way2)!=0  &&  ((weg_t *)objlist.bei(1))->get_desc()->get_styp()!=type_tram; }
+	inline crossing_t *get_crossing() const {
+		if (flags & has_way2) {
+			if (obj_t* obj = objlist.bei(2)) {
+				if (obj->get_typ() == obj_t::crossing) {
+					return static_cast<crossing_t*>(obj);
+				}
+			}
+		}
+		return NULL;
+	}
 
 	/**
 	* returns the vehicle of a convoi (if there)

--- a/boden/grund.h
+++ b/boden/grund.h
@@ -646,10 +646,6 @@ public:
 	weg_t *get_weg(waytype_t typ) const {
 		if (weg_t* const w = get_weg_nr(0)) {
 			const waytype_t wt = w->get_waytype();
-			// if (wt > typ) {
-			// 	// ways are ordered wrt to waytype
-			// 	return NULL;
-			// }
 			if(wt == typ || (typ == any_wt && wt > 0)) {
 				return w;
 			}

--- a/boden/wege/weg.cc
+++ b/boden/wege/weg.cc
@@ -164,6 +164,39 @@ weg_t::~weg_t()
 	}
 }
 
+bool weg_t::needs_crossing(const way_desc_t* other) const
+{
+	// certain way always needs crossing (or never)
+	switch (desc->get_waytype()) {
+		case powerline_wt:
+			return false;
+		case water_wt:
+		case air_wt:
+			return true;
+		default:
+			break;
+	}
+	switch (other->get_waytype()) {
+		case powerline_wt:
+			return false;
+		case water_wt:
+		case air_wt:
+			return true;
+		default:
+			break;
+	}
+	// only now we can check if there is a tramway involved
+	if (desc->get_styp() == type_tram) {
+		// we are tramway
+		return false;
+	}
+	if (other->get_styp() == type_tram) {
+		// other is tramway
+		return false;
+	}
+	// needs a crossing
+	return true;
+}
 
 void weg_t::rdwr(loadsave_t *file)
 {
@@ -359,10 +392,9 @@ void weg_t::count_sign()
 		max_speed = desc->get_topspeed(); // reset max_speed
 		uint8 i = 1;
 		// if there is a crossing, the start index is at least three ...
-		if(  gr->ist_uebergang()  ) {
+		if(  const crossing_t* cr = gr->get_crossing()  ) {
 			flags |= HAS_CROSSING;
 			i = 3;
-			const crossing_t* cr = gr->find<crossing_t>();
 			uint32 top_speed = cr->get_desc()->get_maxspeed( cr->get_desc()->get_waytype(0)==get_waytype() ? 0 : 1);
 			if(  top_speed < max_speed  ) {
 				max_speed = top_speed;

--- a/boden/wege/weg.h
+++ b/boden/wege/weg.h
@@ -122,6 +122,12 @@ public:
 	weg_t() : obj_no_info_t() { init(); }
 
 	virtual ~weg_t();
+	
+	/**
+	 * @returns true if a crossing is needed
+	 */
+	bool needs_crossing(const way_desc_t* other) const;
+
 
 #ifdef MULTI_THREAD
 	void lock_mutex();

--- a/dataobj/objlist.cc
+++ b/dataobj/objlist.cc
@@ -470,8 +470,23 @@ bool objlist_t::add(obj_t* new_obj)
 	if(pri==0) {
 		// check for other ways to keep order! (maximum is two ways per tile at the moment)
 		weg_t const* const w   = obj_cast<weg_t>(obj.some[0]);
-		uint8        const pos = w  &&  w->get_waytype() < static_cast<weg_t*>(new_obj)->get_waytype() ? 1 : 0;
-		intern_insert_at(new_obj, pos);
+		if (!w) {
+			// first way
+			intern_insert_at(new_obj, 0);
+			return true;
+		}
+		bool w_is_tram = w->get_desc()->get_styp() == type_tram;
+		bool new_is_tram = static_cast<weg_t*>(new_obj)->get_desc()->get_styp() == type_tram;
+		if(new_is_tram  &&  !w_is_tram) {
+			intern_insert_at(new_obj, 1);
+		}
+		else if(!new_is_tram  &&  w_is_tram) {
+			intern_insert_at(new_obj, 0);
+		}
+		else {
+			uint8 const pos = w && w->get_waytype() < static_cast<weg_t*>(new_obj)->get_waytype() ? 1 : 0;
+			intern_insert_at(new_obj, pos);
+		}
 		return true;
 	}
 

--- a/simcity.cc
+++ b/simcity.cc
@@ -3435,7 +3435,7 @@ bool stadt_t::build_road(const koord k, player_t* player_, bool forced)
 {
 	grund_t* bd = welt->lookup_kartenboden(k);
 
-	if (bd->get_typ() != grund_t::boden) {
+	if (!bd || bd->get_typ() != grund_t::boden) {
 		// not on water, monorails, foundations, tunnel or bridges
 		return false;
 	}

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -4696,12 +4696,12 @@ bool convoi_t::can_overtake(overtaker_t *other_overtaker, sint32 other_speed, si
 			if(  gr==NULL  ) {
 				return false;
 			}
-			// not overtaking on railroad crossings or normal crossings ...
-			if (gr->get_crossing()) {
-				return false;
-			}
 			strasse_t *str = (strasse_t*)gr->get_weg(road_wt);
 			if(  str==0  ) {
+				return false;
+			}
+			// not overtaking on railroad crossings or normal crossings ...
+			if(  gr->get_crossing() ) {
 				return false;
 			}
 			if(  ribi_t::is_threeway(str->get_ribi())  &&  overtaking_mode > oneway_mode  ) {
@@ -4815,15 +4815,11 @@ bool convoi_t::can_overtake(overtaker_t *other_overtaker, sint32 other_speed, si
 		pos_next = route.at(route_index++);
 		grund_t *gr = welt->lookup(pos);
 		// no ground, or slope => about
-		if(  gr==NULL || gr->get_crossing()  ) {
+		if(  gr==NULL  ) {
 			return false;
 		}
 		strasse_t *str = (strasse_t*)gr->get_weg(road_wt);
 		if(  str==NULL  ) {
-			return false;
-		}
-		if (ribi_t::is_threeway(str->get_ribi())) {
-			// no overtaking on normal way crossings ...
 			return false;
 		}
 		overtaking_mode_t overtaking_mode_loop = str->get_overtaking_mode();
@@ -4851,7 +4847,7 @@ bool convoi_t::can_overtake(overtaker_t *other_overtaker, sint32 other_speed, si
 			}
 		}
 		// not overtaking on railroad crossings or on normal crossings ...
-		if(  overtaking_mode_loop >= twoway_mode  ) {
+		if(  overtaking_mode_loop >= twoway_mode  &&  (gr->get_crossing()  ||  ribi_t::is_threeway(str->get_ribi()))  ) {
 			return false;
 		}
 		// street gets too slow (TODO: should be able to be correctly accounted for)

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -2569,8 +2569,7 @@ void convoi_t::vorfahren()
 				grund_t* gr = welt->lookup(v->get_pos());
 				if(gr) {
 					gr->obj_remove(v);
-					if(gr->ist_uebergang()) {
-						crossing_t *cr = gr->find<crossing_t>(2);
+					if(crossing_t *cr = gr->get_crossing()) {
 						cr->release_crossing(v);
 					}
 					// eventually unreserve this
@@ -2939,15 +2938,13 @@ void convoi_t::rdwr(loadsave_t *file)
 					state = INITIAL;
 				}
 				// add to blockstrecke
-				if(v->get_waytype()==track_wt  ||  v->get_waytype()==monorail_wt  ||  v->get_waytype()==maglev_wt  ||  v->get_waytype()==narrowgauge_wt) {
-					schiene_t* sch = (schiene_t*)gr->get_weg(v->get_waytype());
-					if(sch) {
-						sch->reserve(self,ribi_t::none);
-					}
-					// add to crossing
-					if(gr->ist_uebergang()) {
-						gr->find<crossing_t>()->add_to_crossing(v);
-					}
+				if(schiene_t* sch = dynamic_cast<schiene_t*>(gr->get_weg(v->get_waytype()))) {
+					sch->reserve(self,ribi_t::none);
+				}
+				// add to crossing
+				if(crossing_t *cr = gr->get_crossing()) {
+					cr->finish_rd();	// add crossing logic if needed (as finish_rd() was not yet processed
+					cr->add_to_crossing(v);
 				}
 				if(  gr->get_top()>253  ) {
 					dbg->warning( "convoi_t::rdwr()", "cannot put vehicle on ground at (%s)", gr->get_pos().get_str() );
@@ -4243,14 +4240,10 @@ void convoi_t::destroy()
 	for(  uint8 i = anz_vehikel;  i-- != 0;  ) {
 		if(  !fahr[i]->get_flag( obj_t::not_on_map )  ) {
 			// remove from rails/roads/crossings
-			grund_t *gr = welt->lookup(fahr[i]->get_pos());
 			fahr[i]->set_last( true );
+			fahr[i]->set_pos_next(koord3d::invalid);	// to removed from crossings and reservations
 			fahr[i]->leave_tile();
-			if(  gr  &&  gr->ist_uebergang()  ) {
-				gr->find<crossing_t>()->release_crossing(fahr[i]);
-			}
 			fahr[i]->set_flag( obj_t::not_on_map );
-
 		}
 		// no need to substract maintenance, since it is booked as running costs
 
@@ -4703,12 +4696,12 @@ bool convoi_t::can_overtake(overtaker_t *other_overtaker, sint32 other_speed, si
 			if(  gr==NULL  ) {
 				return false;
 			}
-			strasse_t *str = (strasse_t*)gr->get_weg(road_wt);
-			if(  str==0  ) {
+			// not overtaking on railroad crossings or normal crossings ...
+			if (gr->get_crossing()) {
 				return false;
 			}
-			// not overtaking on railroad crossings or normal crossings ...
-			if(  str->is_crossing() ) {
+			strasse_t *str = (strasse_t*)gr->get_weg(road_wt);
+			if(  str==0  ) {
 				return false;
 			}
 			if(  ribi_t::is_threeway(str->get_ribi())  &&  overtaking_mode > oneway_mode  ) {
@@ -4822,11 +4815,15 @@ bool convoi_t::can_overtake(overtaker_t *other_overtaker, sint32 other_speed, si
 		pos_next = route.at(route_index++);
 		grund_t *gr = welt->lookup(pos);
 		// no ground, or slope => about
-		if(  gr==NULL  ) {
+		if(  gr==NULL || gr->get_crossing()  ) {
 			return false;
 		}
 		strasse_t *str = (strasse_t*)gr->get_weg(road_wt);
 		if(  str==NULL  ) {
+			return false;
+		}
+		if (ribi_t::is_threeway(str->get_ribi())) {
+			// no overtaking on normal way crossings ...
 			return false;
 		}
 		overtaking_mode_t overtaking_mode_loop = str->get_overtaking_mode();
@@ -4854,7 +4851,7 @@ bool convoi_t::can_overtake(overtaker_t *other_overtaker, sint32 other_speed, si
 			}
 		}
 		// not overtaking on railroad crossings or on normal crossings ...
-		if(  overtaking_mode_loop >= twoway_mode  &&  (str->is_crossing()  ||  ribi_t::is_threeway(str->get_ribi()))  ) {
+		if(  overtaking_mode_loop >= twoway_mode  ) {
 			return false;
 		}
 		// street gets too slow (TODO: should be able to be correctly accounted for)
@@ -5240,7 +5237,7 @@ void convoi_t::calc_crossing_reservation() {
 	for(  uint32 i=route.get_count()-1;  i>0;  i--  ) {
 		const grund_t *gr = welt->lookup(route.at(i));
 		const schiene_t *sch1 = dynamic_cast<schiene_t*>(gr ? gr->get_weg(front()->get_waytype()) : NULL);
-		const crossing_t* cr = (sch1  &&  sch1->is_crossing()) ? gr->find<crossing_t>(2) : NULL;
+		const crossing_t* cr = (sch1  &&  gr->get_crossing()) ? gr->get_crossing() : NULL;
 		if(  !cr  ) {
 			// this tile is not a crossing.
 			continue;

--- a/simtool.cc
+++ b/simtool.cc
@@ -2749,7 +2749,7 @@ uint8 tool_build_way_t::is_valid_pos( player_t *player, const koord3d &pos, cons
 	grund_t *gr=welt->lookup(pos);
 	if(  gr  &&  slope_t::is_way(gr->get_weg_hang())  ) {
 		// ignore tunnel tiles (except road tunnel for tram track building ..)
-		if(  gr->get_typ() == grund_t::tunnelboden  &&  !gr->ist_karten_boden()  && !(desc->is_tram()  && gr->hat_weg(road_wt)) ) {
+		if(  gr->get_typ() == grund_t::tunnelboden  &&  !gr->ist_karten_boden()  && !( desc->is_tram()  && ( gr->hat_weg(road_wt) || gr->hat_weg(monorail_wt) || gr->hat_weg(maglev_wt) || gr->hat_weg(narrowgauge_wt) ) )  ) {
 			return 0;
 		}
 		bool const elevated = desc->get_styp() == type_elevated  &&  desc->get_wtyp() != air_wt;

--- a/vehicle/simroadtraffic.cc
+++ b/vehicle/simroadtraffic.cc
@@ -313,8 +313,8 @@ private_car_t::~private_car_t()
 {
 	// first: release crossing
 	grund_t *gr = welt->lookup(get_pos());
-	if(gr  &&  gr->ist_uebergang()) {
-		gr->find<crossing_t>(2)->release_crossing(this);
+	if(gr  &&  gr->get_crossing()) {
+		gr->get_crossing()->release_crossing(this);
 	}
 	
 	// unreserve tiles
@@ -709,14 +709,13 @@ bool private_car_t::ist_weg_frei(grund_t *gr)
 	overtaking_mode_t mode_of_start_point = str->get_overtaking_mode();
 	bool enter_passing_lane_from_side_road = false;
 	// check exit from crossings and intersections, allow to proceed after 4 consecutive
-	for(uint8 c=0; !obj   &&  (str->is_crossing()  ||  int_block)  &&  c<4; c++) {
+	for(uint8 c=0; !obj   &&  (gr->get_crossing()  ||  int_block)  &&  c<4; c++) {
 		if(  route[test_index]==koord3d::invalid  ) {
 			// coordinate is not determined. stop inspection.
 			break;
 		}
 		
-		if(  str->is_crossing()  ) {
-			crossing_t* cr = gr->find<crossing_t>(2);
+		if(  crossing_t* cr = gr->get_crossing()  ) {
 			if(  !cr->request_crossing(this)  ) {
 				// wait here
 				current_speed = 48;
@@ -1361,8 +1360,8 @@ void private_car_t::hop(grund_t* to)
 	route_index = (route_index+1)%welt->get_settings().get_citycar_max_look_forward();
 	pos_next = route[route_index];
 	enter_tile(to);
-	if(to->ist_uebergang()) {
-		to->find<crossing_t>(2)->add_to_crossing(this);
+	if(crossing_t* cr = to->get_crossing()) {
+		cr->add_to_crossing(this);
 	}
 }
 
@@ -1489,7 +1488,7 @@ bool private_car_t::can_overtake( overtaker_t *other_overtaker, sint32 other_spe
 			}
 			sint8 overtaking_mode = str->get_overtaking_mode();
 			// not overtaking on railroad crossings ...
-			if(  str->is_crossing() ) {
+			if(  gr->get_crossing() ) {
 				return false;
 			}
 			if(  ribi_t::is_threeway(str->get_ribi())  &&  overtaking_mode > oneway_mode  ) {
@@ -1577,7 +1576,7 @@ bool private_car_t::can_overtake( overtaker_t *other_overtaker, sint32 other_spe
 		}
 
 		// not overtaking on railroad crossings ...
-		if(  str->is_crossing() ) {
+		if(  gr->get_crossing() ) {
 			return false;
 		}
 

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -215,11 +215,24 @@ void vehicle_base_t::leave_tile()
 {
 	// first: release crossing
 	grund_t *gr = welt->lookup(get_pos());
-	if(  gr  &&  gr->ist_uebergang()  ) {
-		crossing_t *cr = gr->find<crossing_t>(2);
-		grund_t *gr2 = welt->lookup(pos_next);
-		if(  gr2==NULL  ||  gr2==gr  ||  !gr2->ist_uebergang()  ||  cr->get_logic()!=gr2->find<crossing_t>(2)->get_logic()  ) {
-			cr->release_crossing(this);
+	if (gr) {
+		if (crossing_t* cr = gr->get_crossing()) {
+			grund_t* gr2 = welt->lookup(pos_next);
+			bool release = gr2==NULL ||  gr2 == gr;
+			if (!release) {
+				// check if we stay on crossing
+				if (crossing_t* cr2 = gr2->get_crossing()) {
+					// only release if new crossing ahead
+					release = (cr->get_logic() != cr2->get_logic());
+				}
+			}
+			if (release) {
+				cr->release_crossing(this);
+			}
+			else {
+				// release when no longer a crossing
+				cr->release_crossing(this);
+			}
 		}
 	}
 
@@ -1266,8 +1279,8 @@ void vehicle_t::hop(grund_t* gr)
 		else{
 			speed_limit = kmh_to_speed( weg->get_max_speed() );
 		}
-		if(  weg->is_crossing()  ) {
-			gr->find<crossing_t>(2)->add_to_crossing(this);
+		if(  crossing_t* cr = gr->get_crossing()  ) {
+			cr->add_to_crossing(this);
 		}
 	}
 	else {
@@ -2335,7 +2348,8 @@ bool road_vehicle_t::can_enter_tile(const grund_t *gr, sint32 &restart_speed, ui
 		// no further check, when already entered a crossing (to allow leaving it)
 		if(  !second_check_count  ) {
 			const grund_t *gr_current = welt->lookup(get_pos());
-			if(  gr_current  &&  gr_current->ist_uebergang()  ) {
+			if(  gr_current  &&  gr_current->get_crossing()  ) {
+				// always allow to leave a crossing
 				return true;
 			}
 			// always allow to leave traffic lights (avoid vehicles stuck on crossings directly after though)
@@ -2512,9 +2526,8 @@ bool road_vehicle_t::can_enter_tile(const grund_t *gr, sint32 &restart_speed, ui
 		overtaking_mode_t mode_of_start_point = str->get_overtaking_mode();
 		bool enter_passing_lane_from_side_road = false;
 		// check exit from crossings and intersections, allow to proceed after 4 consecutive
-		while(  !obj   &&  (str->is_crossing()  ||  int_block)  &&  test_index < r.get_count()  &&  test_index < route_index + 4u  ) {
-			if(  str->is_crossing()  ) {
-				crossing_t* cr = gr->find<crossing_t>(2);
+		while(  !obj   &&  (int_block  ||  gr->get_crossing())  &&  test_index < r.get_count()  &&  test_index < route_index + 4u  ) {
+			if (crossing_t* cr = gr->get_crossing()) {
 				if(  !cr->request_crossing(this)  ) {
 					restart_speed = 0;
 					return false;
@@ -2634,7 +2647,7 @@ bool road_vehicle_t::can_enter_tile(const grund_t *gr, sint32 &restart_speed, ui
 			test_index++;
 		}
 
-		if(  obj  &&  test_index > route_index + 1u  &&  !str->is_crossing()  &&  !int_block  ) {
+		if(  obj  &&  test_index > route_index + 1u  &&  !gr->get_crossing()  &&  !int_block  ) {
 			// found a car blocking us after checking at least 1 intersection or crossing
 			// and the car is in a place we could stop. So if it can move, assume it will, so we will too.
 			// but check only upto 8 cars ahead to prevent infinite recursion on roundabouts.
@@ -3901,14 +3914,17 @@ bool rail_vehicle_t::can_enter_tile(const grund_t *gr, sint32 &restart_speed, ui
 	uint8 next_c_steps;
 	if(  cnv->get_state()==convoi_t::CAN_START  ||  cnv->get_state()==convoi_t::CAN_START_ONE_MONTH  ||  cnv->get_state()==convoi_t::CAN_START_TWO_MONTHS  ) {
 		// reserve first block at the start until the next signal
-		grund_t *gr_current = welt->lookup( get_pos() );
-		weg_t *w = gr_current ? gr_current->get_weg(get_waytype()) : NULL;
-		if(  w==NULL  ||  !(w->has_signal()  ||  w->is_crossing())  ) {
-			// free track => reserve up to next signal
-			bool block_reservation = block_reserver(cnv->get_route(), max(route_index,1)-1, next_signal, next_crossing, 0, true, false );
-			if(  block_reservation  ) {
-				cnv->set_next_stop_index( next_crossing<next_signal ? next_crossing : next_signal );
-				return true;
+		if (grund_t* gr_current = welt->lookup(get_pos())) {
+			if (weg_t* w = gr_current->get_weg(get_waytype())) {
+				if (!(w->has_signal()  ||  gr_current->get_crossing())) {
+					// free track => reserve up to next signal
+					if (!block_reserver(cnv->get_route(), max(route_index, 1) - 1, next_signal, next_crossing, 0, true, false)) {
+						restart_speed = 0;
+						return false;
+					}
+					cnv->set_next_stop_index(next_crossing < next_signal ? next_crossing : next_signal);
+					return true;
+				}
 			} else if(  can_couple(cnv->get_route(), route_index, next_coupling, next_c_steps)  &&  next_coupling!=route_t::INVALID_INDEX  ) {
 				cnv->set_next_coupling(next_coupling, next_c_steps);
 				cnv->set_next_stop_index(min(next_crossing,min(next_signal,next_coupling)));
@@ -3984,7 +4000,7 @@ bool rail_vehicle_t::can_enter_tile(const grund_t *gr, sint32 &restart_speed, ui
 		}
 		else if(  crossing_reservation_index[i].first <= route_index  &&  crossing_reservation_index[i].second > route_index  ) {
 			grund_t* cr_gr = welt->lookup(cnv->get_route()->at(crossing_reservation_index[i].second));
-			crossing_t* cr = cr_gr ? cr_gr->find<crossing_t>(2) : NULL;
+			crossing_t* cr = cr_gr ? cr_gr->get_crossing() : NULL;
 			if(  cr  ) {
 				cr->request_crossing(this);
 			}
@@ -4005,28 +4021,26 @@ bool rail_vehicle_t::can_enter_tile(const grund_t *gr, sint32 &restart_speed, ui
 		// Is a crossing?
 		// note: crossing and signal might exist on same tile
 		// so first check crossing
-		if(  sch1->is_crossing()  ) {
-			if(  crossing_t* cr = gr_next_block->find<crossing_t>(2)  ) {
-				// ok, here is a draw/turnbridge ...
-				bool ok = cr->request_crossing(this);
-				if(!ok) {
-					// cannot cross => wait here
-					restart_speed = 0;
-					return cnv->get_next_stop_index()>route_index+1;
+		if(crossing_t* cr = gr_next_block->get_crossing()) {
+			// ok, here is a draw/turnbridge ...
+			bool ok = cr->request_crossing(this);
+			if(!ok) {
+				// cannot cross => wait here
+				restart_speed = 0;
+				return cnv->get_next_stop_index()>route_index+1;
+			}
+			else if(  !sch1->has_signal()  ) {
+				// can reserve: find next place to do something and drive on
+				if(  block_pos == cnv->get_route()->back()  ) {
+					// is also last tile => go on ...
+					cnv->set_next_stop_index( route_t::INVALID_INDEX );
+					return true;
 				}
-				else if(  !sch1->has_signal()  ) {
-					// can reserve: find next place to do something and drive on
-					if(  block_pos == cnv->get_route()->back()  ) {
-						// is also last tile => go on ...
-						cnv->set_next_stop_index( route_t::INVALID_INDEX );
-						return true;
-					}
-					else if(  !block_reserver( cnv->get_route(), cnv->get_next_stop_index(), next_signal, next_crossing, 0, true, false )  ) {
-						dbg->error( "rail_vehicle_t::can_enter_tile()", "block not free but was reserved!" );
-						return false;
-					}
-					cnv->set_next_stop_index( next_crossing<next_signal ? next_crossing : next_signal );
+				else if(  !block_reserver( cnv->get_route(), cnv->get_next_stop_index(), next_signal, next_crossing, 0, true, false )  ) {
+					dbg->error( "rail_vehicle_t::can_enter_tile()", "block not free but was reserved!" );
+					return false;
 				}
+				cnv->set_next_stop_index( next_crossing<next_signal ? next_crossing : next_signal );
 			}
 		}
 
@@ -4117,7 +4131,16 @@ bool rail_vehicle_t::block_reserver(const route_t *route, uint16 start_index, ui
 				// use reserved_tiles instead of next_reservation_index to hold reservations.
 				cnv->reserve_pos(pos);
 			}
-			if(next_crossing_index==route_t::INVALID_INDEX  &&  sch1->is_crossing()) {
+			if (gr->has_two_ways()) {
+				// we may need to reserve the other way as well
+				if (schiene_t* sch0 = dynamic_cast<schiene_t*>(gr->get_weg_nr(gr->get_weg_nr(0) == sch1))) {
+					// the other way is reservable too => try to reserve it
+					if (!sch0->reserve(cnv->self, ribi_type(route->at(max(1u, i) - 1u), route->at(min(route->get_count() - 1u, i + 1u))))) {
+						success = false;
+					}
+				}
+			}
+			if(next_crossing_index==route_t::INVALID_INDEX  &&  gr->get_crossing()) {
 				next_crossing_index = i;
 			}
 		}
@@ -4140,8 +4163,8 @@ bool rail_vehicle_t::block_reserver(const route_t *route, uint16 start_index, ui
 					signal->set_state(roadsign_t::STATE_RED);
 				}
 			}
-			if(sch1->is_crossing()) {
-				gr->find<crossing_t>()->release_crossing(this);
+			if(crossing_t* cr = gr->get_crossing()) {
+				cr->release_crossing(this);
 			}
 		}
 	}
@@ -4156,10 +4179,18 @@ bool rail_vehicle_t::block_reserver(const route_t *route, uint16 start_index, ui
 	// free, in case of un-reserve or no success in reservation
 	if(!success) {
 		// free reservation
-		for ( int j=start_index; j<i; j++) {
-			schiene_t * sch1 = (schiene_t *)welt->lookup( route->at(j))->get_weg(get_waytype());
-			sch1->unreserve(cnv->self);
-			cnv->unreserve_pos(route->at(j));
+		for ( int j=start_index; j<i; j++) {if (grund_t * gr=welt->lookup(route->at(j))) {
+				schiene_t* sch1 = (schiene_t*)gr->get_weg(get_waytype());
+				if(sch1) {
+					sch1->unreserve(cnv->self);
+					if (gr->has_two_ways()) {
+						// we may need to reserve the other way as well
+						if (schiene_t* sch0 = dynamic_cast<schiene_t*>(gr->get_weg_nr(gr->get_weg_nr(0) == sch1))) {
+							sch0->unreserve(cnv->self);
+						}
+					}
+				}
+			}
 		}
 		cnv->set_next_reservation_index( start_index );
 		return false;
@@ -4291,6 +4322,13 @@ void rail_vehicle_t::leave_tile()
 					signal_t* sig = gr->find<signal_t>();
 					if(sig) {
 						sig->set_state(  roadsign_t::STATE_RED );
+					}
+				}
+				if (gr->has_two_ways()) {
+					// we may need to reserve the other way as well
+					if (schiene_t* sch1 = dynamic_cast<schiene_t*>(gr->get_weg_nr(gr->get_weg_nr(0) == sch0))) {
+						// the other way is reservable too => unreserve it
+						sch1->unreserve(this);
 					}
 				}
 			}

--- a/vehicle/simvehicle.h
+++ b/vehicle/simvehicle.h
@@ -167,7 +167,9 @@ public:
 
 	ribi_t::ribi get_90direction() const {return ribi_type(get_pos(), get_pos_next());}
 
-	koord3d get_pos_next() const {return pos_next;}
+	koord3d get_pos_next() const {return pos_next;}	
+	
+	void set_pos_next(koord3d pn) { pos_next = pn; }
 
 	waytype_t get_waytype() const OVERRIDE = 0;
 


### PR DESCRIPTION
併用軌道をほかの軌道(モノレール、ナローゲージ等)上に引けるようにしました

本機能はstandard版124.3.1までに導入された https://github.com/simutrans/simutrans/commit/e6dd3b46e9dcfd7bbf044817ff0d6238db406481
および https://github.com/simutrans/simutrans/commit/f7a9946c8d44d352cec11a63a274ebcfe491274c
を移植したものになります。

ただし、トンネル内でも併用軌道を敷設できるように変更しました