### PR TITLE
electric car can enter non-electric way when non-electric car coupled

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -5362,11 +5362,11 @@ bool convoi_t::is_waiting_for_coupling() const {
 }
 
 bool convoi_t::check_electrification() {
-	is_electric = false;
+	is_electric = true;
 	convoihandle_t c = find_most_parent_convoi();
 	while(  c.is_bound()  ) {
 		for(uint8 i=0;  i<c->get_vehicle_count();  i++) {
-			is_electric |= c->get_vehikel(i)->get_desc()->get_engine_type()==vehicle_desc_t::electric;
+			is_electric &= c->get_vehikel(i)->get_desc()->get_engine_type()==vehicle_desc_t::electric;
 		}
 		c = c->get_coupling_convoi();
 	}

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -5362,8 +5362,8 @@ bool convoi_t::is_waiting_for_coupling() const {
 }
 
 bool convoi_t::check_electrification() {
+	is_electric = true;
 	convoihandle_t c = find_most_parent_convoi();
-	is_electric = c->front()->get_desc()->get_engine_type()==vehicle_desc_t::electric;
 	while(  c.is_bound()  &&  is_electric  ) {
 		for(uint8 i=0;  i<c->get_vehicle_count();  i++) {
 			is_electric &= !(c->get_vehikel(i)->get_desc()->get_engine_type()!=vehicle_desc_t::electric && c->get_vehikel(i)->get_desc()->get_power()>0);

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -5366,7 +5366,7 @@ bool convoi_t::check_electrification() {
 	convoihandle_t c = find_most_parent_convoi();
 	while(  c.is_bound()  ) {
 		for(uint8 i=0;  i<c->get_vehicle_count();  i++) {
-			is_electric &= c->get_vehikel(i)->get_desc()->get_engine_type()==vehicle_desc_t::electric;
+			is_electric &= !(c->get_vehikel(i)->get_desc()->get_engine_type()!=vehicle_desc_t::electric && c->get_vehikel(i)->get_desc()->get_power()>0);
 		}
 		c = c->get_coupling_convoi();
 	}

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -5362,9 +5362,9 @@ bool convoi_t::is_waiting_for_coupling() const {
 }
 
 bool convoi_t::check_electrification() {
-	is_electric = true;
 	convoihandle_t c = find_most_parent_convoi();
-	while(  c.is_bound()  ) {
+	is_electric = c->front()->get_desc()->get_engine_type()==vehicle_desc_t::electric;
+	while(  c.is_bound()  &&  is_electric  ) {
 		for(uint8 i=0;  i<c->get_vehicle_count();  i++) {
 			is_electric &= !(c->get_vehikel(i)->get_desc()->get_engine_type()!=vehicle_desc_t::electric && c->get_vehikel(i)->get_desc()->get_power()>0);
 		}


### PR DESCRIPTION
電車以外の車両と連結中の場合、電車も非電化区間に直通できるようになります。
条件は以下の通りです。
・非電化の車両と連結
・上記の車両が出力が0より大きいとき
※非電化車両でも客車等では本機能は有効にならず、電化区間しか走行できません
※非電化区間でも電車の出力は有効のままです