### PR TITLE
BUG_FIX: do not press bt_wait_load when promote line

### DIFF
--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -883,11 +883,15 @@ DBG_MESSAGE("schedule_gui_t::action_triggered()","comp=%p combo=%p",comp,&line_s
 	}
 	else if(comp == &bt_wait_load) {
 		if (!schedule->empty()) {
-			schedule->at(schedule->get_current_stop()).waiting_time_shift = !bt_wait_load.pressed;
+			if( schedule->at(schedule->get_current_stop()).waiting_time_shift == 0 ) {
+				schedule->at(schedule->get_current_stop()).waiting_time_shift = (uint16)numimp_wait_load.get_value();
+			} else {
+				schedule->at(schedule->get_current_stop()).waiting_time_shift = 0;
+			}
 			update_selection();
 		}
 	}
-	else if(comp == &numimp_wait_load) {
+	else if(comp == &numimp_wait_load && bt_wait_load.pressed) {
 		if(!schedule->empty()) {
 			schedule->at(schedule->get_current_stop()).waiting_time_shift = (uint16)p.i;
 			update_selection();


### PR DESCRIPTION
積むまで待機を設定したスケジュールについて、路線作成ボタンを押したときに、bt_wait_loadが押されて同一路線判定されない問題を解消しました