### PR TITLE
BUG FIX: air_vehicle_t::target_height update for non_leading vehicle

### DIFF
--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -5375,7 +5375,6 @@ void air_vehicle_t::hop(grund_t* gr)
 		flying_height = front_air->get_flyingheight();
 		target_height = front_air->get_targetheight();
 		state = front_state;
-		dbg->message("air_vehicle_t::hop()","this vehicle's state is %i, height:%i, target:%i",state,flying_height,target_height);
 		
 		// hop to next tile
 		vehicle_t::hop(gr);

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -5373,7 +5373,9 @@ void air_vehicle_t::hop(grund_t* gr)
 		air_vehicle_t *const front_air =  dynamic_cast<air_vehicle_t*>(cnv->front());
 		front_air->get_event_index(front_state,dummy_takeoff,dummy_stopsearch,dummy_landing);
 		flying_height = front_air->get_flyingheight();
+		target_height = front_air->get_targetheight();
 		state = front_state;
+		dbg->message("air_vehicle_t::hop()","this vehicle's state is %i, height:%i, target:%i",state,flying_height,target_height);
 		
 		// hop to next tile
 		vehicle_t::hop(gr);

--- a/vehicle/simvehicle.h
+++ b/vehicle/simvehicle.h
@@ -802,6 +802,7 @@ public:
 	void rdwr_from_convoi(loadsave_t *file) OVERRIDE;
 
 	int get_flyingheight() const {return flying_height-get_hoff()-2;}
+	int get_targetheight() const {return target_height-get_hoff()-2;}
 
 	// image: when flying empty, on ground the plane
 	image_id get_image() const OVERRIDE {return !is_on_ground() ? IMG_EMPTY : image;}


### PR DESCRIPTION
先頭車両以外のtarget_heightの処理を改善しました