### PR TITLE
FIX : env_t::show_vehicle_states does not switch to 4 when using simple_tool

### DIFF
--- a/simtool.h
+++ b/simtool.h
@@ -1100,7 +1100,7 @@ public:
 	tool_vehicle_tooltips_t() : tool_t(TOOL_VEHICLE_TOOLTIPS | SIMPLE_TOOL) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate("Toggle vehicle tooltips"); }
 	bool init( player_t * ) OVERRIDE {
-		env_t::show_vehicle_states = (env_t::show_vehicle_states+1)%4;
+		env_t::show_vehicle_states = (env_t::show_vehicle_states+1)%5;
 		welt->set_dirty();
 		return false;
 	}


### PR DESCRIPTION
simple_tool[20]を使用した際に、新規追加された表示モードに入らない問題の修正