### PR TITLE
BUG FIX: schedule->at(i) overflow

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -4069,7 +4069,7 @@ void convoi_t::push_goods_waiting_time_if_needed() {
 	uint32 average_waiting_time = weighed_sum_waiting_time / total_goods_amount;
 	const linehandle_t line = get_line();
 	schedule_t* schedule_to_push = line.is_bound() ? line->get_schedule() : schedule;
-	uint8 push_stop=schedule_to_push->get_corresponding_entry_index(schedule,schedule->get_current_stop());
+	uint8 push_stop=max((sint16)schedule_to_push->get_corresponding_entry_index(schedule,schedule->get_current_stop()),0);
 	schedule_to_push->at(push_stop).push_waiting_time(average_waiting_time);
 
 	// update journey time window

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -4069,11 +4069,12 @@ void convoi_t::push_goods_waiting_time_if_needed() {
 	uint32 average_waiting_time = weighed_sum_waiting_time / total_goods_amount;
 	const linehandle_t line = get_line();
 	schedule_t* schedule_to_push = line.is_bound() ? line->get_schedule() : schedule;
-	if(  schedule_to_push->get_corresponding_entry_index(schedule,schedule->get_current_stop())<0  ) {
-		dbg->error("convoi_t::push_goods_waiting_time_if_needed() ", "Could not find a stop index %i for push waitinig time.",schedule->get_current_stop());
+	const sint16 current_index_on_line_schedule = schedule_to_push->get_corresponding_entry_index(schedule, schedule->get_current_stop());
+	if(  current_index_on_line_schedule<0  ) {
+		dbg->error("convoi_t::push_goods_waiting_time_if_needed() ", "Could not find a stop index %i for push waitinig time.", schedule->get_current_stop());
 		return;
 	}
-	schedule_to_push->at((uint8)schedule_to_push->get_corresponding_entry_index(schedule,schedule->get_current_stop())).push_waiting_time(average_waiting_time);
+	schedule_to_push->at((uint8)current_index_on_line_schedule).push_waiting_time(average_waiting_time);
 
 
 	// update journey time window

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -4069,8 +4069,12 @@ void convoi_t::push_goods_waiting_time_if_needed() {
 	uint32 average_waiting_time = weighed_sum_waiting_time / total_goods_amount;
 	const linehandle_t line = get_line();
 	schedule_t* schedule_to_push = line.is_bound() ? line->get_schedule() : schedule;
-	uint8 push_stop=max((sint16)schedule_to_push->get_corresponding_entry_index(schedule,schedule->get_current_stop()),0);
-	schedule_to_push->at(push_stop).push_waiting_time(average_waiting_time);
+	if(  schedule_to_push->get_corresponding_entry_index(schedule,schedule->get_current_stop())<0  ) {
+		dbg->error("convoi_t::push_goods_waiting_time_if_needed() ", "Could not find a stop index %i for push waitinig time.",schedule->get_current_stop());
+		return;
+	}
+	schedule_to_push->at((uint8)schedule_to_push->get_corresponding_entry_index(schedule,schedule->get_current_stop())).push_waiting_time(average_waiting_time);
+
 
 	// update journey time window
 	gui_goods_waiting_time_t* window = dynamic_cast<gui_goods_waiting_time_t*>(win_get_magic((ptrdiff_t)line.get_rep()));

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -4069,7 +4069,8 @@ void convoi_t::push_goods_waiting_time_if_needed() {
 	uint32 average_waiting_time = weighed_sum_waiting_time / total_goods_amount;
 	const linehandle_t line = get_line();
 	schedule_t* schedule_to_push = line.is_bound() ? line->get_schedule() : schedule;
-	schedule_to_push->at(schedule->get_current_stop()).push_waiting_time(average_waiting_time);
+	uint8 push_stop=schedule_to_push->get_corresponding_entry_index(schedule,schedule->get_current_stop());
+	schedule_to_push->at(push_stop).push_waiting_time(average_waiting_time);
 
 	// update journey time window
 	gui_goods_waiting_time_t* window = dynamic_cast<gui_goods_waiting_time_t*>(win_get_magic((ptrdiff_t)line.get_rep()));


### PR DESCRIPTION
convoi_t::push_goods_waiting_time_if_needed() 内において、schedule->at(i) が不適切な値を示す場合があり、クラッシュしていました。
当該箇所を特定し修正しました。