### PR TITLE
FIX: no_loadやunload_all使用時に停車駅のコネクションが張られなくなる問題

### DIFF
--- a/simhalt.cc
+++ b/simhalt.cc
@@ -1407,6 +1407,9 @@ sint32 haltestelle_t::rebuild_connections()
 				aggregate_weight_jt = estimated_waiting_ticks(schedule, current_entry_index) - current_entry.get_median_convoy_stopping_time();
 				aggregate_weight_rc = WEIGHT_WAIT;
 			 	force_transfer_search |= (current_entry.is_unload_all()  ||  current_entry.is_no_load()  ||  current_entry.is_no_unload());
+				// If loading is allowed at somewhere by here, we still need to connect the further halts.
+				// Reset no_load_section to false in case that we can load here.
+				no_load_section &= current_entry.is_no_load();
 				interval = 0;
 				continue;
 			}


### PR DESCRIPTION
原因: https://github.com/teamhimeh/simutrans/pull/91

no_loadやunload_allを使用した時に、`haltestelle_t::rebuild_connections` でコネクションが張られなくなる問題を修正します。

具体例: スケジュールが次のようになっていて、C駅のコネクションを計算する時

```
1) A
2) B
3) C <-自駅
4) D
5) E (A) <- 全員降車
6) D
7) C <-自駅
8) B
```

E駅に全員降車が設定されており、 `no_load_section` がtrueになる。 `no_load_section` は7番のエントリでリセットされていなければならないが、リセットされていなかったためC駅からB, A駅に到達ができなくなっていた。