### PR TITLE
do not reserve departure slot if coupling not done yet

### DIFF
--- a/dataobj/schedule.cc
+++ b/dataobj/schedule.cc
@@ -325,6 +325,13 @@ void schedule_t::rdwr(loadsave_t *file)
 					file->rdwr_long(entries[i].convoy_stopping_time[j]);
 				}
 			}
+			if(file->get_OTRP_version()<45) {
+				// before OTRP v45, do not use minimum_load when wait_for_time
+				if(entries[i].get_wait_for_time()) {
+					entries[i].minimum_loading = 0;
+					entries[i].waiting_time_shift = 0;
+				}
+			}
 		}
 	}
 	if(file->is_loading()) {

--- a/dataobj/schedule_entry.h
+++ b/dataobj/schedule_entry.h
@@ -49,7 +49,7 @@ public:
 		TRANSFER_INTERVAL = 1U << 7,
 		REVERSE_CONVOY	  = 1U << 8, // convoy reverses the order of its vehicles.
 		REVERSE_COUPLING  = 1U << 9, // The convoy reverses the parent-child relationship of the convoy coupling.
-		WAIT_LOAD_LEVEL   = 1U << 10,// Do not leave stop until load level condition satisfied even if wait_for_time comming.
+		WAIT_LOAD_COND    = 1U << 10,// Do not leave stop until load level condition satisfied even if wait_for_time comming.
 	};
 
 	/**
@@ -141,8 +141,8 @@ public:
 	void set_reverse_convoi_coupling(bool y) { y ? stop_flags |= REVERSE_COUPLING : stop_flags &= ~REVERSE_COUPLING; }
 	uint16 get_stop_flags() const { return stop_flags; }
 	void set_stop_flags(uint16 f) { stop_flags = f; }
-	void set_wait_load_level(bool y) {y? stop_flags|= WAIT_LOAD_LEVEL : stop_flags &= ~WAIT_LOAD_LEVEL; }
-	bool is_wait_load_level() const {return (stop_flags&WAIT_LOAD_LEVEL) ; }
+	void set_wait_load_cond(bool y) {y? stop_flags|= WAIT_LOAD_COND : stop_flags &= ~WAIT_LOAD_COND; }
+	bool is_wait_load_cond() const {return (stop_flags&WAIT_LOAD_COND) ; }
 
 	void set_spacing(uint16 a, uint16 b, uint16 c) {
 		spacing = a;

--- a/dataobj/schedule_entry.h
+++ b/dataobj/schedule_entry.h
@@ -49,7 +49,7 @@ public:
 		TRANSFER_INTERVAL = 1U << 7,
 		REVERSE_CONVOY	  = 1U << 8, // convoy reverses the order of its vehicles.
 		REVERSE_COUPLING  = 1U << 9, // The convoy reverses the parent-child relationship of the convoy coupling.
-		WAIT_LOAD_COND    = 1U << 10,// Do not leave stop until load level condition satisfied even if wait_for_time comming.
+		WAIT_COUPLING_DONE= 1U << 10,// Do not leave stop until load level condition satisfied even if wait_for_time comming.
 	};
 
 	/**
@@ -141,8 +141,8 @@ public:
 	void set_reverse_convoi_coupling(bool y) { y ? stop_flags |= REVERSE_COUPLING : stop_flags &= ~REVERSE_COUPLING; }
 	uint16 get_stop_flags() const { return stop_flags; }
 	void set_stop_flags(uint16 f) { stop_flags = f; }
-	void set_wait_load_cond(bool y) {y? stop_flags|= WAIT_LOAD_COND : stop_flags &= ~WAIT_LOAD_COND; }
-	bool is_wait_load_cond() const {return (stop_flags&WAIT_LOAD_COND) ; }
+	void set_wait_coupling_done(bool y) {y? stop_flags|= WAIT_COUPLING_DONE : stop_flags &= ~WAIT_COUPLING_DONE; }
+	bool is_wait_coupling_done() const {return (stop_flags&WAIT_COUPLING_DONE) ; }
 
 	void set_spacing(uint16 a, uint16 b, uint16 c) {
 		spacing = a;

--- a/dataobj/schedule_entry.h
+++ b/dataobj/schedule_entry.h
@@ -49,6 +49,7 @@ public:
 		TRANSFER_INTERVAL = 1U << 7,
 		REVERSE_CONVOY	  = 1U << 8, // convoy reverses the order of its vehicles.
 		REVERSE_COUPLING  = 1U << 9, // The convoy reverses the parent-child relationship of the convoy coupling.
+		WAIT_LOAD_LEVEL   = 1U << 10,// Do not leave stop until load level condition satisfied even if wait_for_time comming.
 	};
 
 	/**
@@ -140,7 +141,9 @@ public:
 	void set_reverse_convoi_coupling(bool y) { y ? stop_flags |= REVERSE_COUPLING : stop_flags &= ~REVERSE_COUPLING; }
 	uint16 get_stop_flags() const { return stop_flags; }
 	void set_stop_flags(uint16 f) { stop_flags = f; }
-	
+	void set_wait_load_level(bool y) {y? stop_flags|= WAIT_LOAD_LEVEL : stop_flags &= ~WAIT_LOAD_LEVEL; }
+	bool is_wait_load_level() const {return (stop_flags&WAIT_LOAD_LEVEL) ; }
+
 	void set_spacing(uint16 a, uint16 b, uint16 c) {
 		spacing = a;
 		spacing_shift = b;

--- a/dataobj/schedule_entry.h
+++ b/dataobj/schedule_entry.h
@@ -49,7 +49,7 @@ public:
 		TRANSFER_INTERVAL = 1U << 7,
 		REVERSE_CONVOY	  = 1U << 8, // convoy reverses the order of its vehicles.
 		REVERSE_COUPLING  = 1U << 9, // The convoy reverses the parent-child relationship of the convoy coupling.
-		WAIT_COUPLING_DONE= 1U << 10,// Do not leave stop until load level condition satisfied even if wait_for_time comming.
+		WAIT_COUPLING_DONE= 1U << 10,// Do not reserve departure slot until coupling done.
 	};
 
 	/**

--- a/documentation/ja.OTRP.tab
+++ b/documentation/ja.OTRP.tab
@@ -173,10 +173,10 @@ reverse convoy coupling
 連結を反転する(T)
 Reverses the parents-children order of the coupled convoys.
 連結の親子関係を反転します．
-Not Depart Until Load Condition
-発車条件を満たすまで発車しない
-not leave stop until loading condition satisfied even if departure time comes.
-積載率等の発車条件を満たすまで発車枠を取得しません(積載率、最大待ち時間、連結に対して有効です)。
+Not Depart Until Coupling
+連結するまで発車しない
+not leave stop until coupling done even if departure time comes.
+連結が完了するまで発車枠を取得しません。
 #------円表記------
 $
  円

--- a/documentation/ja.OTRP.tab
+++ b/documentation/ja.OTRP.tab
@@ -173,6 +173,10 @@ reverse convoy coupling
 連結を反転する(T)
 Reverses the parents-children order of the coupled convoys.
 連結の親子関係を反転します．
+Not Depart Until Load Condition
+発車条件を満たすまで発車しない
+not leave stop until loading condition satisfied even if departure time comes.
+積載率等の発車条件を満たすまで発車枠を取得しません(積載率、最大待ち時間、連結に対して有効です)。
 #------円表記------
 $
  円

--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -529,6 +529,12 @@ void schedule_gui_t::init(schedule_t* schedule_, player_t* player, convoihandle_
 		new_component<gui_fill_t>();
 	}
 	end_table();
+
+	bt_wait_load_level_satisfy.init(button_t::square_state, "Not Depart Until Load Level");
+	bt_wait_load_level_satisfy.set_tooltip("not leave stop until loading level satisfied even if departure time comes.");
+	bt_wait_load_level_satisfy.add_listener(this);
+	bt_wait_load_level_satisfy.disable();
+	add_component(&bt_wait_load_level_satisfy);
 	
 	bt_load_before_departure.init(button_t::square_automatic, "Load before departure");
 	bt_load_before_departure.set_tooltip("Do not load cargos until the departure time comes.");
@@ -652,6 +658,7 @@ void schedule_gui_t::update_selection()
 	bt_no_unload.disable();
 	bt_unload_all.disable();
 	bt_wait_for_time.disable();
+	bt_wait_load_level_satisfy.disable();
 	numimp_spacing.disable();
 	numimp_spacing_shift.disable();
 	numimp_delay_tolerance.disable();
@@ -709,8 +716,10 @@ void schedule_gui_t::update_selection()
 				numimp_spacing_shift.enable();
 				numimp_delay_tolerance.enable();
 				bt_load_before_departure.enable();
+				bt_wait_load_level_satisfy.enable();
+				bt_wait_load_level_satisfy.pressed = schedule->at(current_stop).is_wait_load_level();
 			}
-			else {
+			if( !wft || bt_wait_load_level_satisfy.pressed ) {
 				// disable departure time settings and enable minimum loading
 				lb_load.set_color( SYSCOL_TEXT );
 				numimp_load.enable();
@@ -970,6 +979,13 @@ DBG_MESSAGE("schedule_gui_t::action_triggered()","comp=%p combo=%p",comp,&line_s
 	else if(comp == &bt_wait_for_time) {
 		if (!schedule->empty()) {
 			schedule->at(schedule->get_current_stop()).set_wait_for_time(!bt_wait_for_time.pressed);
+			update_selection();
+		}
+	}
+	else if(comp == &bt_wait_load_level_satisfy) {
+		if( !schedule->empty() ) {
+			schedule->at(schedule->get_current_stop()).set_wait_load_level(!bt_wait_load_level_satisfy.pressed);
+			bt_wait_load_level_satisfy.pressed = schedule->at(schedule->get_current_stop()).is_wait_load_level();
 			update_selection();
 		}
 	}

--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -530,11 +530,11 @@ void schedule_gui_t::init(schedule_t* schedule_, player_t* player, convoihandle_
 	}
 	end_table();
 
-	bt_wait_load_condition_satisfy.init(button_t::square_state, "Not Depart Until Coupling");
-	bt_wait_load_condition_satisfy.set_tooltip("not leave stop until coupling done even if departure time comes.");
-	bt_wait_load_condition_satisfy.add_listener(this);
-	bt_wait_load_condition_satisfy.disable();
-	add_component(&bt_wait_load_condition_satisfy);
+	bt_wait_coupling_done.init(button_t::square_state, "Not Depart Until Coupling");
+	bt_wait_coupling_done.set_tooltip("not leave stop until coupling done even if departure time comes.");
+	bt_wait_coupling_done.add_listener(this);
+	bt_wait_coupling_done.disable();
+	add_component(&bt_wait_coupling_done);
 	
 	bt_load_before_departure.init(button_t::square_automatic, "Load before departure");
 	bt_load_before_departure.set_tooltip("Do not load cargos until the departure time comes.");
@@ -658,7 +658,7 @@ void schedule_gui_t::update_selection()
 	bt_no_unload.disable();
 	bt_unload_all.disable();
 	bt_wait_for_time.disable();
-	bt_wait_load_condition_satisfy.disable();
+	bt_wait_coupling_done.disable();
 	numimp_spacing.disable();
 	numimp_spacing_shift.disable();
 	numimp_delay_tolerance.disable();
@@ -717,9 +717,9 @@ void schedule_gui_t::update_selection()
 				numimp_delay_tolerance.enable();
 				bt_load_before_departure.enable();
 				if( bt_wait_for_child.pressed ) {
-					bt_wait_load_condition_satisfy.enable();
+					bt_wait_coupling_done.enable();
 				}
-				bt_wait_load_condition_satisfy.pressed = schedule->at(current_stop).is_wait_load_cond();
+				bt_wait_coupling_done.pressed = schedule->at(current_stop).is_wait_coupling_done();
 			}
 			lb_load.set_color( SYSCOL_TEXT );
 			numimp_load.enable();
@@ -981,10 +981,10 @@ DBG_MESSAGE("schedule_gui_t::action_triggered()","comp=%p combo=%p",comp,&line_s
 			update_selection();
 		}
 	}
-	else if(comp == &bt_wait_load_condition_satisfy) {
+	else if(comp == &bt_wait_coupling_done) {
 		if( !schedule->empty() ) {
-			schedule->at(schedule->get_current_stop()).set_wait_load_cond(!bt_wait_load_condition_satisfy.pressed);
-			bt_wait_load_condition_satisfy.pressed = schedule->at(schedule->get_current_stop()).is_wait_load_cond();
+			schedule->at(schedule->get_current_stop()).set_wait_coupling_done(!bt_wait_coupling_done.pressed);
+			bt_wait_coupling_done.pressed = schedule->at(schedule->get_current_stop()).is_wait_coupling_done();
 			update_selection();
 		}
 	}
@@ -1302,5 +1302,5 @@ void schedule_gui_t::extract_advanced_settings(bool yesno) {
 	bt_find_parent.set_visible(coupling_waytype  &&  yesno);
 	bt_reverse_convoy.set_visible(coupling_waytype  &&  yesno);
 	bt_reverse_coupling.set_visible(coupling_waytype  &&  yesno);
-	bt_wait_load_condition_satisfy.set_visible(coupling_waytype && yesno);
+	bt_wait_coupling_done.set_visible(coupling_waytype && yesno);
 }

--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -530,8 +530,8 @@ void schedule_gui_t::init(schedule_t* schedule_, player_t* player, convoihandle_
 	}
 	end_table();
 
-	bt_wait_load_condition_satisfy.init(button_t::square_state, "Not Depart Until Load Condition");
-	bt_wait_load_condition_satisfy.set_tooltip("not leave stop until loading condition satisfied even if departure time comes.");
+	bt_wait_load_condition_satisfy.init(button_t::square_state, "Not Depart Until Coupling");
+	bt_wait_load_condition_satisfy.set_tooltip("not leave stop until coupling done even if departure time comes.");
 	bt_wait_load_condition_satisfy.add_listener(this);
 	bt_wait_load_condition_satisfy.disable();
 	add_component(&bt_wait_load_condition_satisfy);
@@ -716,28 +716,27 @@ void schedule_gui_t::update_selection()
 				numimp_spacing_shift.enable();
 				numimp_delay_tolerance.enable();
 				bt_load_before_departure.enable();
-				bt_wait_load_condition_satisfy.enable();
+				if( bt_wait_for_child.pressed ) {
+					bt_wait_load_condition_satisfy.enable();
+				}
 				bt_wait_load_condition_satisfy.pressed = schedule->at(current_stop).is_wait_load_cond();
 			}
-			if( !wft || bt_wait_load_condition_satisfy.pressed ) {
-				// disable departure time settings and enable minimum loading
-				lb_load.set_color( SYSCOL_TEXT );
-				numimp_load.enable();
-				if(  schedule->at(current_stop).minimum_loading>0  ||  schedule->at(current_stop).get_coupling_point()!=0  ) {
-					bt_wait_load.enable();
-					uint16 wait = schedule->at(current_stop).waiting_time_shift;
-					bt_wait_load.pressed = wait>0;
-					if(  wait>0  ) {
-						lb_wait.set_color( SYSCOL_TEXT );
-						numimp_wait_load.enable();
-						if(  schedule->at(current_stop).minimum_loading  ==  200  ){
-							bt_load_before_departure.enable();
-						}
+			lb_load.set_color( SYSCOL_TEXT );
+			numimp_load.enable();
+			if(  schedule->at(current_stop).minimum_loading>0  ||  schedule->at(current_stop).get_coupling_point()!=0  ) {
+				bt_wait_load.enable();
+				uint16 wait = schedule->at(current_stop).waiting_time_shift;
+				bt_wait_load.pressed = wait>0;
+				if(  wait>0  ) {
+					lb_wait.set_color( SYSCOL_TEXT );
+					numimp_wait_load.enable();
+					if(  schedule->at(current_stop).minimum_loading  ==  200  ){
+						bt_load_before_departure.enable();
 					}
 				}
-				sprintf(lb_spacing_str, "off");
-				sprintf(lb_spacing_shift_str,"");
 			}
+			sprintf(lb_spacing_str, "off");
+			sprintf(lb_spacing_shift_str,"");
 			
 			numimp_load.set_value( schedule->at(current_stop).minimum_loading );
 			numimp_wait_load.set_value( max(1, schedule->at(current_stop).waiting_time_shift) );
@@ -1303,4 +1302,5 @@ void schedule_gui_t::extract_advanced_settings(bool yesno) {
 	bt_find_parent.set_visible(coupling_waytype  &&  yesno);
 	bt_reverse_convoy.set_visible(coupling_waytype  &&  yesno);
 	bt_reverse_coupling.set_visible(coupling_waytype  &&  yesno);
+	bt_wait_load_condition_satisfy.set_visible(coupling_waytype && yesno);
 }

--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -530,11 +530,11 @@ void schedule_gui_t::init(schedule_t* schedule_, player_t* player, convoihandle_
 	}
 	end_table();
 
-	bt_wait_load_level_satisfy.init(button_t::square_state, "Not Depart Until Load Level");
-	bt_wait_load_level_satisfy.set_tooltip("not leave stop until loading level satisfied even if departure time comes.");
-	bt_wait_load_level_satisfy.add_listener(this);
-	bt_wait_load_level_satisfy.disable();
-	add_component(&bt_wait_load_level_satisfy);
+	bt_wait_load_condition_satisfy.init(button_t::square_state, "Not Depart Until Load Condition");
+	bt_wait_load_condition_satisfy.set_tooltip("not leave stop until loading condition satisfied even if departure time comes.");
+	bt_wait_load_condition_satisfy.add_listener(this);
+	bt_wait_load_condition_satisfy.disable();
+	add_component(&bt_wait_load_condition_satisfy);
 	
 	bt_load_before_departure.init(button_t::square_automatic, "Load before departure");
 	bt_load_before_departure.set_tooltip("Do not load cargos until the departure time comes.");
@@ -658,7 +658,7 @@ void schedule_gui_t::update_selection()
 	bt_no_unload.disable();
 	bt_unload_all.disable();
 	bt_wait_for_time.disable();
-	bt_wait_load_level_satisfy.disable();
+	bt_wait_load_condition_satisfy.disable();
 	numimp_spacing.disable();
 	numimp_spacing_shift.disable();
 	numimp_delay_tolerance.disable();
@@ -716,10 +716,10 @@ void schedule_gui_t::update_selection()
 				numimp_spacing_shift.enable();
 				numimp_delay_tolerance.enable();
 				bt_load_before_departure.enable();
-				bt_wait_load_level_satisfy.enable();
-				bt_wait_load_level_satisfy.pressed = schedule->at(current_stop).is_wait_load_level();
+				bt_wait_load_condition_satisfy.enable();
+				bt_wait_load_condition_satisfy.pressed = schedule->at(current_stop).is_wait_load_cond();
 			}
-			if( !wft || bt_wait_load_level_satisfy.pressed ) {
+			if( !wft || bt_wait_load_condition_satisfy.pressed ) {
 				// disable departure time settings and enable minimum loading
 				lb_load.set_color( SYSCOL_TEXT );
 				numimp_load.enable();
@@ -982,10 +982,10 @@ DBG_MESSAGE("schedule_gui_t::action_triggered()","comp=%p combo=%p",comp,&line_s
 			update_selection();
 		}
 	}
-	else if(comp == &bt_wait_load_level_satisfy) {
+	else if(comp == &bt_wait_load_condition_satisfy) {
 		if( !schedule->empty() ) {
-			schedule->at(schedule->get_current_stop()).set_wait_load_level(!bt_wait_load_level_satisfy.pressed);
-			bt_wait_load_level_satisfy.pressed = schedule->at(schedule->get_current_stop()).is_wait_load_level();
+			schedule->at(schedule->get_current_stop()).set_wait_load_cond(!bt_wait_load_condition_satisfy.pressed);
+			bt_wait_load_condition_satisfy.pressed = schedule->at(schedule->get_current_stop()).is_wait_load_cond();
 			update_selection();
 		}
 	}

--- a/gui/schedule_gui.h
+++ b/gui/schedule_gui.h
@@ -65,7 +65,7 @@ class schedule_gui_t : public gui_frame_t, public action_listener_t
 	button_t bt_find_parent, bt_wait_for_child; // convoy coupling
 	button_t bt_no_load, bt_no_unload, bt_tmp_schedule, bt_wait_for_time, 
 		bt_same_dep_time, bt_full_load_acceleration, bt_full_load_time,bt_unload_all,bt_transfer_interval,
-		bt_load_before_departure, bt_reverse_convoy, bt_reverse_coupling;
+		bt_load_before_departure, bt_reverse_convoy, bt_reverse_coupling, bt_wait_load_level_satisfy;
 	gui_numberinput_t numimp_spacing, numimp_spacing_shift, 
 		numimp_delay_tolerance, numimp_max_speed, numimp_tbgr_waiting_time;
 	gui_label_t lb_spacing, lb_spacing_shift, lb_title1, lb_title2, lb_max_speed, lb_tbgr_waiting_time;

--- a/gui/schedule_gui.h
+++ b/gui/schedule_gui.h
@@ -65,7 +65,7 @@ class schedule_gui_t : public gui_frame_t, public action_listener_t
 	button_t bt_find_parent, bt_wait_for_child; // convoy coupling
 	button_t bt_no_load, bt_no_unload, bt_tmp_schedule, bt_wait_for_time, 
 		bt_same_dep_time, bt_full_load_acceleration, bt_full_load_time,bt_unload_all,bt_transfer_interval,
-		bt_load_before_departure, bt_reverse_convoy, bt_reverse_coupling, bt_wait_load_level_satisfy;
+		bt_load_before_departure, bt_reverse_convoy, bt_reverse_coupling, bt_wait_load_condition_satisfy;
 	gui_numberinput_t numimp_spacing, numimp_spacing_shift, 
 		numimp_delay_tolerance, numimp_max_speed, numimp_tbgr_waiting_time;
 	gui_label_t lb_spacing, lb_spacing_shift, lb_title1, lb_title2, lb_max_speed, lb_tbgr_waiting_time;

--- a/gui/schedule_gui.h
+++ b/gui/schedule_gui.h
@@ -65,7 +65,7 @@ class schedule_gui_t : public gui_frame_t, public action_listener_t
 	button_t bt_find_parent, bt_wait_for_child; // convoy coupling
 	button_t bt_no_load, bt_no_unload, bt_tmp_schedule, bt_wait_for_time, 
 		bt_same_dep_time, bt_full_load_acceleration, bt_full_load_time,bt_unload_all,bt_transfer_interval,
-		bt_load_before_departure, bt_reverse_convoy, bt_reverse_coupling, bt_wait_load_condition_satisfy;
+		bt_load_before_departure, bt_reverse_convoy, bt_reverse_coupling, bt_wait_coupling_done;
 	gui_numberinput_t numimp_spacing, numimp_spacing_shift, 
 		numimp_delay_tolerance, numimp_max_speed, numimp_tbgr_waiting_time;
 	gui_label_t lb_spacing, lb_spacing_shift, lb_title1, lb_title2, lb_max_speed, lb_tbgr_waiting_time;

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -3621,7 +3621,7 @@ bool can_depart(convoihandle_t cnv, halthandle_t halt, uint32 arrived_time, uint
 	}
 
 	// if not calculate waiting time, return cond.
-	return cond&coupling_done_cond;
+	return loading_cond&coupling_done_cond;
 }
 
 

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -3560,25 +3560,35 @@ sint32 subtract_ticks(uint32 v1, uint32 v2) {
  */
 bool can_depart(convoihandle_t cnv, halthandle_t halt, uint32 arrived_time, uint32 time_to_load, bool &coupling_cond, uint32 &go_on_ticks) {
 	convoihandle_t c = cnv;
-	// First, check whether we have to wait for coupling at this stop.
 	coupling_cond = false;
+	go_on_ticks = 0;
+	bool cond = true;
 	while(  c.is_bound()  ) {
 		const schedule_entry_t e = c->get_schedule()->get_current_entry();
+		// First, check whether we have to wait for coupling at this stop.
 		coupling_cond |= (e.get_coupling_point()==1  &&  !c->is_coupling_done()  &&  !(c->get_coupling_convoi().is_bound()  &&  c->is_coupled()));
 		if (  c->is_coupling_done()  ||  !c->get_convoi_coupling_in_progress().is_bound()  ||  c->get_convoi_coupling_in_progress()->get_convoi_coupling_in_progress()!=c  ) {
 			// The convoi_coupling_in_progress flag blocks the departure.
 			// Reset the flag if it is outdated to avoid blocking the departure forever.
 			c->unset_convoi_coupling_in_progress();
 		}
+		// And check the loading condition: load enough? maximum waiting time? coupling done?
+		const bool loading_cond = c->get_loading_level() >= e.minimum_loading; // minimum loading
+		const bool waiting_time_cond = (e.waiting_time_shift > 0  &&  world()->get_ticks() - arrived_time > (world()->ticks_per_world_month / e.waiting_time_shift) ); // waiting time
+		bool c_cond = loading_cond; // condition of this convoy
+		c_cond &= !(e.get_coupling_point()==1  &&  !c->is_coupling_done()  &&  !(c->get_coupling_convoi().is_bound()  &&  c->is_coupled())); // coupling condition
+		c_cond |= c->get_no_load(); // no load
+		c_cond |= waiting_time_cond;
+		cond &= c_cond;
 		c = c->get_coupling_convoi();
 	}
 
 	const schedule_entry_t current_entry = cnv->get_schedule()->get_current_entry();
 
-	// designated departure time has the absolute priority.
+	// designated departure time has the absolute priority (but if is_wait_load_level, cnv can not reserve departure slot).
 	// If departure time is set to the parent, all conditions of children are ignored.
 	// Departure time settings of children have no effect.
-	if(  current_entry.get_wait_for_time()  ) {
+	if(  current_entry.get_wait_for_time() &&  (cond||!current_entry.is_wait_load_level())  ) {
 		if(  arrived_time==0  ) {
 			// arrived_time is not registered for some reasons. replace it to the current ticks.
 			arrived_time = world()->get_ticks();
@@ -3604,20 +3614,7 @@ bool can_depart(convoihandle_t cnv, halthandle_t halt, uint32 arrived_time, uint
 		return is_first_ticks_bigger(world()->get_ticks(), go_on_ticks - time_to_load);
 	}
 
-	c = cnv;
-	go_on_ticks = 0;
-	bool cond = true;
-	while(  c.is_bound()  &&  cond  ) {
-		const schedule_entry_t e = c->get_schedule()->get_current_entry();
-		const bool loading_cond = c->get_loading_level() >= e.minimum_loading; // minimum loading
-		const bool waiting_time_cond = (e.waiting_time_shift > 0  &&  world()->get_ticks() - arrived_time > (world()->ticks_per_world_month / e.waiting_time_shift) ); // waiting time
-		bool c_cond = loading_cond; // condition of this convoy
-		c_cond &= !(e.get_coupling_point()==1  &&  !c->is_coupling_done()  &&  !(c->get_coupling_convoi().is_bound()  &&  c->is_coupled())); // coupling condition
-		c_cond |= c->get_no_load(); // no load
-		c_cond |= waiting_time_cond;
-		cond &= c_cond;
-		c = c->get_coupling_convoi();
-	}
+	// if not calculate waiting time, return cond.
 	return cond;
 }
 

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -3586,10 +3586,10 @@ bool can_depart(convoihandle_t cnv, halthandle_t halt, uint32 arrived_time, uint
 
 	const schedule_entry_t current_entry = cnv->get_schedule()->get_current_entry();
 
-	// designated departure time has the absolute priority (but if is_wait_load_cond(), cnv can not reserve departure slot until departure condition satisfied).
+	// designated departure time has the absolute priority (but if is_wait_coupling_done(), cnv can not reserve departure slot until coupling done).
 	// If departure time is set to the parent, all conditions of children are ignored.
 	// Departure time settings of children have no effect.
-	if(  current_entry.get_wait_for_time() &&  cond  &&  (coupling_cond||!current_entry.is_wait_load_cond())  ) {
+	if(  current_entry.get_wait_for_time() &&  cond  &&  (coupling_cond||!current_entry.is_wait_coupling_done())  ) {
 		if(  arrived_time==0  ) {
 			// arrived_time is not registered for some reasons. replace it to the current ticks.
 			arrived_time = world()->get_ticks();

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -3576,8 +3576,8 @@ bool can_depart(convoihandle_t cnv, halthandle_t halt, uint32 arrived_time, uint
 		const bool loading_cond = c->get_loading_level() >= e.minimum_loading; // minimum loading
 		const bool waiting_time_cond = (e.waiting_time_shift > 0  &&  world()->get_ticks() - arrived_time > (world()->ticks_per_world_month / e.waiting_time_shift) ); // waiting time
 		bool c_cond = loading_cond; // condition of this convoy
-		c_cond &= !(e.get_coupling_point()==1  &&  !c->is_coupling_done()  &&  !(c->get_coupling_convoi().is_bound()  &&  c->is_coupled())); // coupling condition
 		c_cond |= c->get_no_load(); // no load
+		c_cond &= !(e.get_coupling_point()==1  &&  !c->is_coupling_done()  &&  !(c->get_coupling_convoi().is_bound()  &&  c->is_coupled())); // coupling condition
 		c_cond |= waiting_time_cond;
 		cond &= c_cond;
 		c = c->get_coupling_convoi();
@@ -3585,10 +3585,10 @@ bool can_depart(convoihandle_t cnv, halthandle_t halt, uint32 arrived_time, uint
 
 	const schedule_entry_t current_entry = cnv->get_schedule()->get_current_entry();
 
-	// designated departure time has the absolute priority (but if is_wait_load_level, cnv can not reserve departure slot).
+	// designated departure time has the absolute priority (but if is_wait_load_cond(), cnv can not reserve departure slot until departure condition satisfied).
 	// If departure time is set to the parent, all conditions of children are ignored.
 	// Departure time settings of children have no effect.
-	if(  current_entry.get_wait_for_time() &&  (cond||!current_entry.is_wait_load_level())  ) {
+	if(  current_entry.get_wait_for_time() &&  (cond||!current_entry.is_wait_load_cond())  ) {
 		if(  arrived_time==0  ) {
 			// arrived_time is not registered for some reasons. replace it to the current ticks.
 			arrived_time = world()->get_ticks();

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -3563,6 +3563,7 @@ bool can_depart(convoihandle_t cnv, halthandle_t halt, uint32 arrived_time, uint
 	coupling_cond = false;
 	go_on_ticks = 0;
 	bool cond = true;
+	bool coupling_done_cond = true;
 	while(  c.is_bound()  ) {
 		const schedule_entry_t e = c->get_schedule()->get_current_entry();
 		// First, check whether we have to wait for coupling at this stop.
@@ -3577,9 +3578,9 @@ bool can_depart(convoihandle_t cnv, halthandle_t halt, uint32 arrived_time, uint
 		const bool waiting_time_cond = (e.waiting_time_shift > 0  &&  world()->get_ticks() - arrived_time > (world()->ticks_per_world_month / e.waiting_time_shift) ); // waiting time
 		bool c_cond = loading_cond; // condition of this convoy
 		c_cond |= c->get_no_load(); // no load
-		c_cond &= !(e.get_coupling_point()==1  &&  !c->is_coupling_done()  &&  !(c->get_coupling_convoi().is_bound()  &&  c->is_coupled())); // coupling condition
 		c_cond |= waiting_time_cond;
 		cond &= c_cond;
+		coupling_done_cond &= !(e.get_coupling_point()==1  &&  !c->is_coupling_done()  &&  !(c->get_coupling_convoi().is_bound()  &&  c->is_coupled())); // coupling condition
 		c = c->get_coupling_convoi();
 	}
 
@@ -3588,7 +3589,7 @@ bool can_depart(convoihandle_t cnv, halthandle_t halt, uint32 arrived_time, uint
 	// designated departure time has the absolute priority (but if is_wait_load_cond(), cnv can not reserve departure slot until departure condition satisfied).
 	// If departure time is set to the parent, all conditions of children are ignored.
 	// Departure time settings of children have no effect.
-	if(  current_entry.get_wait_for_time() &&  (cond||!current_entry.is_wait_load_cond())  ) {
+	if(  current_entry.get_wait_for_time() &&  cond  &&  (coupling_cond||!current_entry.is_wait_load_cond())  ) {
 		if(  arrived_time==0  ) {
 			// arrived_time is not registered for some reasons. replace it to the current ticks.
 			arrived_time = world()->get_ticks();
@@ -3615,7 +3616,7 @@ bool can_depart(convoihandle_t cnv, halthandle_t halt, uint32 arrived_time, uint
 	}
 
 	// if not calculate waiting time, return cond.
-	return cond;
+	return cond&coupling_done_cond;
 }
 
 

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -3562,7 +3562,7 @@ bool can_depart(convoihandle_t cnv, halthandle_t halt, uint32 arrived_time, uint
 	convoihandle_t c = cnv;
 	coupling_cond = false;
 	go_on_ticks = 0;
-	bool cond = true;
+	bool loading_cond = true;
 	bool coupling_done_cond = true;
 	while(  c.is_bound()  ) {
 		const schedule_entry_t e = c->get_schedule()->get_current_entry();
@@ -3573,23 +3573,28 @@ bool can_depart(convoihandle_t cnv, halthandle_t halt, uint32 arrived_time, uint
 			// Reset the flag if it is outdated to avoid blocking the departure forever.
 			c->unset_convoi_coupling_in_progress();
 		}
+		c = c->get_coupling_convoi();
+	}
+	c = cnv;
+	while(  c.is_bound()  ) {
+		const schedule_entry_t e = c->get_schedule()->get_current_entry();
 		// And check the loading condition: load enough? maximum waiting time? coupling done?
-		const bool loading_cond = c->get_loading_level() >= e.minimum_loading; // minimum loading
+		const bool loading_level_cond = c->get_loading_level() >= e.minimum_loading; // minimum loading
 		const bool waiting_time_cond = (e.waiting_time_shift > 0  &&  world()->get_ticks() - arrived_time > (world()->ticks_per_world_month / e.waiting_time_shift) ); // waiting time
-		bool c_cond = loading_cond; // condition of this convoy
+		bool c_cond = loading_level_cond; // condition of this convoy
 		c_cond |= c->get_no_load(); // no load
 		c_cond |= waiting_time_cond;
-		cond &= c_cond;
+		loading_cond &= c_cond;
 		coupling_done_cond &= !(e.get_coupling_point()==1  &&  !c->is_coupling_done()  &&  !(c->get_coupling_convoi().is_bound()  &&  c->is_coupled())); // coupling condition
 		c = c->get_coupling_convoi();
 	}
 
 	const schedule_entry_t current_entry = cnv->get_schedule()->get_current_entry();
 
-	// designated departure time has the absolute priority (but if is_wait_coupling_done(), cnv can not reserve departure slot until coupling done).
+	// Use the scheduled departure time as long as the other departure conditions are satisfied.
 	// If departure time is set to the parent, all conditions of children are ignored.
 	// Departure time settings of children have no effect.
-	if(  current_entry.get_wait_for_time() &&  cond  &&  (coupling_cond||!current_entry.is_wait_coupling_done())  ) {
+	if(  current_entry.get_wait_for_time() &&  loading_cond  &&  (coupling_done_cond||!current_entry.is_wait_coupling_done())  ) {
 		if(  arrived_time==0  ) {
 			// arrived_time is not registered for some reasons. replace it to the current ticks.
 			arrived_time = world()->get_ticks();


### PR DESCRIPTION
発車条件が整うまで発車時刻枠を予約しないよう設定できるようにしました。
例：貨物の100%積むまで待機とダイヤを両立させるため、100%積載を完了するまで発車枠の予約を見送る