### PR TITLE
BUG FIX:avoid coupling double

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -2012,6 +2012,7 @@ void convoi_t::ziel_erreicht()
 				wait_lock = 0;
 				set_next_coupling(route_t::INVALID_INDEX, 0);
 				v->get_convoi()->set_coupling_done(true);
+				unset_convoi_coupling_in_progress();
 				coupling_done = true;
 				return;
 			}
@@ -5307,7 +5308,6 @@ bool convoi_t::couple_convoi(convoihandle_t coupled) {
 	coupling_convoi->front()->set_leading(false);
 	back()->set_last(false);
 	must_recalc_min_top_speed();
-	unset_convoi_coupling_in_progress();
 	return true;
 }
 

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -5389,6 +5389,10 @@ bool convoi_t::can_start_coupling(convoi_t* parent) const {
 	if(  parent->self->get_coupling_convoi().is_bound()  &&  parent->is_coupled()  ) {
 		return false;
 	}
+	// If the waiting convoy is already coupled at this station, return false
+	if(  parent->self->is_coupling_done()  ) {
+		return false;
+	}
 	return true;
 }
 


### PR DESCRIPTION
同じ駅で多重に連結するのを防ぎます。
coupling_in_progressフラグでは折り返しを行う機回しの場合に多重連結を防げなかったため、coupling_doneフラグを併用します。