### PR TITLE
Add threaded step for convoi_t

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -620,6 +620,7 @@ SOURCES += utils/simrandom.cc
 SOURCES += utils/simstring.cc
 SOURCES += utils/simstring+money.cc
 SOURCES += utils/simthread.cc
+SOURCES += utils/thread_pool.cc
 SOURCES += vehicle/movingobj.cc
 SOURCES += vehicle/pedestrian.cc
 SOURCES += vehicle/simroadtraffic.cc

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -5697,3 +5697,18 @@ void convoi_t::unset_convoi_coupling_in_progress() {
 	self->delete_convoi_coupling_in_progress();
 	dbg->message( "convoi_t::unset_convoi_coupling_in_progress()","%i and %i convoys are now coupling or canceling couple", self.get_id(), c->self.get_id() );
 }
+
+
+bool convoi_t::needs_threaded_step() const
+{
+	// TODO: implement logic to determine if threaded processing is needed
+	// For now, always return false as requested
+	return false;
+}
+
+
+void convoi_t::threaded_step()
+{
+	// TODO: implement threaded operations from step()
+	// This will be called after all convoys have completed their regular step()
+}

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -741,6 +741,18 @@ public:
 	void step();
 
 	/**
+	 * Check if this convoy needs threaded processing
+	 * @return true if threaded_step() should be called
+	 */
+	bool needs_threaded_step() const;
+
+	/**
+	 * Multithreaded version of some operations from step()
+	 * This is called after all convoys have completed their regular step()
+	 */
+	void threaded_step();
+
+	/**
 	* sets a new convoi in route
 	*/
 	void start();

--- a/simworld.cc
+++ b/simworld.cc
@@ -15,6 +15,7 @@
 #include "simcity.h"
 #include "simcolor.h"
 #include "simconvoi.h"
+#include "utils/thread_pool.h"
 #include "simdebug.h"
 #include "simdepot.h"
 #include "simfab.h"
@@ -4239,6 +4240,23 @@ void karte_t::step()
 			INT_CHECK("simworld 1947");
 		}
 	}
+
+	// multithreaded step for convois
+	DBG_DEBUG4("karte_t::step", "threaded step convois");
+	static thread_pool_t thread_pool(4); // TODO: make thread count configurable
+	
+	// collect convoys that need threaded processing
+	for (size_t i = 0; i < convoi_array.get_count(); i++) {
+		convoihandle_t cnv = convoi_array[i];
+		if(  cnv.is_bound()  &&  cnv->needs_threaded_step()  ) {
+			thread_pool.enqueue([cnv]() {
+				cnv->threaded_step();
+			});
+		}
+	}
+	
+	// wait for all threaded operations to complete
+	thread_pool.wait_for_all();
 
 	// now step all towns (to generate passengers)
 	DBG_DEBUG4("karte_t::step", "step cities");

--- a/utils/thread_pool.cc
+++ b/utils/thread_pool.cc
@@ -1,0 +1,116 @@
+/*
+ * This file is part of the Simutrans project under the Artistic License.
+ * (see LICENSE.txt)
+ */
+
+#include "thread_pool.h"
+
+#ifdef MULTI_THREAD
+
+thread_pool_t::thread_pool_t(int thread_count) : stop(false), active_tasks(0), pending_tasks(0)
+{
+	pthread_mutex_init(&queue_mutex, nullptr);
+	pthread_cond_init(&condition, nullptr);
+	pthread_cond_init(&finished_condition, nullptr);
+
+	workers.reserve(thread_count);
+	for (int i = 0; i < thread_count; ++i) {
+		pthread_t worker;
+		pthread_create(&worker, nullptr, worker_thread, this);
+		workers.push_back(worker);
+	}
+}
+
+thread_pool_t::~thread_pool_t()
+{
+	// Signal all threads to stop
+	pthread_mutex_lock(&queue_mutex);
+	stop = true;
+	pthread_cond_broadcast(&condition);
+	pthread_mutex_unlock(&queue_mutex);
+
+	// Wait for all threads to finish
+	for (pthread_t worker : workers) {
+		pthread_join(worker, nullptr);
+	}
+
+	// Clean up
+	pthread_mutex_destroy(&queue_mutex);
+	pthread_cond_destroy(&condition);
+	pthread_cond_destroy(&finished_condition);
+}
+
+void* thread_pool_t::worker_thread(void* arg)
+{
+	thread_pool_t* pool = static_cast<thread_pool_t*>(arg);
+	pool->worker_loop();
+	return nullptr;
+}
+
+void thread_pool_t::worker_loop()
+{
+	while (true) {
+		task_t task([]{});
+		bool has_task = false;
+
+		// Get next task from queue
+		pthread_mutex_lock(&queue_mutex);
+		while (tasks.empty() && !stop) {
+			pthread_cond_wait(&condition, &queue_mutex);
+		}
+
+		if (stop && tasks.empty()) {
+			pthread_mutex_unlock(&queue_mutex);
+			break;
+		}
+
+		if (!tasks.empty()) {
+			task = tasks.front();
+			tasks.pop();
+			pending_tasks--;
+			active_tasks++;
+			has_task = true;
+		}
+
+		pthread_mutex_unlock(&queue_mutex);
+
+		// Execute task
+		if (has_task) {
+			task.func();
+
+			// Mark task as completed
+			pthread_mutex_lock(&queue_mutex);
+			active_tasks--;
+			if (active_tasks == 0 && pending_tasks == 0) {
+				pthread_cond_broadcast(&finished_condition);
+			}
+			pthread_mutex_unlock(&queue_mutex);
+		}
+	}
+}
+
+void thread_pool_t::enqueue(std::function<void()> func)
+{
+	pthread_mutex_lock(&queue_mutex);
+	
+	if (!stop) {
+		tasks.emplace(func);
+		pending_tasks++;
+		pthread_cond_signal(&condition);
+	}
+	
+	pthread_mutex_unlock(&queue_mutex);
+}
+
+void thread_pool_t::wait_for_all()
+{
+	pthread_mutex_lock(&queue_mutex);
+	
+	while (active_tasks > 0 || pending_tasks > 0) {
+		pthread_cond_wait(&finished_condition, &queue_mutex);
+	}
+	
+	pthread_mutex_unlock(&queue_mutex);
+}
+
+#endif

--- a/utils/thread_pool.h
+++ b/utils/thread_pool.h
@@ -1,0 +1,92 @@
+/*
+ * This file is part of the Simutrans project under the Artistic License.
+ * (see LICENSE.txt)
+ */
+
+#ifndef UTILS_THREAD_POOL_H
+#define UTILS_THREAD_POOL_H
+
+#ifdef MULTI_THREAD
+
+#include <pthread.h>
+#include <vector>
+#include <queue>
+#include <functional>
+#include "../utils/simthread.h"
+
+/**
+ * Simple thread pool implementation for parallel lambda execution
+ * Provides basic parallel execution capabilities with wait-for-completion
+ */
+class thread_pool_t
+{
+private:
+	struct task_t {
+		std::function<void()> func;
+		task_t(std::function<void()> f) : func(f) {}
+	};
+
+	std::vector<pthread_t> workers;
+	std::queue<task_t> tasks;
+	pthread_mutex_t queue_mutex;
+	pthread_cond_t condition;
+	pthread_cond_t finished_condition;
+	bool stop;
+	int active_tasks;
+	int pending_tasks;
+
+	static void* worker_thread(void* arg);
+	void worker_loop();
+
+public:
+	/**
+	 * Constructor - creates thread pool with specified number of worker threads
+	 * @param thread_count Number of worker threads to create
+	 */
+	thread_pool_t(int thread_count);
+
+	/**
+	 * Destructor - stops all threads and cleans up resources
+	 */
+	~thread_pool_t();
+
+	/**
+	 * Submit a lambda function for parallel execution
+	 * @param func Lambda function to execute
+	 */
+	void enqueue(std::function<void()> func);
+
+	/**
+	 * Wait for all submitted tasks to complete
+	 */
+	void wait_for_all();
+
+	/**
+	 * Get the number of worker threads
+	 */
+	int get_thread_count() const { return workers.size(); }
+};
+
+#else
+
+// Dummy implementation for single-threaded builds
+class thread_pool_t
+{
+public:
+	thread_pool_t(int /*thread_count*/) {}
+	~thread_pool_t() {}
+	
+	void enqueue(std::function<void()> func) {
+		func(); // Execute immediately in single-threaded mode
+	}
+	
+	void wait_for_all() {
+		// Nothing to wait for in single-threaded mode
+	}
+	
+	int get_thread_count() const { return 1; }
+};
+
+#endif
+
+#endif


### PR DESCRIPTION
**v45リリース後にmergeすること**

`convoi_t` 向けに、マルチスレッドで処理を実行するための処理の場として`threaded_step` を追加します。この関数は`step` の後に実行され、同時並行で実行してmain threadではすべての実行の完了を待ちます。

現状は `threaded_step` では何も行われませんが、編成の経路検索をここで走らせることを目指します。また、将来的にはthreaded_stepの完了を待っている間に適宜`INT_CHECK` を呼んでローカルゲームでのFPS向上を目指します。