### PR TITLE
wait_coupling_done button update

### DIFF
--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -732,9 +732,7 @@ void schedule_gui_t::update_selection()
 				numimp_spacing_shift.enable();
 				numimp_delay_tolerance.enable();
 				bt_load_before_departure.enable();
-				if( bt_wait_for_child.pressed ) {
-					bt_wait_coupling_done.enable();
-				}
+				bt_wait_coupling_done.enable(); // this button is always enable because waiting convoy is not always itself(child convoy also can be wait for coupling).
 				bt_wait_coupling_done.pressed = schedule->at(current_stop).is_wait_coupling_done();
 			}
 			lb_load.set_color( SYSCOL_TEXT );


### PR DESCRIPTION
schedule_gui_tの```bt_wait_coupling_done```ボタンを常に表示するようにしました。
子編成のみがwait_for_coupling状態でも同様に処理できるようにするためです。