### PR TITLE
not show reverse button for road/air/water wt

### DIFF
--- a/gui/depot_frame.cc
+++ b/gui/depot_frame.cc
@@ -538,6 +538,7 @@ void depot_frame_t::layout(scr_size *size)
 	child_convoi_selector.set_max_size(scr_size(win_size.w - D_MARGIN_RIGHT - ( D_MARGIN_LEFT + (BUTTON_WIDTH_DEPOT + D_H_SPACE)*2 + D_H_SPACE ), LINESPACE * 13 + 2 + 16));
 	bt_reverse.set_pos(scr_coord(D_MARGIN_LEFT + (BUTTON_WIDTH_DEPOT + D_H_SPACE)*3 ,ACTIONS_VSTART - D_BUTTON_HEIGHT));
 	bt_reverse.set_width(BUTTON_WIDTH_DEPOT);
+	bt_reverse.set_visible(should_show_child_convoi_selector);
 
 	bt_start.set_pos(scr_coord(D_MARGIN_LEFT, ACTIONS_VSTART));
 	bt_start.set_size(scr_size(BUTTON_WIDTH_DEPOT, D_BUTTON_HEIGHT));


### PR DESCRIPTION
自動車、飛行機、船舶の車庫に置いてreverseボタンを廃止しました