### PR TITLE
vehicle_t::display_after() update (e.g. show child's convoi level)

### DIFF
--- a/documentation/ja.OTRP.tab
+++ b/documentation/ja.OTRP.tab
@@ -61,6 +61,8 @@ line name and states tooltips
 系統名と車両の状態を表示
 coupled
 連結運転中
+coupled (loading)
+連結運転中(停車中)
 driving
 運転中
 #------Convoy coupling related stuff------
@@ -69,8 +71,8 @@ Wait for coupling
 連結相手を待つ(W)
 Try coupling
 連結を試みる(C)
-Waiting for coupling!
-連結相手を待機中
+Waiting for coupling! (%i->%i%%)
+連結相手を待機中 (%i->%i%%)
 Require parent convoy to enter.
 連結相手がいる時のみ進入を許可
 release back

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -1929,8 +1929,10 @@ void vehicle_t::display_after(int xpos, int ypos, bool is_global) const
 		// now find out what has happened
 		switch(cnv->get_state()) {
 			case convoi_t::COUPLED:
-			case convoi_t::COUPLED_LOADING:
 				tstrncpy( states_text, translator::translate("coupled"), lengthof(states_text) );
+				break;
+			case convoi_t::COUPLED_LOADING:
+				tstrncpy( states_text, translator::translate("coupled (loading)"), lengthof(states_text) );
 				break;
 
 			case convoi_t::WAITING_FOR_CLEARANCE_ONE_MONTH:
@@ -1957,10 +1959,32 @@ void vehicle_t::display_after(int xpos, int ypos, bool is_global) const
 				}
 				else if(  cnv->is_waiting_for_coupling()  ) {
 					// the convoy is waiting for coupling.
-					tstrncpy( states_text, translator::translate("Waiting for coupling!"), lengthof(states_text) );
+					convoihandle_t c = cnv->self;
+					sint32 max_loading_limit = cnv->get_loading_limit();
+					sint32 max_loading_level = cnv->get_loading_level();
+					// search the waiting convoy
+					while(c.is_bound()) {
+						if( c->get_loading_limit() > max_loading_limit && c->get_loading_level() < c->get_loading_limit() ) {
+							max_loading_limit = c->get_loading_limit();
+							max_loading_level = c->get_loading_level();
+						}
+						c = c->get_coupling_convoi();
+					} 
+					snprintf( states_text, states_text_size, translator::translate("Waiting for coupling! (%i->%i%%)"), max_loading_level, max_loading_limit );
 				} else {
 					// the convoy is waiting for minimum loading.
-					snprintf( states_text, states_text_size, translator::translate("Loading (%i->%i%%)!"), cnv->get_loading_level(), cnv->get_loading_limit() );
+					convoihandle_t c = cnv->self;
+					sint32 max_loading_limit = cnv->get_loading_limit();
+					sint32 max_loading_level = cnv->get_loading_level();
+					// search the waiting convoy
+					while(c.is_bound()) {
+						if( c->get_loading_limit() > max_loading_limit && c->get_loading_level() < c->get_loading_limit() ) {
+							max_loading_limit = c->get_loading_limit();
+							max_loading_level = c->get_loading_level();
+						}
+						c = c->get_coupling_convoi();
+					} 
+					snprintf( states_text, states_text_size, translator::translate("Loading (%i->%i%%)!"), max_loading_level, max_loading_limit );
 				}
 				break;
 


### PR DESCRIPTION
編成の状態表示を改善し、子編成が積むまで待機していた場合に積載量を表示できるようにしました