### PR TITLE
BUG FIX: child convoys do not enter depot two times when loading

### DIFF
--- a/simdepot.cc
+++ b/simdepot.cc
@@ -169,6 +169,12 @@ void replace_cars(convoihandle_t cnv, depot_t* depot) {
  */
 void depot_t::convoi_arrived(convoihandle_t acnv, bool schedule_adjust)
 {
+	for( uint32 i=0; i<convois.get_count(); i++ ) {
+		if (acnv==convois[i]) {
+			// there are two same convoys!
+			return;
+		}
+	}
 	if(schedule_adjust) {
 		// here a regular convoi arrived
 

--- a/simdepot.cc
+++ b/simdepot.cc
@@ -170,7 +170,7 @@ void replace_cars(convoihandle_t cnv, depot_t* depot) {
 void depot_t::convoi_arrived(convoihandle_t acnv, bool schedule_adjust)
 {
 	for( uint32 i=0; i<convois.get_count(); i++ ) {
-		if (acnv==convois[i]) {
+		if (acnv==convois.at(i)) {
 			// there are two same convoys!
 			return;
 		}


### PR DESCRIPTION
ゲームロード時に、連結した編成が車庫内で増殖するのを防ぎます