### PR TITLE
BUG FIX:CRASH when checking convoy's coupling during convoi_t::send_to_depot_immediately()

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -5026,6 +5026,7 @@ const char* convoi_t::send_to_depot_immediately(bool local)
 			txt = "%s leads\ndifferent owner's or\ndifferent waytype convoy.\n",get_name();
 			return txt;
 		}
+		c = c->get_coupling_convoi();
 	} 
 	// iterate over all depots and try to find shortest route
 	route_t *shortest_route = new route_t();


### PR DESCRIPTION
車庫入庫チェック時に無限ループに入るバグを解消しました