### PR TITLE
add uncouple button in schedule_entry

### DIFF
--- a/dataobj/schedule.cc
+++ b/dataobj/schedule.cc
@@ -646,6 +646,10 @@ void construct_schedule_entry_attributes(cbuffer_t& buf, schedule_entry_t const&
 		str[cnt] = 'I';
 		cnt++;
 	}
+	if(  flag&schedule_entry_t::UNCOUPLE_CHILD  ) {
+		str[cnt] = 'E';
+		cnt++;
+	}
 	if(  entry.is_reverse_convoy()  ) {
 		str[cnt] = 'R';
 		cnt++;

--- a/dataobj/schedule_entry.h
+++ b/dataobj/schedule_entry.h
@@ -159,8 +159,6 @@ public:
 	uint16 get_stop_flags() const { return stop_flags; }
 	void set_overwrite_max_speed_kmh_of_convoi(bool y) { y ? stop_flags |= MAX_SPEED_KMH_OF_CONVOI : stop_flags &= ~MAX_SPEED_KMH_OF_CONVOI; }
 	bool is_overwrite_max_speed_kmh_of_convoi() const {return (stop_flags&MAX_SPEED_KMH_OF_CONVOI) ; }
-	uint16 get_stop_flags() const { return stop_flags; }
-	void set_stop_flags(uint16 f) { stop_flags = f; }
 	bool is_no_overtake() const {return (stop_flags&NO_OVERTAKE)>0 ;}
 	void set_no_overtake(bool y) { y? stop_flags|=NO_OVERTAKE : stop_flags &= ~NO_OVERTAKE;}
 

--- a/dataobj/schedule_entry.h
+++ b/dataobj/schedule_entry.h
@@ -50,6 +50,7 @@ public:
 		REVERSE_CONVOY	  = 1U << 8, // convoy reverses the order of its vehicles.
 		REVERSE_COUPLING  = 1U << 9, // The convoy reverses the parent-child relationship of the convoy coupling.
 		WAIT_COUPLING_DONE= 1U << 10,// Do not reserve departure slot until coupling done.
+		UNCOUPLE_CHILD    = 1U << 12,// The convoy uncouple its child convoy (only its child: this convoy will be the most child convoy).
 	};
 
 	/**
@@ -139,10 +140,12 @@ public:
 	void set_reverse_convoy(bool y) { y ? stop_flags |= REVERSE_CONVOY : stop_flags&= ~REVERSE_CONVOY; }
 	bool is_reverse_convoi_coupling() const { return (stop_flags&REVERSE_COUPLING)>0; } 
 	void set_reverse_convoi_coupling(bool y) { y ? stop_flags |= REVERSE_COUPLING : stop_flags &= ~REVERSE_COUPLING; }
-	uint16 get_stop_flags() const { return stop_flags; }
-	void set_stop_flags(uint16 f) { stop_flags = f; }
 	void set_wait_coupling_done(bool y) {y? stop_flags|= WAIT_COUPLING_DONE : stop_flags &= ~WAIT_COUPLING_DONE; }
 	bool is_wait_coupling_done() const {return (stop_flags&WAIT_COUPLING_DONE) ; }
+	void set_uncouple_child( bool y ) { y ? stop_flags |= UNCOUPLE_CHILD : stop_flags &= ~UNCOUPLE_CHILD; }
+	bool is_uncouple_child() const { return (stop_flags & UNCOUPLE_CHILD) > 0; }
+	void set_stop_flags(uint16 f) { stop_flags = f; }
+	uint16 get_stop_flags() const { return stop_flags; }
 
 	void set_spacing(uint16 a, uint16 b, uint16 c) {
 		spacing = a;

--- a/documentation/ja.OTRP.tab
+++ b/documentation/ja.OTRP.tab
@@ -77,6 +77,10 @@ Wait for coupling
 連結相手を待つ(W)
 Try coupling
 連結を試みる(C)
+End couple
+後ろと連結終了(E)
+It will uncouple the child convoy here.
+後ろの編成を駅到着時に切り離します．
 Waiting for coupling! (%i->%i%%)
 連結相手を待機中 (%i->%i%%)
 Require parent convoy to enter.

--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -737,11 +737,9 @@ void schedule_gui_t::update_selection()
 		bt_reverse_convoy.pressed = schedule->at(current_stop).is_reverse_convoy();
 		bt_reverse_coupling.enable();
 		bt_reverse_coupling.pressed = schedule->at(current_stop).is_reverse_convoi_coupling();
-<<<<<<< HEAD
 		bt_uncouple_child.enable();
 		bt_uncouple_child.pressed = schedule->at(current_stop).is_uncouple_child();
     
-=======
 		bt_no_overtake.enable();
 		bt_no_overtake.pressed = schedule->at(current_stop).is_no_overtake();
 
@@ -752,7 +750,6 @@ void schedule_gui_t::update_selection()
 		}
 		numimp_max_speed_kmh_of_convoi.set_value( schedule->at(current_stop).max_speed_kmh_of_convoi );
 
->>>>>>> OTRP-KUTAv6
 		// if the next_line is set, the last entry is same as the next_line->get_schedule()->at(0)
 		// so, the flags of last entry can not be editted.
 		if(  haltestelle_t::get_stoppable_halt(schedule->at(current_stop).pos, player, schedule->get_waytype()).is_bound()  && (  (current_stop != schedule->get_count()-1)  ||  !schedule->get_next_line().is_bound()  )  ) {

--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -456,8 +456,8 @@ void schedule_gui_t::init(schedule_t* schedule_, player_t* player, convoihandle_
 		bt_find_parent.disable();
 		add_component(&bt_find_parent);
 
-		bt_uncouple_child.init(button_t::square_state, "Uncouple a child convoy");
-		bt_uncouple_child.set_tooltip("Its child convoy must be uncoupled here.");
+		bt_uncouple_child.init(button_t::square_state, "End couple");
+		bt_uncouple_child.set_tooltip("It will uncouple the child convoy here.");
 		bt_uncouple_child.add_listener(this);
 		bt_uncouple_child.disable();
 		add_component(&bt_uncouple_child);

--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -696,6 +696,8 @@ void schedule_gui_t::update_selection()
 		bt_reverse_convoy.pressed = schedule->at(current_stop).is_reverse_convoy();
 		bt_reverse_coupling.enable();
 		bt_reverse_coupling.pressed = schedule->at(current_stop).is_reverse_convoi_coupling();
+		bt_uncouple_child.enable();
+		bt_uncouple_child.pressed = schedule->at(current_stop).is_uncouple_child();
     
 		// if the next_line is set, the last entry is same as the next_line->get_schedule()->at(0)
 		// so, the flags of last entry can not be editted.
@@ -707,8 +709,6 @@ void schedule_gui_t::update_selection()
 			bt_find_parent.pressed = c==2;
 			bt_wait_for_child.enable();
 			bt_wait_for_child.pressed = c==1;
-			bt_uncouple_child.enable();
-			bt_uncouple_child.pressed = schedule->at(current_stop).is_uncouple_child();
 			bt_no_load.enable();
 			bt_no_load.pressed = schedule->at(current_stop).is_no_load();
 			bt_no_unload.enable();

--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -442,7 +442,7 @@ void schedule_gui_t::init(schedule_t* schedule_, player_t* player, convoihandle_
 	end_table();
 	
 	// coupling related buttons
-	add_table(2,1);
+	add_table(3,1);
 	{
 		bt_wait_for_child.init(button_t::square_state, "Wait for coupling");
 		bt_wait_for_child.set_tooltip("A convoy waits for other convoy to couple.");
@@ -455,6 +455,12 @@ void schedule_gui_t::init(schedule_t* schedule_, player_t* player, convoihandle_
 		bt_find_parent.add_listener(this);
 		bt_find_parent.disable();
 		add_component(&bt_find_parent);
+
+		bt_uncouple_child.init(button_t::square_state, "Uncouple a child convoy");
+		bt_uncouple_child.set_tooltip("Its child convoy must be uncoupled here.");
+		bt_uncouple_child.add_listener(this);
+		bt_uncouple_child.disable();
+		add_component(&bt_uncouple_child);
 	}	
 	end_table();
 
@@ -669,6 +675,7 @@ void schedule_gui_t::update_selection()
 	numimp_load.set_value( 0 );
 	bt_find_parent.disable();
 	bt_wait_for_child.disable();
+	bt_uncouple_child.disable();
 	bt_no_load.disable();
 	bt_no_unload.disable();
 	bt_unload_all.disable();
@@ -700,6 +707,8 @@ void schedule_gui_t::update_selection()
 			bt_find_parent.pressed = c==2;
 			bt_wait_for_child.enable();
 			bt_wait_for_child.pressed = c==1;
+			bt_uncouple_child.enable();
+			bt_uncouple_child.pressed = schedule->at(current_stop).is_uncouple_child();
 			bt_no_load.enable();
 			bt_no_load.pressed = schedule->at(current_stop).is_no_load();
 			bt_no_unload.enable();
@@ -920,6 +929,12 @@ dbg->message("schedule_gui_t::action_triggered()","comp=%p combo=%p",comp,&line_
 	else if(comp == &numimp_wait_load && bt_wait_load.pressed) {
 		if(!schedule->empty()) {
 			schedule->at(schedule->get_current_stop()).waiting_time_shift = (uint16)p.i;
+			update_selection();
+		}
+	}
+	else if(comp == &bt_uncouple_child) {
+		if(!schedule->empty()) {
+			schedule->at(schedule->get_current_stop()).set_uncouple_child(!bt_uncouple_child.pressed);
 			update_selection();
 		}
 	}
@@ -1376,4 +1391,5 @@ void schedule_gui_t::extract_advanced_settings(bool yesno) {
 	bt_reverse_convoy.set_visible(coupling_waytype  &&  yesno);
 	bt_reverse_coupling.set_visible(coupling_waytype  &&  yesno);
 	bt_wait_coupling_done.set_visible(coupling_waytype && yesno);
+	bt_uncouple_child.set_visible(coupling_waytype && yesno);
 }

--- a/gui/schedule_gui.h
+++ b/gui/schedule_gui.h
@@ -65,7 +65,7 @@ class schedule_gui_t : public gui_frame_t, public action_listener_t
 	button_t bt_find_parent, bt_wait_for_child; // convoy coupling
 	button_t bt_no_load, bt_no_unload, bt_tmp_schedule, bt_wait_for_time, 
 		bt_same_dep_time, bt_full_load_acceleration, bt_full_load_time,bt_unload_all,bt_transfer_interval,
-		bt_load_before_departure, bt_reverse_convoy, bt_reverse_coupling, bt_wait_coupling_done;
+		bt_load_before_departure, bt_reverse_convoy, bt_reverse_coupling, bt_wait_coupling_done, bt_uncouple_child;
 	gui_numberinput_t numimp_spacing, numimp_spacing_shift, 
 		numimp_delay_tolerance, numimp_max_speed, numimp_tbgr_waiting_time;
 	gui_label_t lb_spacing, lb_spacing_shift, lb_title1, lb_title2, lb_max_speed, lb_tbgr_waiting_time, lb_next_line;

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -1926,6 +1926,8 @@ void convoi_t::ziel_erreicht()
 				set_next_coupling(route_t::INVALID_INDEX, 0);
 				v->get_convoi()->set_coupling_done(true);
 				coupling_done = true;
+				// before reverse convoy coupling, we ask it to uncouple its child or not (set in schedule_entry)
+				uncouple_convoy_by_schedule_setting();
 				// then, chage the order if next direction is backward of "self"
 				// Attention! reverse_convoy_coupling() must be called when loading!
 				// if we call it before stop, the convoys will be reversed immediately, and it makes position calculation bug. 
@@ -1955,6 +1957,8 @@ void convoi_t::ziel_erreicht()
 			c->set_arrived_time(world()->get_ticks());
 			c = c->get_coupling_convoi();
 		}
+		// check uncouple its child (set in schedule_entry)
+		uncouple_convoy_by_schedule_setting();
 	}
 	else {
 		// Neither depot nor station: waypoint
@@ -5329,7 +5333,7 @@ convoihandle_t convoi_t::uncouple_convoi() {
 }
 
 bool convoi_t::can_continue_coupling() const {
-	if(  !coupling_convoi.is_bound() || get_schedule()->get_current_entry().is_uncouple_child()  ) {
+	if(  !coupling_convoi.is_bound()  ) {
 		// this convoy is not coupling with others!
 		return false;
 	}
@@ -5693,6 +5697,19 @@ void convoi_t::unset_convoi_coupling_in_progress() {
 	c->delete_convoi_coupling_in_progress();
 	self->delete_convoi_coupling_in_progress();
 	dbg->message( "convoi_t::unset_convoi_coupling_in_progress()","%i and %i convoys are now coupling or canceling couple", self.get_id(), c->self.get_id() );
+}
+
+void convoi_t::uncouple_convoy_by_schedule_setting()
+{
+	convoihandle_t c = self;
+	while( c.is_bound() ) {
+		// to keep child convoy because it may be uncouple now!
+		convoihandle_t child_convoy = c->get_coupling_convoi();
+		if(c->get_schedule()->get_current_entry().is_uncouple_child()) {
+			c->uncouple_convoi();
+		}
+		c = child_convoy;
+	}
 }
 
 

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -2461,8 +2461,9 @@ void convoi_t::vorfahren()
 		// the back vehicles position is set.
 		if (c->reversing_needed){
 			c->reverse_vehicles_at_halt_if_needed();
-			c->uncouple_done = false;
 		}
+		// reset uncouple done flag
+		c->uncouple_done = false;
 		c = c->get_coupling_convoi();
 	}
 
@@ -3226,16 +3227,17 @@ void convoi_t::rdwr(loadsave_t *file)
 		reversed = false;
 		reversing_needed = true;
 	}
-	if(  file->get_OTRP_version()>=47  ) {
-		file->rdwr_bool(uncouple_done);
-	} else {
-		uncouple_done=false;
-	}
 
 	if(  file->get_OTRP_version()>=47  ) {
 		file->rdwr_short( max_speed_kmh_of_convoi );
 	} else {
 		max_speed_kmh_of_convoi = 0;
+	}
+
+	if(  file->get_OTRP_version()>=48  ) {
+		file->rdwr_bool(uncouple_done);
+	} else {
+		uncouple_done=false;
 	}
 
 	if(  file->is_loading()  ) {
@@ -5745,8 +5747,9 @@ void convoi_t::uncouple_convoy_by_schedule_setting()
 		convoihandle_t child_convoy = c->get_coupling_convoi();
 		if(c->get_schedule()->get_current_entry().is_uncouple_child()&&!c->uncouple_done) {
 			c->uncouple_convoi();
-			c->uncouple_done=true;
 		}
+		// avoid uncouple repeatedly
+		c->uncouple_done=true;
 		c = child_convoy;
 	}
 }

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -5086,6 +5086,7 @@ const char* convoi_t::send_to_depot_immediately(bool local)
 			txt = "%s leads\ndifferent owner's or\ndifferent waytype convoy.\n",get_name();
 			return txt;
 		}
+		c = c->get_coupling_convoi();
 	} 
 	// iterate over all depots and try to find shortest route
 	route_t *shortest_route = new route_t();

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -1926,8 +1926,6 @@ void convoi_t::ziel_erreicht()
 				set_next_coupling(route_t::INVALID_INDEX, 0);
 				v->get_convoi()->set_coupling_done(true);
 				coupling_done = true;
-				// before reverse convoy coupling, we ask it to uncouple its child or not (set in schedule_entry)
-				uncouple_convoy_by_schedule_setting();
 				// then, chage the order if next direction is backward of "self"
 				// Attention! reverse_convoy_coupling() must be called when loading!
 				// if we call it before stop, the convoys will be reversed immediately, and it makes position calculation bug. 
@@ -1957,8 +1955,6 @@ void convoi_t::ziel_erreicht()
 			c->set_arrived_time(world()->get_ticks());
 			c = c->get_coupling_convoi();
 		}
-		// check uncouple its child (set in schedule_entry)
-		uncouple_convoy_by_schedule_setting();
 	}
 	else {
 		// Neither depot nor station: waypoint
@@ -5333,7 +5329,7 @@ convoihandle_t convoi_t::uncouple_convoi() {
 }
 
 bool convoi_t::can_continue_coupling() const {
-	if(  !coupling_convoi.is_bound()  ) {
+	if(  !coupling_convoi.is_bound() || get_schedule()->get_current_entry().is_uncouple_child()  ) {
 		// this convoy is not coupling with others!
 		return false;
 	}
@@ -5697,19 +5693,6 @@ void convoi_t::unset_convoi_coupling_in_progress() {
 	c->delete_convoi_coupling_in_progress();
 	self->delete_convoi_coupling_in_progress();
 	dbg->message( "convoi_t::unset_convoi_coupling_in_progress()","%i and %i convoys are now coupling or canceling couple", self.get_id(), c->self.get_id() );
-}
-
-void convoi_t::uncouple_convoy_by_schedule_setting()
-{
-	convoihandle_t c = self;
-	while( c.is_bound() ) {
-		// to keep child convoy because it may be uncouple now!
-		convoihandle_t child_convoy = c->get_coupling_convoi();
-		if(c->get_schedule()->get_current_entry().is_uncouple_child()) {
-			c->uncouple_convoi();
-		}
-		c = child_convoy;
-	}
 }
 
 

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -160,6 +160,7 @@ void convoi_t::init(player_t *player)
 	next_coupling_steps = 0;
 
 	coupling_done = false;
+	uncouple_done = false;
 
 	coupling_convoi = convoihandle_t();
 
@@ -1945,8 +1946,6 @@ void convoi_t::ziel_erreicht()
 			c->set_arrived_time(world()->get_ticks());
 			c = c->get_coupling_convoi();
 		}
-		// check uncouple its child (set in schedule_entry)
-		uncouple_convoy_by_schedule_setting();
 	}
 	else {
 		// Neither depot nor station: waypoint
@@ -2447,6 +2446,7 @@ void convoi_t::vorfahren()
 		// the back vehicles position is set.
 		if (c->reversing_needed){
 			c->reverse_vehicles_at_halt_if_needed();
+			c->uncouple_done = false;
 		}
 		c = c->get_coupling_convoi();
 	}
@@ -3211,6 +3211,11 @@ void convoi_t::rdwr(loadsave_t *file)
 		reversed = false;
 		reversing_needed = true;
 	}
+	if(  file->get_OTRP_version()>=47  ) {
+		file->rdwr_bool(uncouple_done);
+	} else {
+		uncouple_done=false;
+	}
 
 	if(  file->is_loading()  ) {
 		reserve_route();
@@ -3737,8 +3742,8 @@ void convoi_t::hat_gehalten(halthandle_t halt, uint32 halt_length_in_vehicle_ste
 {
 	convoihandle_t c = self;
 
-
 	if(  get_coupling_convoi().is_bound() && !is_coupled()  ) {
+		uncouple_convoy_by_schedule_setting();
 		convoihandle_t const temp_parent_convoi = self;
 		bool coupled_at_this_stop = false;
 		while(  c->get_coupling_convoi().is_bound()  ) {
@@ -5722,8 +5727,9 @@ void convoi_t::uncouple_convoy_by_schedule_setting()
 	while( c.is_bound() ) {
 		// to keep child convoy because it may be uncouple now!
 		convoihandle_t child_convoy = c->get_coupling_convoi();
-		if(c->get_schedule()->get_current_entry().is_uncouple_child()) {
+		if(c->get_schedule()->get_current_entry().is_uncouple_child()&&!c->uncouple_done) {
 			c->uncouple_convoi();
+			c->uncouple_done=true;
 		}
 		c = child_convoy;
 	}

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -1931,6 +1931,8 @@ void convoi_t::ziel_erreicht()
 				set_next_coupling(route_t::INVALID_INDEX, 0);
 				v->get_convoi()->set_coupling_done(true);
 				coupling_done = true;
+				// before reverse convoy coupling, we ask it to uncouple its child or not (set in schedule_entry)
+				uncouple_convoy_by_schedule_setting();
 				// then, chage the order if next direction is backward of "self"
 				// Attention! reverse_convoy_coupling() must be called when loading!
 				// if we call it before stop, the convoys will be reversed immediately, and it makes position calculation bug. 
@@ -1955,6 +1957,8 @@ void convoi_t::ziel_erreicht()
 			c->set_arrived_time(world()->get_ticks());
 			c = c->get_coupling_convoi();
 		}
+		// check uncouple its child (set in schedule_entry)
+		uncouple_convoy_by_schedule_setting();
 	}
 	else {
 		// Neither depot nor station: waypoint
@@ -5026,7 +5030,6 @@ const char* convoi_t::send_to_depot_immediately(bool local)
 			txt = "%s leads\ndifferent owner's or\ndifferent waytype convoy.\n",get_name();
 			return txt;
 		}
-		c = c->get_coupling_convoi();
 	} 
 	// iterate over all depots and try to find shortest route
 	route_t *shortest_route = new route_t();
@@ -5622,7 +5625,7 @@ void convoi_t::next_stop_button_pressed() {
 	while( c.is_bound() ) {
 		schedule_t *schedule = c->get_schedule();
 		convoihandle_t const temp_c = c->get_coupling_convoi();
-		if( !c->can_continue_coupling() ) {
+		if( !c->can_continue_coupling() || schedule->get_current_entry().is_uncouple_child() ) {
 			c->uncouple_convoi();
 		}
 		c->change_line_to_next_if_needed();
@@ -5672,6 +5675,19 @@ void convoi_t::unset_convoi_coupling_in_progress() {
 	c->delete_convoi_coupling_in_progress();
 	self->delete_convoi_coupling_in_progress();
 	dbg->message( "convoi_t::unset_convoi_coupling_in_progress()","%i and %i convoys are now coupling or canceling couple", self.get_id(), c->self.get_id() );
+}
+
+void convoi_t::uncouple_convoy_by_schedule_setting()
+{
+	convoihandle_t c = self;
+	while( c.is_bound() ) {
+		// to keep child convoy because it may be uncouple now!
+		convoihandle_t child_convoy = c->get_coupling_convoi();
+		if(c->get_schedule()->get_current_entry().is_uncouple_child()) {
+			c->uncouple_convoi();
+		}
+		c = child_convoy;
+	}
 }
 
 

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -1111,10 +1111,7 @@ public:
 	// the new line is stored in schedule->next_line_id
 	void change_line_to_next_if_needed();
 
-	// uncouple child concoy by schedule_entry
-	// this function should be called in ziel_erreicht() or at waypoint
-	// this function must be called after stop or reach waypoint & before reverse convoy coupling!
-	void uncouple_convoy_by_schedule_setting();
+
 
 };
 

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -1118,6 +1118,11 @@ public:
 	// the new line is stored in schedule->next_line_id
 	void change_line_to_next_if_needed();
 
+	// uncouple child concoy by schedule_entry
+	// this function should be called in ziel_erreicht() or at waypoint
+	// this function must be called after stop or reach waypoint & before reverse convoy coupling!
+	void uncouple_convoy_by_schedule_setting();
+
 };
 
 #endif

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -254,6 +254,11 @@ private:
 	bool no_load;
 
 	/**
+	* uncouple at this stop
+	*/
+	bool uncouple_done;
+
+	/**
 	* the convoi caches its freight info; it is only recalculation after loading or resorting
 	*/
 	bool freight_info_resort;

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -1111,7 +1111,10 @@ public:
 	// the new line is stored in schedule->next_line_id
 	void change_line_to_next_if_needed();
 
-
+	// uncouple child concoy by schedule_entry
+	// this function should be called in ziel_erreicht() or at waypoint
+	// this function must be called after stop or reach waypoint & before reverse convoy coupling!
+	void uncouple_convoy_by_schedule_setting();
 
 };
 

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -1227,6 +1227,8 @@ void vehicle_t::hop(grund_t* gr)
 		}
 		else {
 			cnv->register_journey_time();
+			// before reverse convoy coupling, uncouple child
+			cnv->uncouple_convoy_by_schedule_setting();
 			// advance schedule for all coupling convoys.
 			// check reverse convoy coupling at this stop
 			if(  cnv->self->reverse_convoy_coupling_at_waypoint()  ) {
@@ -1234,20 +1236,22 @@ void vehicle_t::hop(grund_t* gr)
 				return;
 			}
 			convoihandle_t c = cnv->self;
-			convoihandle_t child = c->get_coupling_convoi(); 
 			while(  c.is_bound()  ) {
 				if(c->get_schedule()->get_current_entry().is_reverse_convoy()) {
 					c->reverse_vehicles_on_user_request();
 				}
 				c->set_time_last_arrived(world()->get_ticks());
-				if(  !c->can_continue_coupling()  ) {
+				c->get_schedule()->advance();
+				c = c->get_coupling_convoi();
+			}
+			c = cnv->self;
+			convoihandle_t child = c->get_coupling_convoi(); 
+			while(  child.is_bound()  ) {
+				if( c->get_schedule()->get_current_entry().pos != child->get_schedule()->get_current_entry().pos ) {
 					c->uncouple_convoi();
 				}
-				c->get_schedule()->advance();
 				c = child;
-				if(  child.is_bound()  ) {
-					child = child->get_coupling_convoi();
-				}
+				child = child->get_coupling_convoi();
 			}
 			const koord3d ziel = cnv->get_schedule()->get_current_entry().pos;
 			cnv->set_schedule_target( cnv->is_waypoint(ziel) ? ziel : koord3d::invalid );

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -1227,6 +1227,8 @@ void vehicle_t::hop(grund_t* gr)
 		}
 		else {
 			cnv->register_journey_time();
+			// before reverse convoy coupling, uncouple child
+			cnv->uncouple_convoy_by_schedule_setting();
 			// advance schedule for all coupling convoys.
 			// check reverse convoy coupling at this stop
 			if(  cnv->self->reverse_convoy_coupling_at_waypoint()  ) {

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -1227,8 +1227,6 @@ void vehicle_t::hop(grund_t* gr)
 		}
 		else {
 			cnv->register_journey_time();
-			// before reverse convoy coupling, uncouple child
-			cnv->uncouple_convoy_by_schedule_setting();
 			// advance schedule for all coupling convoys.
 			// check reverse convoy coupling at this stop
 			if(  cnv->self->reverse_convoy_coupling_at_waypoint()  ) {
@@ -1236,22 +1234,20 @@ void vehicle_t::hop(grund_t* gr)
 				return;
 			}
 			convoihandle_t c = cnv->self;
+			convoihandle_t child = c->get_coupling_convoi(); 
 			while(  c.is_bound()  ) {
 				if(c->get_schedule()->get_current_entry().is_reverse_convoy()) {
 					c->reverse_vehicles_on_user_request();
 				}
 				c->set_time_last_arrived(world()->get_ticks());
-				c->get_schedule()->advance();
-				c = c->get_coupling_convoi();
-			}
-			c = cnv->self;
-			convoihandle_t child = c->get_coupling_convoi(); 
-			while(  child.is_bound()  ) {
-				if( c->get_schedule()->get_current_entry().pos != child->get_schedule()->get_current_entry().pos ) {
+				if(  !c->can_continue_coupling()  ) {
 					c->uncouple_convoi();
 				}
+				c->get_schedule()->advance();
 				c = child;
-				child = child->get_coupling_convoi();
+				if(  child.is_bound()  ) {
+					child = child->get_coupling_convoi();
+				}
 			}
 			const koord3d ziel = cnv->get_schedule()->get_current_entry().pos;
 			cnv->set_schedule_target( cnv->is_waypoint(ziel) ? ziel : koord3d::invalid );


### PR DESCRIPTION
スケジュールにuncoupleボタンを追加しました
このボタンを押すと、その駅/中継点に到着したときに自身の子編成のみを分割します(cnv->uncouple()を呼びます)
動作条件は
・駅/中継点到着時またはnext_stop_button押下時
・連結反転動作前(=連結時は連結直後の親決め前)