### PR TITLE
貨物の積載/荷下ろし処理の高速化

### DIFF
--- a/simhalt.cc
+++ b/simhalt.cc
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "freight_list_sorter.h"
 
@@ -90,6 +91,300 @@ struct halt_waiting_goods_t {
 
 	halt_waiting_goods_t(const ware_t& w, uint32 t) : goods(w), arrived_time(t) {}
     halt_waiting_goods_t() : arrived_time(INVALID_CARGO_ARRIVED_TIME) {}
+};
+
+
+// The data structure to append and pop the cargo items with less than O(N) calculation,
+// where N is the number of cargo items in the queue.
+struct haltestelle_t::cargo_queue_t {
+	private:
+		struct item_t;
+		typedef std::list<std::list<item_t>::iterator> item_iterator_list;
+
+		struct item_t {
+			cargo_item_t cargo;
+			uint64 index;
+
+			// inverted indexes
+			uint16 zwischenziel_id;
+			// The iterator to this item's iterator in zwischenziel_index.
+			item_iterator_list::iterator zwischenziel_iter;
+			uint16 ziel_id;
+			// The iterator to this item's iterator in ziel_index.
+			item_iterator_list::iterator ziel_iter;
+
+			item_t(const cargo_item_t& c, uint64 idx): cargo(c), index(idx) {
+				zwischenziel_id = c->goods.get_zwischenziel().get_id();
+				ziel_id = c->goods.get_ziel().get_id();
+				// Initialize iterators to empty
+				zwischenziel_iter = item_iterator_list::iterator();
+				ziel_iter = item_iterator_list::iterator();
+			}
+		};
+		std::list<item_t> cargos;
+
+		// key: halt id to get off, value: the vector of the cargo item iterators
+		std::unordered_map<uint16, item_iterator_list> zwischenziel_index;
+
+		// key: halt id of final destination, value: the vector of the cargo item iterators
+		std::unordered_map<uint16, item_iterator_list> ziel_index;
+
+		// The set of the halt id whose ziel_index needs re-sorting.
+		std::unordered_set<uint16> ziel_index_resorting_halts;
+
+		// The set of the halt id whose zwischenziel_index needs re-sorting.
+		std::unordered_set<uint16> zwischenziel_index_resorting_halts;
+
+	public:
+		// Iterator wrapper class
+		class iterator {
+		private:
+			std::list<item_t>::iterator it;
+			
+		public:
+			iterator(std::list<item_t>::iterator iter) : it(iter) {}
+
+			cargo_item_t& operator*() { return it->cargo; }
+			cargo_item_t* operator->() { return &it->cargo; }
+			const cargo_item_t* operator->() const { return &it->cargo; }
+
+			bool operator==(const iterator& other) const { return it == other.it; }
+			bool operator!=(const iterator& other) const { return !(*this == other); }
+			
+			iterator& operator++() { 
+				++it;
+				return *this;
+			}
+			iterator operator++(int) {
+				iterator tmp(*this);
+				it++;
+				return tmp;
+			}
+			
+			friend struct cargo_queue_t;
+		};
+		
+		// Const iterator wrapper class
+		class const_iterator {
+		private:
+			std::list<item_t>::const_iterator it;
+			
+		public:
+			const_iterator(std::list<item_t>::const_iterator iter) : it(iter) {}
+
+			const cargo_item_t& operator*() const { return it->cargo; }
+			const cargo_item_t* operator->() const { return &it->cargo; }
+
+			bool operator==(const const_iterator& other) const { return it == other.it; }
+			bool operator!=(const const_iterator& other) const { return !(*this == other); }
+			
+			const_iterator& operator++() { 
+				++it;
+				return *this;
+			}
+			const_iterator operator++(int) {
+				const_iterator tmp(*this);
+				it++;
+				return tmp;
+			}
+			
+			friend struct cargo_queue_t;
+		};
+
+		class zwischenziel_iterator {
+		private:
+			item_iterator_list::iterator list_iter;
+			halthandle_t zwischenziel;
+
+		public:
+			zwischenziel_iterator() = default;
+			zwischenziel_iterator(item_iterator_list::iterator iter, halthandle_t id) : list_iter(iter), zwischenziel(id) {}
+
+			cargo_item_t& operator*() { return (*list_iter)->cargo; }
+			cargo_item_t* operator->() { return &((*list_iter)->cargo); }
+
+			bool operator==(const zwischenziel_iterator& other) const {
+				return zwischenziel == other.zwischenziel && list_iter == other.list_iter;
+			}
+			bool operator!=(const zwischenziel_iterator& other) const { return !(*this == other); }
+
+			zwischenziel_iterator& operator++() {
+				++list_iter;
+				return *this;
+			}
+			zwischenziel_iterator operator++(int) {
+				zwischenziel_iterator tmp(*this);
+				++list_iter;
+				return tmp;
+			}
+
+			halthandle_t get_zwischenziel() const { return zwischenziel; }
+			uint64 get_storage_index() const { return (*(list_iter))->index; }
+
+			friend struct cargo_queue_t;
+		};
+		
+		// Invalid iterator
+		iterator end_iterator() { return iterator(cargos.end()); }
+
+		// Invalid const iterator
+		const_iterator end_iterator() const { return const_iterator(cargos.end()); }
+
+		zwischenziel_iterator zwischenziel_begin(halthandle_t zwischenziel) {
+			auto& list = zwischenziel_index[zwischenziel.get_id()];
+			if (list.empty()) {
+				return zwischenziel_iterator(list.end(), zwischenziel);
+			}
+			return zwischenziel_iterator(list.begin(), zwischenziel);
+		}
+
+		zwischenziel_iterator zwischenziel_end(halthandle_t zwischenziel) {
+			auto& list = zwischenziel_index[zwischenziel.get_id()];
+			return zwischenziel_iterator(list.end(), zwischenziel);
+		}
+
+		void append(const cargo_item_t& item) {
+			// Create a new item in the storage
+			uint64 item_index = cargos.empty() ? 0 : cargos.back().index + 1;
+			cargos.push_back(item_t(item, item_index));
+			std::list<item_t>::iterator item_iterator = std::prev(cargos.end());
+
+			item_iterator_list& zwischenziel_itr_list = zwischenziel_index[item.get()->goods.get_zwischenziel().get_id()];
+			zwischenziel_itr_list.push_back(item_iterator);
+			item_iterator->zwischenziel_iter = std::prev(zwischenziel_itr_list.end());
+
+			item_iterator_list& ziel_itr_list = ziel_index[item.get()->goods.get_ziel().get_id()];
+			ziel_itr_list.push_back(item_iterator);
+			item_iterator->ziel_iter = std::prev(ziel_itr_list.end());
+		}
+
+		// TODO: hide internal properties
+		const std::list<std::list<item_t>::iterator>& get_ziel_iterators(halthandle_t ziel) const {
+			if(ziel_index.find(ziel.get_id()) == ziel_index.end()) {
+				static std::list<std::list<item_t>::iterator> empty_list;
+				return empty_list; // Return an empty list if no items found
+			}
+			return ziel_index.at(ziel.get_id());
+		}
+
+		// Erase function compatible with slist_tpl iterators - returns iterator to next element
+		iterator erase(const iterator& iter) {
+			if (iter == end_iterator()) {
+				return iterator(cargos.end());
+			}
+			// Erase from the index tables.
+			zwischenziel_index[iter.it->zwischenziel_id].erase(iter.it->zwischenziel_iter);
+			ziel_index[iter.it->ziel_id].erase(iter.it->ziel_iter);
+
+			// Erase from cargos and return next iterator
+			return iterator(cargos.erase(iter.it));
+		}
+
+		zwischenziel_iterator erase(const zwischenziel_iterator& iter) {
+			halthandle_t zwischenziel = iter.zwischenziel;
+			if (iter == zwischenziel_end(zwischenziel)) {
+				return zwischenziel_end(zwischenziel);
+			}
+			// Make a local copy of the item here since it will be removed from cargos.
+			item_t item_copy = **iter.list_iter;
+			cargos.erase(*iter.list_iter); // Erase from cargos
+			ziel_index[item_copy.ziel_id].erase(item_copy.ziel_iter);
+			auto next_itr = zwischenziel_index[item_copy.zwischenziel_id].erase(iter.list_iter);
+			return zwischenziel_iterator(next_itr, zwischenziel);
+		}
+
+		// Updates the storage internal index of the given iterator.
+		// IMPORTANT: Call sort_indices after calling update_index for all required iterators.
+		void update_index(const iterator& iter) {
+			const uint16 ziel_id = iter->get()->goods.get_ziel().get_id();
+			if(  iter.it->ziel_id!=ziel_id  ) {
+				// Ziel changed
+				// Remove from old index
+				ziel_index[iter.it->ziel_id].erase(iter.it->ziel_iter);
+				// Add to new index
+				iter.it->ziel_id = ziel_id;
+				item_iterator_list& ziel_itr_list = ziel_index[ziel_id];
+				// Sorted later by sort_indices. Append to the last to reduce the calculation cost.
+				ziel_itr_list.push_back(iter.it);
+				iter.it->ziel_iter = std::prev(ziel_itr_list.end());
+				ziel_index_resorting_halts.insert(ziel_id);
+			}
+			const uint16 zwischenziel_id = iter->get()->goods.get_zwischenziel().get_id();
+			if(  iter.it->zwischenziel_id!=zwischenziel_id  ) {
+				// Zwischenziel changed
+				// Remove from old index
+				zwischenziel_index[iter.it->zwischenziel_id].erase(iter.it->zwischenziel_iter);
+				// Add to new index
+				iter.it->zwischenziel_id = zwischenziel_id;
+				item_iterator_list& zwischenziel_itr_list = zwischenziel_index[zwischenziel_id];
+				// Sorted later by sort_indices. Append to the last to reduce the calculation cost.
+				zwischenziel_itr_list.push_back(iter.it);
+				iter.it->zwischenziel_iter = std::prev(zwischenziel_itr_list.end());
+				zwischenziel_index_resorting_halts.insert(zwischenziel_id);
+			}
+		}
+
+		void update_index(const zwischenziel_iterator& iter) {
+			update_index(iterator(*iter.list_iter));
+		}
+
+		void sort_indices() {
+			// Sort the zwischenziel_index entries which need resorting
+			for (uint16 halt_id : zwischenziel_index_resorting_halts) {
+				item_iterator_list& list = zwischenziel_index[halt_id];
+				if (list.size() <= 1) {
+					continue; // No need to sort
+				}
+				list.sort([](const std::list<item_t>::iterator& a, const std::list<item_t>::iterator& b) {
+					return a->index < b->index;
+				});
+			}
+			zwischenziel_index_resorting_halts.clear();
+
+			// Sort the ziel_index entries which need resorting
+			for (uint16 halt_id : ziel_index_resorting_halts) {
+				item_iterator_list& list = ziel_index[halt_id];
+				if (list.size() <= 1) {
+					continue; // No need to sort
+				}
+				list.sort([](const std::list<item_t>::iterator& a, const std::list<item_t>::iterator& b) {
+					return a->index < b->index;
+				});
+			}
+			ziel_index_resorting_halts.clear();
+		}
+
+		bool empty() const { return cargos.empty(); }
+
+		uint32 get_count() const { return cargos.size(); }
+
+		void clear() {
+			cargos.clear();
+			zwischenziel_index.clear();
+			ziel_index.clear();
+		}
+
+		// Sets all zwischenziels of the waiting items in the storage
+		void get_zwischenziel_of_items(vector_tpl<halthandle_t>& zwischenziels) const {
+			for(const auto& zwischenziel_index_entry : zwischenziel_index) {
+				if(zwischenziel_index_entry.second.empty()) {
+					continue;
+				}
+				const halthandle_t zwischenziel = (*zwischenziel_index_entry.second.cbegin())->cargo.get()->goods.get_zwischenziel();
+				if(zwischenziel.get_id() != zwischenziel_index_entry.first) {
+					dbg->error("cargo_queue_t::get_zwischenziel_of_items", "Inconsistent zwischenziel index: id %d, zwischenziel id %d", zwischenziel_index_entry.first, zwischenziel.get_id());
+				}
+				zwischenziels.append(zwischenziel);
+			}
+		}
+
+		// Provide range-based iteration support
+		iterator begin() { return iterator(cargos.begin()); }
+		iterator end() { return iterator(cargos.end()); }
+		const_iterator begin() const { return const_iterator(cargos.begin()); }
+		const_iterator end() const { return const_iterator(cargos.end()); }
+		const_iterator cbegin() const { return const_iterator(cargos.cbegin()); }
+		const_iterator cend() const { return const_iterator(cargos.cend()); }
 };
 
 void haltestelle_t::reset_routing()
@@ -476,7 +771,7 @@ haltestelle_t::haltestelle_t(loadsave_t* file)
 {
 	last_loading_step = welt->get_steps();
 
-	cargo = (slist_tpl<cargo_item_t> **)calloc( goods_manager_t::get_max_catg_index(), sizeof(slist_tpl<cargo_item_t> *) );
+	cargo = new cargo_queue_t*[goods_manager_t::get_max_catg_index()];
 	fresh_cargo.resize( goods_manager_t::get_max_catg_index() );
 	all_links = new link_t[ goods_manager_t::get_max_catg_index() ];
 	staged_all_links = NULL;
@@ -520,7 +815,7 @@ haltestelle_t::haltestelle_t(koord k, player_t* player)
 	reconnect_counter = welt->get_schedule_counter()-1;
 	last_catg_index = 255;
 
-	cargo = (slist_tpl<cargo_item_t> **)calloc( goods_manager_t::get_max_catg_index(), sizeof(slist_tpl<cargo_item_t> *) );
+	cargo = new cargo_queue_t*[goods_manager_t::get_max_catg_index()];
 	fresh_cargo.resize( goods_manager_t::get_max_catg_index() );
 	all_links = new link_t[ goods_manager_t::get_max_catg_index() ];
 	staged_all_links = NULL;
@@ -585,15 +880,14 @@ haltestelle_t::~haltestelle_t()
 	self.detach();
 
 	for(unsigned i=0; i<goods_manager_t::get_max_catg_index(); i++) {
-		if (cargo[i]) {
-			FOR(slist_tpl<cargo_item_t>, const &w, *cargo[i]) {
+		if(cargo[i]) {
+			for(const auto& w : *cargo[i]) {
 				fabrik_t::update_transit(&w->goods, false);
 			}
 			delete cargo[i];
-			cargo[i] = NULL;
 		}
 	}
-	free( cargo );
+	delete[] cargo;
 	delete[] all_links;
 	if(  staged_all_links  ) {
 		delete[] staged_all_links;
@@ -611,16 +905,16 @@ void haltestelle_t::rotate90( const sint16 y_size )
 	// rotate cargo (good) destinations
 	// iterate over all different categories
 	for(unsigned i=0; i<goods_manager_t::get_max_catg_index(); i++) {
-		if(cargo[i]) {
-			slist_tpl<cargo_item_t>& warray = *cargo[i];
-			for (  slist_tpl<cargo_item_t>::iterator ware = warray.begin();  ware!=warray.end();  ) {
-				if(  ware->get()->goods.menge>0  ) {
-					ware->get()->goods.rotate90(y_size);
-					ware ++;
-				} else {
-					// empty => remove
-					ware = warray.erase(ware);
-				}
+		if(cargo[i]==NULL) {
+			continue;
+		}
+		for(haltestelle_t::cargo_queue_t::iterator ware = cargo[i]->begin(); ware != cargo[i]->end();) {
+			if(ware->get()->goods.menge > 0) {
+				ware->get()->goods.rotate90(y_size);
+				ware++;
+			} else {
+				// empty => remove
+				ware = cargo[i]->erase(ware);
 			}
 		}
 	}
@@ -1118,8 +1412,8 @@ bool haltestelle_t::reroute_goods(sint16 &units_remaining)
 		}
 
 		// first: clean out the array
-		slist_tpl<cargo_item_t> * warray = cargo[last_catg_index];
-		for (  slist_tpl<cargo_item_t>::iterator ware = warray->begin(); ware!=warray->end();  ) {
+		cargo_queue_t * warray = cargo[last_catg_index];
+		for (  cargo_queue_t::iterator ware = warray->begin(); ware!=warray->end();  ) {
 			const ware_t& goods = ware->get()->goods;
 			if(  goods.menge==0  ) {
 				ware = warray->erase(ware);
@@ -1148,7 +1442,7 @@ bool haltestelle_t::reroute_goods(sint16 &units_remaining)
 		// if something left
 		// re-route goods to adapt to changes in world layout,
 		// remove all goods whose destination was removed from the map
-		for(  slist_tpl<cargo_item_t>::iterator ware = warray->begin();  ware!=warray->end();  ) {
+		for(  cargo_queue_t::iterator ware = warray->begin();  ware!=warray->end();  ) {
 			ware_t& goods = ware->get()->goods;
 			if(  !is_route_search_needed(goods)  ) {
 				ware++;
@@ -1161,10 +1455,11 @@ bool haltestelle_t::reroute_goods(sint16 &units_remaining)
 				ware = warray->erase(ware);
 			}
 			else {
+				warray->update_index(ware);
 				ware++;
 			}
 		}
-
+		warray->sort_indices(); // Required to call after calling update_index()
 	}
 	// likely the display must be updated after this
 	resort_freight_info = true;
@@ -2235,9 +2530,9 @@ void haltestelle_t::liefere_an_fabrik(const ware_t& ware) const
 bool haltestelle_t::recall_ware( ware_t& w, uint32 menge )
 {
 	w.menge = 0;
-	slist_tpl<cargo_item_t> *warray = cargo[w.get_desc()->get_catg_index()];
+	cargo_queue_t *warray = cargo[w.get_desc()->get_catg_index()];
 	if(warray!=NULL) {
-		FOR(slist_tpl<cargo_item_t>, & tmp, *warray) {
+		for(cargo_item_t &tmp : *warray) {
 			ware_t& goods = tmp->goods;
 			// skip empty entries
 			if(goods.menge==0  ||  w.get_index()!=goods.get_index()  ||  w.get_zielpos()!=goods.get_zielpos()) {
@@ -2267,120 +2562,119 @@ bool haltestelle_t::recall_ware( ware_t& w, uint32 menge )
 
 
 void haltestelle_t::fetch_goods_nearest_first(slist_tpl<ware_t> &load, const goods_desc_t *good_category, uint32 requested_amount, const vector_tpl<halthandle_t>& destination_halts) {
-	slist_tpl<cargo_item_t> *wares = cargo[good_category->get_catg_index()];
+	cargo_queue_t *wares = cargo[good_category->get_catg_index()];
 	if(  !wares  ||  wares->empty()  ) {
 		return;
 	}
+	search_route_for_invalid_zwischenziel_goods(wares);
+
 	// first iterate over the next stop, then over the ware
 	// might be a little slower, but ensures that passengers to nearest stop are served first
 	// this allows for separate high speed and normal service
 	for(  uint32 i=0; i < destination_halts.get_count();  i++  ) {
 		halthandle_t plan_halt = destination_halts[i];
 
-		// REMOVED: The random offset will ensure that all goods have an equal chance to be loaded.
-		for(  slist_tpl<cargo_item_t>::iterator tmp = wares->begin();  tmp!=wares->end();  tmp++) {
-			ware_t& goods = tmp->get()->goods;
-			// skip empty entries
+		for( cargo_queue_t::zwischenziel_iterator iter = wares->zwischenziel_begin(plan_halt);  iter != wares->zwischenziel_end(plan_halt);) {
+			ware_t& goods = iter->get()->goods;
 			if(goods.menge==0) {
+				iter = wares->erase(iter);
 				continue;
 			}
 
-			// goods without route -> returning passengers/mail
-			if(  !goods.get_zwischenziel().is_bound()  ) {
-				search_route_resumable(goods);
-				if (!goods.get_ziel().is_bound()) {
-					// no route anymore
-					goods.menge = 0;
+			// compatible car and right target stop?
+			if(  plan_halt->is_overcrowded( goods.get_index() )  ) {
+				if (welt->get_settings().is_avoid_overcrowding() && goods.get_ziel() != plan_halt) {
+					// do not go for transfer to overcrowded transfer stop
+					iter++;
 					continue;
 				}
 			}
 
-			// compatible car and right target stop?
-			if(  goods.get_zwischenziel()==plan_halt  ) {
-				if(  plan_halt->is_overcrowded( goods.get_index() )  ) {
-					if (welt->get_settings().is_avoid_overcrowding() && goods.get_ziel() != plan_halt) {
-						// do not go for transfer to overcrowded transfer stop
-						continue;
-					}
-				}
+			// not too much?
+			ware_t neu(goods);
+			if(  goods.menge > requested_amount  ) {
+				// not all can be loaded
+				neu.menge = requested_amount;
+				goods.menge -= requested_amount;
+				requested_amount = 0;
+			}
+			else {
+				requested_amount -= goods.menge;
+				goods.menge = 0;
+				iter = wares->erase(iter);
+			}
+			load.insert(neu);
 
-				// not too much?
-				ware_t neu(goods);
-				if(  goods.menge > requested_amount  ) {
-					// not all can be loaded
-					neu.menge = requested_amount;
-					goods.menge -= requested_amount;
-					requested_amount = 0;
-				}
-				else {
-					requested_amount -= goods.menge;
-					// leave an empty entry => joining will more often work
-					goods.menge = 0;
-				}
-				load.insert(neu);
+			book(neu.menge, HALT_DEPARTED);
+			resort_freight_info = true;
 
-				book(neu.menge, HALT_DEPARTED);
-				resort_freight_info = true;
-
-				if (requested_amount==0) {
-					return;
-				}
+			if (requested_amount==0) {
+				return;
 			}
 		}
-
 		// nothing there to load
 	}
 }
 
 
 void haltestelle_t::fetch_goods_FIFO(slist_tpl<ware_t> &load, const goods_desc_t *good_category, uint32 requested_amount, const vector_tpl<halthandle_t>& destination_halts) {
-	slist_tpl<cargo_item_t> *wares = cargo[good_category->get_catg_index()];
-	if(  !wares  ||  wares->empty()  ) {
+	cargo_queue_t *wares = cargo[good_category->get_catg_index()];
+	if(  !wares  ||  wares->empty()  ||  destination_halts.empty()  ) {
 		return;
 	}
-	// The table to check if a specific halt is contained in the destination_halts vector quickly.
-	// The vector size is 65536 because the halt id is 16 bit.
-	bool dest_halts_table[65536];
-	MEMZERON(dest_halts_table, 65536);
-	FOR(vector_tpl<halthandle_t>, const& h, destination_halts) {
-		dest_halts_table[h.get_id()] = true;
-	}
+	search_route_for_invalid_zwischenziel_goods(wares);
 
-	for(  slist_tpl<cargo_item_t>::iterator ware = wares->begin();  ware!=wares->end();  ) {
-		ware_t& goods = ware->get()->goods;
-		// empty entry -> remove
-		if(goods.menge==0) {
-			ware = wares->erase(ware);
-			continue;
-		}
-
-		// goods without route -> returning passengers/mail
-		if(  !goods.get_zwischenziel().is_bound()  ) {
-			search_route_resumable(goods);
-			if (!goods.get_ziel().is_bound()) {
-				// no route anymore
-				ware = wares->erase(ware);
-				continue;
+	auto increment_while_zwischenziel_is_overcrowded = [&](cargo_queue_t::zwischenziel_iterator& iter) {
+		while(iter != wares->zwischenziel_end(iter.get_zwischenziel())) {
+			ware_t& goods = (*iter)->goods;
+			const bool is_ware_to_overcrowded_halt = welt->get_settings().is_avoid_overcrowding()  &&
+				goods.get_zwischenziel()->is_overcrowded(goods.get_index())  &&
+				goods.get_ziel() != goods.get_zwischenziel();
+			if(  is_ware_to_overcrowded_halt  ) {
+				++iter;
+			} else {
+				break;
 			}
 		}
+	};
 
-		// right target stop, and not overcrowding?
-		// do not go for transfer to overcrowded transfer stop
-		if(
-			!dest_halts_table[goods.get_zwischenziel().get_id()]  ||
-			(welt->get_settings().is_avoid_overcrowding()  &&
-				goods.get_zwischenziel()->is_overcrowded( goods.get_index() )  &&
-				goods.get_ziel() != goods.get_zwischenziel())
-		) {
-			ware++;
+	// Key: destination halt id, value: the iterator to the earliest cargo item to the destination.
+	std::unordered_map<uint16, cargo_queue_t::zwischenziel_iterator> dest_cargo_item_map;
+	// First, fill dest_cargo_item_map
+	FOR(vector_tpl<halthandle_t>, const& h, destination_halts) {
+		cargo_queue_t::zwischenziel_iterator first_item_itr = wares->zwischenziel_begin(h);
+		increment_while_zwischenziel_is_overcrowded(first_item_itr);
+		dest_cargo_item_map[h.get_id()] = first_item_itr;
+	}
+
+	while(requested_amount > 0) {
+		// Pick the goods whose storage index is the earliest across all destinations.
+		cargo_queue_t::zwischenziel_iterator first_item_itr = std::min_element(
+			dest_cargo_item_map.begin(), 
+			dest_cargo_item_map.end(),
+			[&](const auto& a, const auto& b) {
+				// Compare by storage index
+				uint64 storage_index_a = a.second == wares->zwischenziel_end(a.second.get_zwischenziel()) ? UINT64_MAX : a.second.get_storage_index();
+				uint64 storage_index_b = b.second == wares->zwischenziel_end(b.second.get_zwischenziel()) ? UINT64_MAX : b.second.get_storage_index();
+				return storage_index_a < storage_index_b;
+			}
+		)->second;
+		if(first_item_itr == wares->zwischenziel_end(first_item_itr.get_zwischenziel())) {
+			// no more goods for these destination halts
+			break;
+		}
+		ware_t& goods = first_item_itr->get()->goods;
+		if (goods.menge == 0) {
+			cargo_queue_t::zwischenziel_iterator next_item_itr = wares->erase(first_item_itr);
+			increment_while_zwischenziel_is_overcrowded(next_item_itr);
+			dest_cargo_item_map[next_item_itr.get_zwischenziel().get_id()] = next_item_itr;
 			continue;
 		}
 
-		// not too much?
-		ware_t neu(goods);
+		ware_t new_goods(goods);
 		if(  goods.menge > requested_amount  ) {
 			// not all can be loaded
-			neu.menge = requested_amount;
+			new_goods.menge = requested_amount;
 			goods.menge -= requested_amount;
 			requested_amount = 0;
 		}
@@ -2388,26 +2682,53 @@ void haltestelle_t::fetch_goods_FIFO(slist_tpl<ware_t> &load, const goods_desc_t
 			requested_amount -= goods.menge;
 			// leave an empty entry => joining will more often work
 			goods.menge = 0;
-			ware = wares->erase(ware);
+			cargo_queue_t::zwischenziel_iterator next_item_itr = wares->erase(first_item_itr);
+			increment_while_zwischenziel_is_overcrowded(next_item_itr);
+			dest_cargo_item_map[next_item_itr.get_zwischenziel().get_id()] = next_item_itr;
 		}
-		load.insert(neu);
+		load.insert(new_goods);
 
-		book(neu.menge, HALT_DEPARTED);
+		book(new_goods.menge, HALT_DEPARTED);
 		resort_freight_info = true;
+	}
+}
 
-		if (requested_amount==0) {
-			return;
+
+void haltestelle_t::search_route_for_invalid_zwischenziel_goods(cargo_queue_t *wares) {
+vector_tpl<halthandle_t> goods_zwischenziels;
+	wares->get_zwischenziel_of_items(goods_zwischenziels);
+	vector_tpl<cargo_queue_t::zwischenziel_iterator> rerouted_iterators;
+	for(const auto& zwischenziel : goods_zwischenziels) {
+		if(  zwischenziel.is_bound()  ) {
+			continue;
+		}
+		// Needs rerouting
+		for(cargo_queue_t::zwischenziel_iterator itr = wares->zwischenziel_begin(zwischenziel); itr != wares->zwischenziel_end(zwischenziel);)
+		{
+			search_route_resumable(itr->get()->goods);
+			if(  itr->get()->goods.get_ziel().is_bound()  ) {
+				// update_index should not be called here. Otherwise, search_route_resumable may be ran for already rerouted goods.
+				rerouted_iterators.append(itr);
+				itr++;
+			} else {
+				// no route anymore
+				itr = wares->erase(itr);
+			}
 		}
 	}
+	for(cargo_queue_t::zwischenziel_iterator itr : rerouted_iterators) {
+		wares->update_index(itr);
+	}
+	wares->sort_indices();
 }
 
 
 uint32 haltestelle_t::get_ware_summe(const goods_desc_t *wtyp) const
 {
 	int sum = 0;
-	const slist_tpl<cargo_item_t> * warray = cargo[wtyp->get_catg_index()];
+	const cargo_queue_t * warray = cargo[wtyp->get_catg_index()];
 	if(warray!=NULL) {
-		FOR(slist_tpl<cargo_item_t>, const& i, *warray) {
+		for(const cargo_item_t& i : *warray) {
 			if (wtyp->get_index() == i->goods.get_index()) {
 				sum += i->goods.menge;
 			}
@@ -2419,9 +2740,9 @@ uint32 haltestelle_t::get_ware_summe(const goods_desc_t *wtyp) const
 
 uint32 haltestelle_t::get_ware_fuer_zielpos(const goods_desc_t *wtyp, const koord zielpos) const
 {
-	const slist_tpl<cargo_item_t> * warray = cargo[wtyp->get_catg_index()];
+	const cargo_queue_t * warray = cargo[wtyp->get_catg_index()];
 	if(warray!=NULL) {
-		FOR(slist_tpl<cargo_item_t>, const& ware, *warray) {
+		for(const cargo_item_t& ware : *warray) {
 			const ware_t& goods = ware->goods;
 			if(wtyp->get_index()==goods.get_index()  &&  goods.get_zielpos()==zielpos) {
 				return goods.menge;
@@ -2435,9 +2756,9 @@ uint32 haltestelle_t::get_ware_fuer_zielpos(const goods_desc_t *wtyp, const koor
 uint32 haltestelle_t::get_ware_fuer_zwischenziel(const goods_desc_t *wtyp, const halthandle_t zwischenziel) const
 {
 	uint32 sum = 0;
-	const slist_tpl<cargo_item_t> * warray = cargo[wtyp->get_catg_index()];
+	const cargo_queue_t * warray = cargo[wtyp->get_catg_index()];
 	if(warray!=NULL) {
-		FOR(slist_tpl<cargo_item_t>, const& ware, *warray) {
+		for(const cargo_item_t& ware : *warray) {
 			const ware_t& goods = ware->goods;
 			if(wtyp->get_index()==goods.get_index()  &&  goods.get_zwischenziel()==zwischenziel) {
 				sum += goods.menge;
@@ -2458,17 +2779,19 @@ bool haltestelle_t::vereinige_waren(const ware_t &ware)
 	}
 
 	// pruefen ob die ware mit bereits wartender ware vereinigt werden kann
-	slist_tpl<cargo_item_t> * warray = cargo[ware.get_desc()->get_catg_index()];
+	cargo_queue_t * warray = cargo[ware.get_desc()->get_catg_index()];
 	if(  !warray  ) {
 		return false;
 	}
-	FOR(slist_tpl<cargo_item_t>, & tmp_cargo, *warray) {
-		ware_t& tmp = tmp_cargo->goods;
+	for(auto& tmp_cargo : warray->get_ziel_iterators(ware.get_ziel())) {
+		ware_t& tmp = tmp_cargo->cargo->goods;
 		// join packets with same destination
 		if(ware.same_destination(tmp)) {
 			if(  ware.get_zwischenziel().is_bound()  &&  ware.get_zwischenziel()!=self  ) {
 				// update route if there is newer route
 				tmp.set_transit_halts( ware.get_transit_halts() );
+				warray->update_index(tmp_cargo);
+				warray->sort_indices();
 			}
 			tmp.menge += ware.menge;
 			resort_freight_info = true;
@@ -2485,10 +2808,10 @@ bool haltestelle_t::vereinige_waren(const ware_t &ware)
 std::shared_ptr<halt_waiting_goods_t> haltestelle_t::add_goods_to_halt(halt_waiting_goods_t wg)
 {
 	// now we have to add the ware to the stop
-	slist_tpl<cargo_item_t> * warray = cargo[wg.goods.get_desc()->get_catg_index()];
+	cargo_queue_t * warray = cargo[wg.goods.get_desc()->get_catg_index()];
 	if(warray==NULL) {
 		// this type was not stored here before ...
-		warray = new slist_tpl<cargo_item_t>();
+		warray = new cargo_queue_t();
 		cargo[wg.goods.get_desc()->get_catg_index()] = warray;
 	}
 	resort_freight_info = true;
@@ -2617,7 +2940,7 @@ void haltestelle_t::get_freight_info(cbuffer_t & buf)
 				continue;
 			}
 			vector_tpl<ware_t> wvector;
-			FOR(slist_tpl<cargo_item_t>, & w, *cargo[i]) {
+			for(cargo_item_t &w : *cargo[i]) {
 				wvector.append(w->goods);
 			}
 			freight_list_sorter_t::sort_freight(wvector, buf, (freight_list_sorter_t::sort_mode_t)sortierung, NULL, "waiting");
@@ -3027,9 +3350,9 @@ void haltestelle_t::transfer_goods(halthandle_t halt)
 	}
 	// transfer goods to halt
 	for(uint8 i=0; i<goods_manager_t::get_max_catg_index(); i++) {
-		const slist_tpl<cargo_item_t> * warray = cargo[i];
+		const cargo_queue_t * warray = cargo[i];
 		if (warray) {
-			FOR(slist_tpl<cargo_item_t>, const& j, *warray) {
+			for(const cargo_item_t &j : *warray) {
 				halt->add_goods_to_halt(*j.get());
 			}
 			delete cargo[i];
@@ -3274,7 +3597,7 @@ void haltestelle_t::rdwr(loadsave_t *file)
 	if(file->is_saving()) {
 		const char *s;
 		for(unsigned i=0; i<goods_manager_t::get_max_catg_index(); i++) {
-			slist_tpl<cargo_item_t> *warray = cargo[i];
+			cargo_queue_t *warray = cargo[i];
 			if(warray) {
 				s = "y"; // needs to be non-empty
 				file->rdwr_str(s);
@@ -3286,7 +3609,7 @@ void haltestelle_t::rdwr(loadsave_t *file)
 					uint32 count = warray->get_count();
 					file->rdwr_long(count);
 				}
-				FOR(slist_tpl<cargo_item_t>, & ware, *warray) {
+				for(cargo_item_t &ware : *warray) {
 					ware->goods.rdwr(file);
 					if(  file->get_OTRP_version()>=36  ) {
 						file->rdwr_long(ware->arrived_time);
@@ -3464,8 +3787,8 @@ void haltestelle_t::finish_rd()
 	// fix good destination coordinates
 	for(unsigned i=0; i<goods_manager_t::get_max_catg_index(); i++) {
 		if(cargo[i]) {
-			slist_tpl<cargo_item_t> * warray = cargo[i];
-			FOR(slist_tpl<cargo_item_t>, & j, *warray) {
+			cargo_queue_t * warray = cargo[i];
+			for(cargo_item_t & j : *warray) {
 				j->goods.finish_rd(welt);
 			}
 		}
@@ -4361,13 +4684,11 @@ bool haltestelle_t::is_route_search_needed(const ware_t &ware) const {
 
 void haltestelle_t::extinguish_all_waiting_goods() {
 	for(uint8 goods_ctg_idx=0; goods_ctg_idx<goods_manager_t::get_max_catg_index(); goods_ctg_idx++) {
-		slist_tpl<cargo_item_t>* goods_list = cargo[goods_ctg_idx];
+		cargo_queue_t* goods_list = cargo[goods_ctg_idx];
 		if(  !goods_list  ) {
 			continue;
 		}
-		while(  !goods_list->empty()  ) {
-			goods_list->remove_first();
-		}
+		goods_list->clear();
 	}
 }
 

--- a/simhalt.h
+++ b/simhalt.h
@@ -332,8 +332,11 @@ private:
 
 	using cargo_item_t = std::shared_ptr<halt_waiting_goods_t>;
 
+	// The queue of waiting goods.
+	struct cargo_queue_t;
+
 	// Array with different categories that contains all waiting goods at this stop
-	slist_tpl<cargo_item_t> **cargo;
+	cargo_queue_t** cargo;
 
 	// Array with different categories that contains the reference of
 	// waiting goods which haven't had a chance to be loaded yet.
@@ -580,7 +583,9 @@ private:
 	 * The key is the goods category index.
 	 */
 	inthashtable_tpl<uint8, bool> waiting_amount_exceeds_FIFO_limit;
-	
+
+	void search_route_for_invalid_zwischenziel_goods(cargo_queue_t *wares);
+
 public:
 	enum routing_result_flags {
 		NO_ROUTE          = 0,


### PR DESCRIPTION
貨物の積載、荷下ろし処理を高速化します。具体的には、以下の関数のCPU時間を削減します。

- `haltestelle_t::vereinige_waren` ... 荷下ろしに伴う貨物パケット`ware_t`のmerge作業
- `haltestelle_t::fetch_goods_nearest_first`
- `haltestelle_t::fetch_goods_FIFO`

従来停留所において貨物は`slist_tpl`で保持されていました。貨物を停留所からfetchするときは `slist_tpl` の要素を探索する必要があり、計算量が停留所内の貨物（`ware_t`）の数 `N` に対して `O(N)` になっていました。この計算量は、以下の場合に問題になります。

- FIFOがonで、大量の貨物が停留所に待機している場合
- FIFOがoffで、マップ中に大量の停留所がある場合

このPRでは`slist_tpl`を`cargo_queue_t`に置き換えて、`ziel`（最終目的地停留所）および`zwischenziel`（次の停留所）での探索計算量を`O(1)`にします。以下のように停留所の待機中貨物を保持します。

- `cargo` ... 待機中の貨物を到着順に並べたlinked list（従来のslist_tplによるcargoと同様）
- `zwischenziel_index` ... 特定のzwischenzielを持つ`ware_t`オブジェクトを取ってくるためのindex。unodered mapで、keyがzwischenzielである停留所のid, valueは `cargo` 中の要素へのイテレータを先着順に並べたlinked list。貨物のfetchに使う。
- `ziel_index` ... 特定のzielを持つ`ware_t`オブジェクトを取ってくるためのindex。貨物のmergeに使う。