### PR TITLE
BUG FIX: set convoys on world or in depot after reading and append all convoys completely

### DIFF
--- a/simworld.cc
+++ b/simworld.cc
@@ -5980,6 +5980,7 @@ void karte_t::rdwr_gamestate(loadsave_t *file, loadingscreen_t *ls)
 		}
 
 		char buf[80];
+		vector_tpl<convoi_t*> loading_convoi_array;
 		while(  convoi_nr-->0  ) {
 			if(  file->is_version_less(101, 0)  ) {
 				file->rd_obj_id(buf, 79);
@@ -5988,8 +5989,13 @@ void karte_t::rdwr_gamestate(loadsave_t *file, loadingscreen_t *ls)
 				}
 			}
 			convoi_t *cnv = new convoi_t(file);
+			loading_convoi_array.append(cnv);
 			convoi_array.append(cnv->self);
-
+			if(  (convoi_array.get_count()&7) == 0  ) {
+				ls->set_progress( get_size().y+(get_size().y*convoi_array.get_count())/(2*max_convoi)+128 );
+			}
+		}
+		FOR( vector_tpl<convoi_t*>, cnv, loading_convoi_array ) {
 			if(cnv->in_depot()) {
 				grund_t * gr = lookup(cnv->get_pos());
 				depot_t *dep = gr ? gr->get_depot() : 0;
@@ -6003,9 +6009,6 @@ void karte_t::rdwr_gamestate(loadsave_t *file, loadingscreen_t *ls)
 			}
 			else {
 				sync.add( cnv );
-			}
-			if(  (convoi_array.get_count()&7) == 0  ) {
-				ls->set_progress( get_size().y+(get_size().y*convoi_array.get_count())/(2*max_convoi)+128 );
 			}
 		}
 	DBG_MESSAGE("karte_t::rdwr_gamestate()", "%d convois/trains loaded", convoi_array.get_count());


### PR DESCRIPTION
セーブデータ読み込み時、全編成を一度読み終えてから入庫または配置処理を行います。