### PR TITLE
BUG FIX:haltestelle_t::get_stoppable_halt() update (add waytype check)

### DIFF
--- a/dataobj/schedule.cc
+++ b/dataobj/schedule.cc
@@ -94,7 +94,7 @@ halthandle_t schedule_t::get_next_halt( player_t *player, halthandle_t halt ) co
 	dbg->message("schedule_t::get_next_halt","lets search the next stop");
 	if(  entries.get_count()>1  ) {
 		for(  uint i=1;  i < entries.get_count();  i++  ) {
-			halthandle_t h = haltestelle_t::get_stoppable_halt( entries[ (current_stop+i) % entries.get_count() ].pos, player );
+			halthandle_t h = haltestelle_t::get_stoppable_halt( entries[ (current_stop+i) % entries.get_count() ].pos, player, get_waytype() );
 			if(  h.is_bound()  &&  h != halt  ) {
 				return h;
 			}
@@ -111,7 +111,7 @@ halthandle_t schedule_t::get_prev_halt( player_t *player ) const
 {
 	if(  entries.get_count()>1  ) {
 		for(  uint i=1;  i < entries.get_count()-1u;  i++  ) {
-			halthandle_t h = haltestelle_t::get_stoppable_halt( entries[ (current_stop+entries.get_count()-i) % entries.get_count() ].pos, player );
+			halthandle_t h = haltestelle_t::get_stoppable_halt( entries[ (current_stop+entries.get_count()-i) % entries.get_count() ].pos, player, get_waytype() );
 			if(  h.is_bound()  ) {
 				return h;
 			}
@@ -468,7 +468,7 @@ bool schedule_t::similar( const schedule_t *schedule, const player_t *player )
 	vector_tpl<halthandle_t> halts;
 	for(  uint8 idx = 0;  idx < this->entries.get_count();  idx++  ) {
 		koord3d p = this->entries[idx].pos;
-		halthandle_t halt = haltestelle_t::get_stoppable_halt( p, player );
+		halthandle_t halt = haltestelle_t::get_stoppable_halt( p, player, get_waytype() );
 		if(  halt.is_bound()  ) {
 			halts.insert_unique_ordered( halt, HaltIdOrdering() );
 		}
@@ -476,7 +476,7 @@ bool schedule_t::similar( const schedule_t *schedule, const player_t *player )
 	vector_tpl<halthandle_t> other_halts;
 	for(  uint8 idx = 0;  idx < schedule->entries.get_count();  idx++  ) {
 		koord3d p = schedule->entries[idx].pos;
-		halthandle_t halt = haltestelle_t::get_stoppable_halt( p, player );
+		halthandle_t halt = haltestelle_t::get_stoppable_halt( p, player, get_waytype() );
 		if(  halt.is_bound()  ) {
 			other_halts.insert_unique_ordered( halt, HaltIdOrdering() );
 		}
@@ -663,10 +663,10 @@ void construct_schedule_entry_attributes(cbuffer_t& buf, schedule_entry_t const&
 	}
 }
 
-void schedule_t::gimme_stop_name(cbuffer_t& buf, karte_t* welt, player_t const* const player_, schedule_entry_t const& entry, int const max_chars)
+void schedule_t::gimme_stop_name(cbuffer_t& buf, karte_t* welt, player_t const* const player_, schedule_entry_t const& entry, int const max_chars, waytype_t const wt)
 {
 	const char *p;
-	halthandle_t halt = haltestelle_t::get_stoppable_halt(entry.pos, player_);
+	halthandle_t halt = haltestelle_t::get_stoppable_halt(entry.pos, player_, wt);
 	if(halt.is_bound()) {
 		construct_schedule_entry_attributes(buf, entry);
 		if(  max_chars <= 0  ) {
@@ -734,7 +734,7 @@ bool schedule_t::is_valid_as_next_line(  linehandle_t l  ) const {
 	if( !l.is_bound() || l->get_schedule()->get_count()<2 || l->linetype_to_waytype(l->get_linetype()) != get_waytype() ) {
 		return false;
 	}
-	halthandle_t h = haltestelle_t::get_stoppable_halt( l->get_schedule()->at(0).pos, l->get_owner() );
+	halthandle_t h = haltestelle_t::get_stoppable_halt( l->get_schedule()->at(0).pos, l->get_owner(), l->get_schedule()->get_waytype() );
 	if( !h.is_bound() ) {
 		return false;
 	}

--- a/dataobj/schedule.h
+++ b/dataobj/schedule.h
@@ -243,7 +243,7 @@ public:
 	 * Append description of entry to buf.
 	 * If @p max_chars > 0 then append short version, without loading level and position.
 	 */
-	static void gimme_stop_name(cbuffer_t& buf, karte_t* welt, player_t const* player_, schedule_entry_t const& entry, int max_chars);
+	static void gimme_stop_name(cbuffer_t& buf, karte_t* welt, player_t const* player_, schedule_entry_t const& entry, int max_chars, waytype_t const wt);
 	
 	/*
 	 * Get the index of the corresponding entry of this schedule to Nth entry of the other schedule.

--- a/gui/convoi_info_t.cc
+++ b/gui/convoi_info_t.cc
@@ -317,7 +317,7 @@ void convoi_info_t::update_labels()
 
 	// next stop
 	target_label.buf().append(translator::translate("Fahrtziel"));
-	schedule_t::gimme_stop_name(target_label.buf(), welt, cnv->get_owner(), cnv->get_schedule()->get_current_entry(), 34);
+	schedule_t::gimme_stop_name(target_label.buf(), welt, cnv->get_owner(), cnv->get_schedule()->get_current_entry(), 34, cnv->front()->get_waytype());
 	target_label.update();
 
 	// only show assigned line, if there is one!

--- a/gui/convoi_stops_list_t.cc
+++ b/gui/convoi_stops_list_t.cc
@@ -41,16 +41,18 @@ class convoi_stops_list_item_t : public gui_aligned_container_t, public gui_acti
 	schedule_entry_t entry;
 	bool is_current;
 	uint8 number;
+	waytype_t waytype;
 	player_t* player;
 	gui_image_t arrow;
 	gui_label_buf_t stop;
 
 public:
-	convoi_stops_list_item_t(player_t* pl, schedule_entry_t e, uint n)
+	convoi_stops_list_item_t(player_t* pl, schedule_entry_t e, uint n, waytype_t const wt)
 	{
 		player = pl;
 		entry  = e;
 		number = n;
+		waytype = wt;
 		is_current = false;
 		set_table_layout(2,1);
 		add_component(&arrow);
@@ -61,7 +63,7 @@ public:
 	void update_label()
 	{
 		stop.buf().printf("%i) ", number+1);
-		schedule_t::gimme_stop_name(stop.buf(), welt, player, entry, -1);
+		schedule_t::gimme_stop_name(stop.buf(), welt, player, entry, -1, waytype);
 		stop.set_color(is_current ? SYSCOL_TEXT_HIGHLIGHT : SYSCOL_TEXT);
 		stop.update();
 	}
@@ -97,7 +99,7 @@ public:
 			return false;
 		} 
 		else {
-			halthandle_t h = haltestelle_t::get_stoppable_halt( entry.pos,player );
+			halthandle_t h = haltestelle_t::get_stoppable_halt( entry.pos,player, waytype );
 			if (  h.is_bound()  ) {
 				// show halt info window.
 				create_win(new halt_info_t(h), w_info, magic_halt_info);		
@@ -141,7 +143,7 @@ void convoi_stops_list_t::update_schedule()
 	}
 	else {
 		for(uint i=0; i<gui_schedule->get_count(); i++) {
-			entries.append( new_component<convoi_stops_list_item_t>(player, gui_schedule->at(i), i));
+			entries.append( new_component<convoi_stops_list_item_t>(player, gui_schedule->at(i), i, gui_schedule->get_waytype()));
 			entries.back()->add_listener( this );
 		}
 		entries[ gui_schedule->get_current_stop() ]->set_active(true);

--- a/gui/goods_waiting_time.cc
+++ b/gui/goods_waiting_time.cc
@@ -44,7 +44,7 @@ void gui_goods_waiting_time_stat_t::update()
     set_table_layout(NUM_WAITING_TIME_STORED+2,0);
     for(uint8 index = 0; index < schedule->get_count(); index++) {
         const schedule_entry_t& entry = schedule->at(index);
-        const halthandle_t halt = haltestelle_t::get_stoppable_halt(entry.pos, player);
+        const halthandle_t halt = haltestelle_t::get_stoppable_halt(entry.pos, player, schedule->get_waytype());
         gui_label_buf_t *title_lb = new_component<gui_label_buf_t>(SYSCOL_TEXT, gui_label_t::left);
         if(  halt.is_bound()  ) {
             // Show the halt name

--- a/gui/halt_info.cc
+++ b/gui/halt_info.cc
@@ -802,8 +802,8 @@ void gui_departure_board_t::update_departures(halthandle_t halt)
 	FOR(  vector_tpl<linehandle_t>, line, halt->registered_lines ) {
 		for(  uint j = 0;  j < line->count_convoys();  j++  ) {
 			convoihandle_t cnv = line->get_convoy(j);
-			if(  cnv.is_bound()  &&  ( cnv->get_state() == convoi_t::DRIVING  ||  cnv->is_waiting() )  &&  haltestelle_t::get_stoppable_halt( cnv->get_schedule()->get_current_entry().pos, cnv->get_owner() ) == halt  ) {
-				halthandle_t prev_halt = haltestelle_t::get_stoppable_halt( cnv->front()->last_stop_pos, cnv->get_owner() );
+			if(  cnv.is_bound()  &&  ( cnv->get_state() == convoi_t::DRIVING  ||  cnv->is_waiting() )  &&  haltestelle_t::get_stoppable_halt( cnv->get_schedule()->get_current_entry().pos, cnv->get_owner(), cnv->front()->get_waytype() ) == halt  ) {
+				halthandle_t prev_halt = haltestelle_t::get_stoppable_halt( cnv->front()->last_stop_pos, cnv->get_owner(), cnv->front()->get_waytype() );
 				sint32 delta_t = calc_ticks_until_arrival( cnv );
 				if(  prev_halt.is_bound()  ) {
 					dest_info_t prev( prev_halt, delta_t, cnv );
@@ -827,8 +827,8 @@ void gui_departure_board_t::update_departures(halthandle_t halt)
 	}
 
 	FOR( vector_tpl<convoihandle_t>, cnv, halt->registered_convoys ) {
-		if(  cnv.is_bound()  &&  ( cnv->get_state() == convoi_t::DRIVING  ||  cnv->is_waiting() )  &&  haltestelle_t::get_stoppable_halt( cnv->get_schedule()->get_current_entry().pos, cnv->get_owner() ) == halt  ) {
-			halthandle_t prev_halt = haltestelle_t::get_stoppable_halt( cnv->front()->last_stop_pos, cnv->get_owner() );
+		if(  cnv.is_bound()  &&  ( cnv->get_state() == convoi_t::DRIVING  ||  cnv->is_waiting() )  &&  haltestelle_t::get_stoppable_halt( cnv->get_schedule()->get_current_entry().pos, cnv->get_owner(), cnv->front()->get_waytype() ) == halt  ) {
+			halthandle_t prev_halt = haltestelle_t::get_stoppable_halt( cnv->front()->last_stop_pos, cnv->get_owner(), cnv->front()->get_waytype() );
 			sint32 delta_t = cur_ticks + calc_ticks_until_arrival( cnv );
 			if(  prev_halt.is_bound()  ) {
 				dest_info_t prev( prev_halt, delta_t, cnv );

--- a/gui/journey_time_info.cc
+++ b/gui/journey_time_info.cc
@@ -54,7 +54,7 @@ void gui_journey_time_stat_t::update(linehandle_t line, vector_tpl<uint32*>& jou
 
     // Stopping time at the halt
     lb = new_component<gui_label_buf_t>(SYSCOL_TEXT, gui_label_t::left);
-    halthandle_t const halt = haltestelle_t::get_stoppable_halt(e.pos, player);
+    halthandle_t const halt = haltestelle_t::get_stoppable_halt(e.pos, player, schedule->get_waytype());
     if(  halt.is_bound()  ) {
       // show halt name
       lb->buf().printf("%s", halt->get_name());
@@ -102,7 +102,7 @@ void gui_journey_time_stat_t::update(linehandle_t line, vector_tpl<uint32*>& jou
 void copy_stations_to_clipboard(schedule_t* schedule, player_t* player, bool name_only) {
   cbuffer_t clipboard;
   FOR(minivec_tpl<schedule_entry_t>, const& e, schedule->get_entries()) {
-    halthandle_t const halt = haltestelle_t::get_stoppable_halt(e.pos, player);
+    halthandle_t const halt = haltestelle_t::get_stoppable_halt(e.pos, player, schedule->get_waytype());
     if(  !halt.is_bound()  ) {
       // do not export waypoint
       continue;
@@ -128,7 +128,7 @@ void copy_csv_format(schedule_t* schedule, player_t* player, vector_tpl<uint32*>
   cbuffer_t clipboard;
   clipboard.append("Station Name\tAverage\t1st\t2nd\t3rd\t4th\t5th\n");
   for(uint8 i=0; i<schedule->get_count(); i++) {
-    halthandle_t const halt = haltestelle_t::get_stoppable_halt(schedule->at(i).pos, player);
+    halthandle_t const halt = haltestelle_t::get_stoppable_halt(schedule->at(i).pos, player, schedule->get_waytype());
     if(  halt.is_bound()  ) {
       clipboard.append(halt->get_name());
     } else {

--- a/gui/minimap.cc
+++ b/gui/minimap.cc
@@ -235,7 +235,7 @@ void minimap_t::add_to_schedule_cache( convoihandle_t cnv, bool with_waypoints )
 
 		//cycle on stops
 		//try to read station's coordinates if there's a station at this schedule stop
-		halthandle_t station = haltestelle_t::get_stoppable_halt( cur.pos, cnv->get_owner() );
+		halthandle_t station = haltestelle_t::get_stoppable_halt( cur.pos, cnv->get_owner(), schedule->get_waytype() );
 		if(  station.is_bound()  ) {
 			stop_cache.append_unique( station );
 			temp_stop = station->get_basis_pos();

--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -48,15 +48,17 @@ class gui_schedule_entry_t : public gui_aligned_container_t, public gui_action_c
 	bool is_current;
 	uint number;
 	player_t* player;
+	waytype_t waytype;
 	gui_image_t arrow;
 	gui_label_buf_t stop;
 
 public:
-	gui_schedule_entry_t(player_t* pl, schedule_entry_t e, uint n)
+	gui_schedule_entry_t(player_t* pl, schedule_entry_t e, uint n, waytype_t const wt)
 	{
 		player = pl;
 		entry  = e;
 		number = n;
+		waytype = wt;
 		is_current = false;
 		set_table_layout(2,1);
 
@@ -70,7 +72,7 @@ public:
 	void update_label()
 	{
 		stop.buf().printf("%i) ", number+1);
-		schedule_t::gimme_stop_name(stop.buf(), welt, player, entry, -1);
+		schedule_t::gimme_stop_name(stop.buf(), welt, player, entry, -1, waytype);
 		stop.set_color(is_current ? SYSCOL_TEXT_HIGHLIGHT : SYSCOL_TEXT);
 		stop.update();
 	}
@@ -200,7 +202,7 @@ void schedule_gui_stats_t::update_schedule()
 		}
 		else {
 			for(uint i=0; i<schedule->get_count(); i++) {
-				entries.append( new_component<gui_schedule_entry_t>(player, schedule->at(i), i));
+				entries.append( new_component<gui_schedule_entry_t>(player, schedule->at(i), i, schedule->get_waytype()));
 				entries.back()->add_listener( this );
 			}
 			entries[ schedule->get_current_stop() ]->set_active(true);
@@ -692,7 +694,7 @@ void schedule_gui_t::update_selection()
     
 		// if the next_line is set, the last entry is same as the next_line->get_schedule()->at(0)
 		// so, the flags of last entry can not be editted.
-		if(  haltestelle_t::get_stoppable_halt(schedule->at(current_stop).pos, player).is_bound()  && (  (current_stop != schedule->get_count()-1)  ||  !schedule->get_next_line().is_bound()  )  ) {
+		if(  haltestelle_t::get_stoppable_halt(schedule->at(current_stop).pos, player, schedule->get_waytype()).is_bound()  && (  (current_stop != schedule->get_count()-1)  ||  !schedule->get_next_line().is_bound()  )  ) {
 
 			
 			const uint8 c = schedule->at(current_stop).get_coupling_point();

--- a/gui/schedule_list.cc
+++ b/gui/schedule_list.cc
@@ -766,7 +766,7 @@ void schedule_list_gui_t::update_lineinfo(linehandle_t new_line)
 		// fill haltestellen container with info of stops of the line
 		scrolly_haltestellen.clear_elements();
 		FOR(minivec_tpl<schedule_entry_t>, const& i, new_line->get_schedule()->get_entries()) {
-			halthandle_t const halt = haltestelle_t::get_stoppable_halt(i.pos, player);
+			halthandle_t const halt = haltestelle_t::get_stoppable_halt(i.pos, player, new_line->get_schedule()->get_waytype());
 			if(  halt.is_bound()  ) {
 				scrolly_haltestellen.new_component<halt_list_stats_t>(halt);
 			}

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -268,7 +268,7 @@ bool convoi_t::is_waypoint( koord3d ziel ) const
 		}
 		// so we are on a taxiway/runway here ...
 	}
-	return !haltestelle_t::get_stoppable_halt(ziel,get_owner()).is_bound();
+	return !haltestelle_t::get_stoppable_halt(ziel,get_owner(),fahr[0]->get_waytype()).is_bound();
 }
 
 
@@ -1205,7 +1205,7 @@ bool convoi_t::drive_to()
 
 		// avoid stopping mid-halt
 		if(  start==ziel  ) {
-			halthandle_t halt = haltestelle_t::get_stoppable_halt(ziel,get_owner());
+			halthandle_t halt = haltestelle_t::get_stoppable_halt(ziel,get_owner(),front()->get_waytype());
 			if(  halt.is_bound()  &&  route.is_contained(start)  ) {
 				for(  uint32 i=route.index_of(start);  i<route.get_count();  i++  ) {
 					grund_t *gr = welt->lookup(route.at(i));
@@ -1391,11 +1391,11 @@ void convoi_t::step()
 				else {
 					// Schedule changed at station
 					// this station? then complete loading task else drive on
-					halthandle_t h = haltestelle_t::get_stoppable_halt( get_pos(), get_owner() );
-					if(  h.is_bound()  &&  h==haltestelle_t::get_stoppable_halt( schedule->get_current_entry().pos, get_owner() )  ) {
+					halthandle_t h = haltestelle_t::get_stoppable_halt( get_pos(), get_owner(), front()->get_waytype()  );
+					if(  h.is_bound()  &&  h==haltestelle_t::get_stoppable_halt( schedule->get_current_entry().pos, get_owner(), front()->get_waytype() )  ) {
 						if (route.get_count() > 0) {
 							koord3d const& pos = route.back();
-							if (h == haltestelle_t::get_stoppable_halt(pos, get_owner())) {
+							if (h == haltestelle_t::get_stoppable_halt(pos, get_owner(),front()->get_waytype())) {
 								state = get_pos() == pos ? LOADING : DRIVING;
 								break;
 							}
@@ -1479,7 +1479,7 @@ void convoi_t::step()
 				if(  v->can_enter_tile( restart_speed, 0 )  ) {
 					// can reserve new block => drive on
 					state = (steps_driven>=0) ? LEAVING_DEPOT : DRIVING;
-					if(haltestelle_t::get_stoppable_halt(v->get_pos(),owner).is_bound()) {
+					if(haltestelle_t::get_stoppable_halt(v->get_pos(),owner,v->get_waytype()).is_bound()) {
 						v->play_sound();
 					}
 				}
@@ -1884,7 +1884,7 @@ void convoi_t::ziel_erreicht()
 		c->set_time_last_arrived(world()->get_ticks());
 		c = c->get_coupling_convoi();
 	}
-	halthandle_t halt = haltestelle_t::get_stoppable_halt(schedule->get_current_entry().pos,owner);
+	halthandle_t halt = haltestelle_t::get_stoppable_halt(schedule->get_current_entry().pos,owner,front()->get_waytype());
 
 	// check for coupling
 	if(  next_coupling_index!=route_t::INVALID_INDEX  &&  next_coupling_index<=v->get_route_index()  ) {
@@ -2630,7 +2630,7 @@ void convoi_t::vorfahren()
 			sint32 restart_speed = -1;
 			if(  fahr[0]->can_enter_tile( restart_speed, 0 )  ) {
 				// can reserve new block => drive on
-				if(haltestelle_t::get_stoppable_halt(k0,owner).is_bound()) {
+				if(haltestelle_t::get_stoppable_halt(k0,owner,front()->get_waytype()).is_bound()) {
 					fahr[0]->play_sound();
 				}
 				state = DRIVING;
@@ -3441,7 +3441,7 @@ void convoi_t::laden()
 	wait_lock = (WTT_LOADING*2)+(self.get_id())%1024;
 
 	// find station (ours or public)
-	halthandle_t halt = haltestelle_t::get_stoppable_halt(schedule->get_current_entry().pos,owner);
+	halthandle_t halt = haltestelle_t::get_stoppable_halt(schedule->get_current_entry().pos,owner,front()->get_waytype());
 	if(  halt.is_bound()  ) {
 		// queue for (un)loading, does (un)loading once per step
 		halt->request_loading( self );
@@ -3621,7 +3621,7 @@ uint32 convoi_t::calc_available_halt_length_in_vehicle_steps(koord3d front_vehic
 	}
 
 	bool is_last_diagonal = false;
-	while(  gr  &&  haltestelle_t::get_stoppable_halt(gr->get_pos(), NULL)==halt  ) {
+	while(  gr  &&  haltestelle_t::get_stoppable_halt(gr->get_pos(), NULL, waytype)==halt  ) {
 		const weg_t* way = gr->get_weg(waytype);
 		if(  !way  ) { break; }
 		const ribi_t::ribi way_dir = way->get_ribi_unmasked();
@@ -3659,7 +3659,7 @@ void calc_reachable_halts(vector_tpl<haltestelle_t::reachable_halt_t>& reachable
 		return;
 	}
 
-	const halthandle_t current_halt = haltestelle_t::get_stoppable_halt(schedule->get_current_entry().pos, owner);
+	const halthandle_t current_halt = haltestelle_t::get_stoppable_halt(schedule->get_current_entry().pos, owner, cnv->front()->get_waytype());
 	const uint8 schedule_count = schedule->get_count();
 
 	// We use the line schedule instead of convoy's schedule to fetch the journey time.
@@ -3697,7 +3697,7 @@ void calc_reachable_halts(vector_tpl<haltestelle_t::reachable_halt_t>& reachable
 	for(  uint8 i=1;  i<line_schedule_count;  i++  ) {
 		const uint8 wrap_i = (i + line_schedule_current_index) % line_schedule_count;
 
-		const halthandle_t plan_halt = haltestelle_t::get_stoppable_halt(line_schedule->at(wrap_i).pos, owner);
+		const halthandle_t plan_halt = haltestelle_t::get_stoppable_halt(line_schedule->at(wrap_i).pos, owner, cnv->front()->get_waytype());
 		if(  plan_halt == current_halt  ) {
 			if(  !line_schedule->at(wrap_i).is_no_load()  ) {
 				// we will come later here again ...
@@ -4362,8 +4362,8 @@ DBG_DEBUG("convoi_t::unset_line()", "removing old destinations from line=%d, sch
 // matches two halts; if the pos is not identical, maybe the halt still is the same
 bool convoi_t::matches_halt( const koord3d pos1, const koord3d pos2 )
 {
-	halthandle_t halt1 = haltestelle_t::get_stoppable_halt(pos1, owner );
-	return pos1==pos2  ||  (halt1.is_bound()  &&  halt1==haltestelle_t::get_stoppable_halt( pos2, owner ));
+	halthandle_t halt1 = haltestelle_t::get_stoppable_halt(pos1, owner, front()->get_waytype() );
+	return pos1==pos2  ||  (halt1.is_bound()  &&  halt1==haltestelle_t::get_stoppable_halt( pos2, owner, front()->get_waytype() ));
 }
 
 
@@ -4503,7 +4503,7 @@ void convoi_t::register_stops()
 {
 	if(  schedule  ) {
 		FOR(minivec_tpl<schedule_entry_t>, const& i, schedule->get_entries()) {
-			halthandle_t const halt = haltestelle_t::get_stoppable_halt(i.pos, get_owner());
+			halthandle_t const halt = haltestelle_t::get_stoppable_halt(i.pos, get_owner(), front()->get_waytype());
 			if(  halt.is_bound()  ) {
 				halt->add_convoy(self);
 			}
@@ -4519,7 +4519,7 @@ void convoi_t::unregister_stops()
 {
 	if(  schedule  ) {
 		FOR(minivec_tpl<schedule_entry_t>, const& i, schedule->get_entries()) {
-			halthandle_t const halt = haltestelle_t::get_stoppable_halt(i.pos, get_owner());
+			halthandle_t const halt = haltestelle_t::get_stoppable_halt(i.pos, get_owner(), front()->get_waytype());
 			if(  halt.is_bound()  ) {
 				halt->remove_convoy(self);
 			}

--- a/simhalt.cc
+++ b/simhalt.cc
@@ -543,7 +543,7 @@ halthandle_t haltestelle_t::get_stoppable_halt(const koord3d pos, const player_t
 	const grund_t *gr = welt->lookup(pos);
 	if(  !gr  ) { return halthandle_t(); }
 	const halthandle_t halt = gr->get_halt();
-	if(  halt.is_bound()  ) {
+	if(  halt.is_bound() && gr->get_weg(wt)  ) {
 		const bool accepts_other_player = halt->is_other_player_connection_allowed();
 		if(  player_t::check_owner(player, halt->get_owner())  ||  accepts_other_player  ) {
 			return halt;

--- a/simhalt.cc
+++ b/simhalt.cc
@@ -538,7 +538,7 @@ halthandle_t haltestelle_t::get_halt(const koord3d pos, const player_t *player )
 }
 
 
-halthandle_t haltestelle_t::get_stoppable_halt(const koord3d pos, const player_t *player )
+halthandle_t haltestelle_t::get_stoppable_halt(const koord3d pos, const player_t *player, const waytype_t wt )
 {
 	const grund_t *gr = welt->lookup(pos);
 	if(  !gr  ) { return halthandle_t(); }
@@ -551,6 +551,8 @@ halthandle_t haltestelle_t::get_stoppable_halt(const koord3d pos, const player_t
 	}
 	if(  !gr->is_water()  ) { return halthandle_t(); }
 	// no halt? => we do the water check
+	// if waytype is not water_wt, return false. 
+	if(  wt!=water_wt  ) {return halthandle_t(); }
 	// may catch bus stops close to water ...
 	const planquadrat_t *plan = welt->access(pos.get_2d());
 	const uint8 cnt = plan->get_haltlist_count();
@@ -1643,7 +1645,7 @@ sint32 haltestelle_t::rebuild_connections()
 
 		// find the index from which to start processing
 		uint8 start_index = 0;
-		while(  start_index < schedule->get_count()  &&  get_stoppable_halt( schedule->at(start_index).pos, owner ) != self  ) {
+		while(  start_index < schedule->get_count()  &&  get_stoppable_halt( schedule->at(start_index).pos, owner, schedule->get_waytype() ) != self  ) {
 			++start_index;
 		}
 		if(  start_index==schedule->get_count()  ) {
@@ -1688,7 +1690,7 @@ sint32 haltestelle_t::rebuild_connections()
 		for(  uint8 j=0;  j<schedule->get_count();  ++j  ) {
 			const uint8 current_entry_index = (start_index+j)%schedule->get_count();
 			const schedule_entry_t current_entry = schedule->at(current_entry_index);
-			halthandle_t current_halt = get_stoppable_halt(current_entry.pos, owner );
+			halthandle_t current_halt = get_stoppable_halt(current_entry.pos, owner, schedule->get_waytype() );
 			if(  !current_halt.is_bound()  ) {
 				// ignore way points.
 				// just count the journey time
@@ -4105,7 +4107,7 @@ bool haltestelle_t::add_grund(grund_t *gr, bool relink_factories)
 				// only add unknown lines
 				if(  !registered_lines.is_contained(j)  &&  j->count_convoys() > 0  ) {
 					FOR(  minivec_tpl<schedule_entry_t>, const& k, j->get_schedule()->get_entries()  ) {
-						if(  get_stoppable_halt(k.pos, player) == self  ) {
+						if(  get_stoppable_halt(k.pos, player, j->get_schedule()->get_waytype()) == self  ) {
 							registered_lines.append(j);
 							break;
 						}
@@ -4120,7 +4122,7 @@ bool haltestelle_t::add_grund(grund_t *gr, bool relink_factories)
 		if(  !cnv->get_line().is_bound()  &&  (public_halt  ||  cnv->get_owner()==get_owner())  &&  !registered_convoys.is_contained(cnv)  ) {
 			if(  const schedule_t *const schedule = cnv->get_schedule()  ) {
 				FOR(  minivec_tpl<schedule_entry_t>, const& k, schedule->get_entries()  ) {
-					if (get_stoppable_halt(k.pos, cnv->get_owner()) == self) {
+					if (get_stoppable_halt(k.pos, cnv->get_owner(), schedule->get_waytype()) == self) {
 						registered_convoys.append(cnv);
 						break;
 					}
@@ -4229,7 +4231,7 @@ bool haltestelle_t::rem_grund(grund_t *gr)
 	for(  size_t j = registered_lines.get_count();  j-- != 0;  ) {
 		bool ok = false;
 		FOR(  minivec_tpl<schedule_entry_t>, const& k, registered_lines[j]->get_schedule()->get_entries()  ) {
-			if(  get_stoppable_halt(k.pos, registered_lines[j]->get_owner()) == self  ) {
+			if(  get_stoppable_halt(k.pos, registered_lines[j]->get_owner(),registered_lines[j]->get_schedule()->get_waytype()) == self  ) {
 				ok = true;
 				break;
 			}
@@ -4245,7 +4247,7 @@ bool haltestelle_t::rem_grund(grund_t *gr)
 	for(  size_t j = registered_convoys.get_count();  j-- != 0;  ) {
 		bool ok = false;
 		FOR(  minivec_tpl<schedule_entry_t>, const& k, registered_convoys[j]->get_schedule()->get_entries()  ) {
-			if(  get_stoppable_halt(k.pos, registered_convoys[j]->get_owner()) == self  ) {
+			if(  get_stoppable_halt(k.pos, registered_convoys[j]->get_owner(),registered_convoys[j]->get_schedule()->get_waytype()) == self  ) {
 				ok = true;
 				break;
 			}
@@ -4512,7 +4514,7 @@ bool haltestelle_t::book_departure (uint32 arr_tick, uint32 dep_tick, uint32 exp
 			i = departure_slot_table[idx].erase(i);
 			continue;
 		}
-		if(  is_first_ticks_bigger(i->dep_tick, current_ticks) && (get_stoppable_halt(i->cnv->get_pos(), i->cnv->get_owner()) != self)  ) {
+		if(  is_first_ticks_bigger(i->dep_tick, current_ticks) && (get_stoppable_halt(i->cnv->get_pos(), i->cnv->get_owner(), i->cnv->front()->get_waytype()) != self)  ) {
 			// The convoy is not on this halt while the convoy is yet to depart. Handle it as an invalid.
 			i = departure_slot_table[idx].erase(i);
 			continue;
@@ -4578,7 +4580,7 @@ bool unregistered_journey_time_exists(const schedule_t* schedule, player_t* play
 		if(  
 			this_entry.get_median_journey_time()>0  || // valid record exists
 			this_entry.pos==prev_entry.pos  ||
-			haltestelle_t::get_stoppable_halt(this_entry.pos, player)==haltestelle_t::get_stoppable_halt(prev_entry.pos, player)
+			haltestelle_t::get_stoppable_halt(this_entry.pos, player, schedule->get_waytype())==haltestelle_t::get_stoppable_halt(prev_entry.pos, player, schedule->get_waytype())
 		) {
 			// valid record exists.
 			continue;

--- a/simhalt.cc
+++ b/simhalt.cc
@@ -543,7 +543,7 @@ halthandle_t haltestelle_t::get_stoppable_halt(const koord3d pos, const player_t
 	const grund_t *gr = welt->lookup(pos);
 	if(  !gr  ) { return halthandle_t(); }
 	const halthandle_t halt = gr->get_halt();
-	if(  halt.is_bound() && gr->get_weg(wt)  ) {
+	if(  halt.is_bound() && (gr->get_weg(wt) || wt == any_wt)   ) {
 		const bool accepts_other_player = halt->is_other_player_connection_allowed();
 		if(  player_t::check_owner(player, halt->get_owner())  ||  accepts_other_player  ) {
 			return halt;
@@ -552,7 +552,7 @@ halthandle_t haltestelle_t::get_stoppable_halt(const koord3d pos, const player_t
 	if(  !gr->is_water()  ) { return halthandle_t(); }
 	// no halt? => we do the water check
 	// if waytype is not water_wt, return false. 
-	if(  wt!=water_wt  ) {return halthandle_t(); }
+	if(  wt!=water_wt && wt!=any_wt  ) {return halthandle_t(); }
 	// may catch bus stops close to water ...
 	const planquadrat_t *plan = welt->access(pos.get_2d());
 	const uint8 cnt = plan->get_haltlist_count();

--- a/simhalt.h
+++ b/simhalt.h
@@ -194,7 +194,7 @@ public:
 	/*
 	 * Returns the halt at the given position, if stopping is allowed for the given player.
 	*/
-	static halthandle_t get_stoppable_halt(const koord3d pos, const player_t *player );
+	static halthandle_t get_stoppable_halt(const koord3d pos, const player_t *player, const waytype_t wt );
 
 	static const vector_tpl<halthandle_t>& get_alle_haltestellen() { return alle_haltestellen; }
 

--- a/simhalt.h
+++ b/simhalt.h
@@ -194,7 +194,7 @@ public:
 	/*
 	 * Returns the halt at the given position, if stopping is allowed for the given player.
 	*/
-	static halthandle_t get_stoppable_halt(const koord3d pos, const player_t *player, const waytype_t wt );
+	static halthandle_t get_stoppable_halt(const koord3d pos, const player_t *player, const waytype_t wt=any_wt );
 
 	static const vector_tpl<halthandle_t>& get_alle_haltestellen() { return alle_haltestellen; }
 

--- a/simline.cc
+++ b/simline.cc
@@ -342,7 +342,7 @@ void simline_t::register_stops(schedule_t * schedule)
 {
 DBG_DEBUG("simline_t::register_stops()", "%d schedule entries in schedule %p", schedule->get_count(),schedule);
 	FOR(minivec_tpl<schedule_entry_t>, const& i, schedule->get_entries()) {
-		halthandle_t const halt = haltestelle_t::get_stoppable_halt(i.pos, player);
+		halthandle_t const halt = haltestelle_t::get_stoppable_halt(i.pos, player, schedule->get_waytype());
 		if(halt.is_bound()) {
 //DBG_DEBUG("simline_t::register_stops()", "halt not null");
 			halt->add_line(self);
@@ -364,7 +364,7 @@ void simline_t::unregister_stops()
 void simline_t::unregister_stops(schedule_t * schedule)
 {
 	FOR(minivec_tpl<schedule_entry_t>, const& i, schedule->get_entries()) {
-		halthandle_t const halt = haltestelle_t::get_stoppable_halt(i.pos, player);
+		halthandle_t const halt = haltestelle_t::get_stoppable_halt(i.pos, player, schedule->get_waytype());
 		if(halt.is_bound()) {
 			halt->remove_line(self);
 		}

--- a/simtool.cc
+++ b/simtool.cc
@@ -2533,7 +2533,7 @@ static const char *tool_schedule_insert_aux(karte_t *welt, player_t *player, koo
 		}
 		// and check for ownership
 		if(  bd->is_halt()  ) {
-			if(  !haltestelle_t::get_stoppable_halt(pos, player).is_bound()  ) {
+			if(  !haltestelle_t::get_stoppable_halt(pos, player, schedule->get_waytype()).is_bound()  ) {
 				// A halt exists, but the player check failed.
 				return "Das Feld gehoert\neinem anderen Spieler\n";
 			}
@@ -6970,7 +6970,7 @@ void tool_stop_mover_t::read_start_position(player_t *player, const koord3d &pos
 		}
 	}
 	// .. and halt
-	last_halt = haltestelle_t::get_stoppable_halt(pos,player);
+	last_halt = haltestelle_t::get_stoppable_halt(pos,player,waytype[0]);
 }
 
 
@@ -6982,7 +6982,7 @@ uint8 tool_stop_mover_t::is_valid_pos(  player_t *player, const koord3d &pos, co
 		return 0;
 	}
 	// check halt ownership
-	halthandle_t h = haltestelle_t::get_stoppable_halt(pos,player);
+	halthandle_t h = haltestelle_t::get_stoppable_halt(pos,player,waytype_t::water_wt);
 	if(  h.is_bound()  &&  !player_t::check_owner( player, h->get_owner() )  ) {
 		error = "Das Feld gehoert\neinem anderen Spieler\n";
 		return 0;
@@ -7030,7 +7030,7 @@ const char *tool_stop_mover_t::do_work( player_t *player, const koord3d &last_po
 
 	// second click
 	grund_t *bd = welt->lookup(pos);
-	halthandle_t h = haltestelle_t::get_stoppable_halt(pos,player);
+	halthandle_t h = haltestelle_t::get_stoppable_halt(pos,player,waytype_t::water_wt);
 
 	if (bd) {
 		const halthandle_t new_halt = h;
@@ -7093,7 +7093,7 @@ const char *tool_stop_mover_t::do_work( player_t *player, const koord3d &last_po
 					if(schedule  &&  schedule->is_stop_allowed(bd)) {
 						bool updated = false;
 						for (schedule_entry_t *k = schedule->begin(); k != schedule->end(); k++) {
-							if ((catch_all_halt && haltestelle_t::get_stoppable_halt(k->pos, cnv->get_owner()) == last_halt) ||
+							if ((catch_all_halt && haltestelle_t::get_stoppable_halt(k->pos, cnv->get_owner(),schedule->get_waytype()) == last_halt) ||
 								old_platform.is_contained(k->pos))
 							{
 								k->pos = pos;
@@ -7130,7 +7130,7 @@ const char *tool_stop_mover_t::do_work( player_t *player, const koord3d &last_po
 					bool updated = false;
 					for(schedule_entry_t* k = schedule->begin(); k != schedule->end(); k++) {
 						// ok!
-						if ((catch_all_halt && haltestelle_t::get_stoppable_halt( k->pos, line->get_owner()) == last_halt) ||
+						if ((catch_all_halt && haltestelle_t::get_stoppable_halt( k->pos, line->get_owner(), schedule->get_waytype()) == last_halt) ||
 								old_platform.is_contained(k->pos)) {
 							k->pos   = pos;
 							updated = true;

--- a/simtool.cc
+++ b/simtool.cc
@@ -7030,7 +7030,7 @@ const char *tool_stop_mover_t::do_work( player_t *player, const koord3d &last_po
 
 	// second click
 	grund_t *bd = welt->lookup(pos);
-	halthandle_t h = haltestelle_t::get_stoppable_halt(pos,player,waytype_t::water_wt);
+	halthandle_t h = haltestelle_t::get_stoppable_halt(pos,player,waytype_t::any_wt);
 
 	if (bd) {
 		const halthandle_t new_halt = h;

--- a/simtool.cc
+++ b/simtool.cc
@@ -6982,7 +6982,7 @@ uint8 tool_stop_mover_t::is_valid_pos(  player_t *player, const koord3d &pos, co
 		return 0;
 	}
 	// check halt ownership
-	halthandle_t h = haltestelle_t::get_stoppable_halt(pos,player,waytype_t::water_wt);
+	halthandle_t h = haltestelle_t::get_stoppable_halt(pos,player,waytype_t::any_wt);
 	if(  h.is_bound()  &&  !player_t::check_owner( player, h->get_owner() )  ) {
 		error = "Das Feld gehoert\neinem anderen Spieler\n";
 		return 0;

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -881,7 +881,7 @@ void vehicle_t::remove_stale_cargo()
 			if(  tmp.get_zwischenziel().is_bound()  ) {
 				// the original halt exists, but does we still go there?
 				FOR(minivec_tpl<schedule_entry_t>, const& i, cnv->get_schedule()->get_entries()) {
-					if(  haltestelle_t::get_stoppable_halt( i.pos, cnv->get_owner()) == tmp.get_zwischenziel()  ) {
+					if(  haltestelle_t::get_stoppable_halt( i.pos, cnv->get_owner(), get_waytype()) == tmp.get_zwischenziel()  ) {
 						found = true;
 						break;
 					}
@@ -893,7 +893,7 @@ void vehicle_t::remove_stale_cargo()
 				const int max_count = cnv->get_schedule()->get_count();
 				for(  int i=0;  i<max_count;  i++  ) {
 					// try to unload on next stop
-					halthandle_t halt = haltestelle_t::get_stoppable_halt( cnv->get_schedule()->at( (i+offset)%max_count ).pos, cnv->get_owner() );
+					halthandle_t halt = haltestelle_t::get_stoppable_halt( cnv->get_schedule()->at( (i+offset)%max_count ).pos, cnv->get_owner(), get_waytype() );
 					if(  halt.is_bound()  ) {
 						if(  halt->is_enabled(tmp.get_index())  ) {
 							// ok, lets change here, since goods are accepted here
@@ -2313,7 +2313,7 @@ bool road_vehicle_t::choose_route(sint32 &restart_speed, ribi_t::ribi start_dire
 
 	// are we heading to a target?
 	route_t *rt = cnv->access_route();
-	target_halt = haltestelle_t::get_stoppable_halt( rt->back(), get_owner() );
+	target_halt = haltestelle_t::get_stoppable_halt( rt->back(), get_owner(), get_waytype() );
 	if(  target_halt.is_bound()  ) {
 
 		// since convois can long than one tile, check is more difficult
@@ -2884,7 +2884,7 @@ bool road_vehicle_t::can_enter_tile(const grund_t *gr, sint32 &restart_speed, ui
 		}
 		// If the next tile is our destination and we are on passing lane of oneway mode road, we have to wait until traffic lane become safe.
 		if(  cnv->is_overtaking()  &&  str->get_overtaking_mode()==oneway_mode  &&  route_index == r.get_count() - 1u  ) {
-			halthandle_t halt = haltestelle_t::get_stoppable_halt(welt->lookup(r.at(route_index))->get_pos(),cnv->get_owner());
+			halthandle_t halt = haltestelle_t::get_stoppable_halt(welt->lookup(r.at(route_index))->get_pos(),cnv->get_owner(), get_waytype());
 			vehicle_base_t* v = other_lane_blocked(false, offset);
 			if(  halt.is_bound()  &&  gr->get_weg_ribi(get_waytype())!=0  &&  v  &&  v->get_waytype() == road_wt  ) {
 				restart_speed = 0;
@@ -3198,7 +3198,7 @@ void road_vehicle_t::set_convoi(convoi_t *c)
 		if(target  &&  leading  &&  c->get_route()->empty()) {
 			// reinitialize the target halt
 			const route_t *rt = cnv->get_route();
-			target_halt = haltestelle_t::get_stoppable_halt( rt->back(), get_owner() );
+			target_halt = haltestelle_t::get_stoppable_halt( rt->back(), get_owner(), get_waytype() );
 			if(  target_halt.is_bound()  ) {
 				for(  uint32 i=0;  i<c->get_tile_length()  &&  i+1<rt->get_count();  i++  ) {
 					target_halt->reserve_position( welt->lookup( rt->at(rt->get_count()-i-1) ), cnv->self );


### PR DESCRIPTION
```haltestelle_t::get_stoppable_halt()```の引数に```waytype_t```を追加し、海における停車駅判定の際に```waytype```の整合性をチェックします。これにより、飛行機が港周辺の海を中継点に指定しても駅に停車する判定にならず輸送不可能な旅客経路が発生しなくなります。
linux ubuntu SDL2版で動作確認済み