### PR TITLE
BUG FIX: do not send depot which already in depot

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -5016,7 +5016,12 @@ const char* convoi_t::send_to_depot(bool local)
 const char* convoi_t::send_to_depot_immediately(bool local)
 {
 	const char *txt;
-	// First check : the all convoys are same waytype, same owner, etc...
+	// First check : already in depot, do not send any more
+	if(  state==INITIAL  ) {
+		txt = "%s is already in depot", get_name();
+		return txt;
+	}
+	// Second check : the all convoys are same waytype, same owner, etc...
 	convoihandle_t c = get_coupling_convoi();
 	player_t* const owner = get_owner();
 	waytype_t const waytype = front()->get_waytype();

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -5032,7 +5032,8 @@ const char* convoi_t::send_to_depot_immediately(bool local)
 	const char *txt;
 	// First check : already in depot, do not send any more
 	if(  state==INITIAL  ) {
-		txt = "%s is already in depot", get_name();
+		dbg->message("convoi_t::send_to_depot_immediately()","%s is already in depot.", get_name());
+		txt = "%s is already in depot.\n", get_name();
 		return txt;
 	}
 	// Second check : the all convoys are same waytype, same owner, etc...


### PR DESCRIPTION
車庫にいる編成に対して、路線ウィンドウから全編成を車庫に転送した場合に、車庫にいる編成が別の車庫にも入庫し増殖するバグがありました。
```convoi_t::send_to_depot_immediately```において、```state==INITIAL```の編成には処理を行わないようにしました