### PR TITLE
BUG FIX: stop mover do work in diagonal stop

### DIFF
--- a/boden/wege/weg.cc
+++ b/boden/wege/weg.cc
@@ -243,6 +243,7 @@ void weg_t::rdwr(loadsave_t *file)
 
 // calculate the platform length, and append the string of the platform length to buf.
 void append_platform_length_string_if_needed(cbuffer_t & buf, const weg_t* weg) {
+	const koord3d start_pos = weg->get_pos(); // ref. koord which to avoid loop
 	grund_t* gr = world()->lookup(weg->get_pos());
 	const halthandle_t halt = gr ? gr->get_halt() : halthandle_t();
 	if(  !halt.is_bound()  ) {
@@ -269,7 +270,7 @@ void append_platform_length_string_if_needed(cbuffer_t & buf, const weg_t* weg) 
 		if(  !gr  ) { break; }
 		const weg_t* w = gr->get_weg(weg->get_waytype());
 		const halthandle_t h = gr->get_halt();
-		if(  !w  ||  !h.is_bound()  ||  h.get_id()!=halt.get_id()  ) { break; }
+		if(  !w  ||  !h.is_bound()  ||  h.get_id()!=halt.get_id()   ||  gr->get_pos()==start_pos ) { break; }
 		// now, the halt and the way exist on the new tile.
 		pos = gr->get_pos();
 		const ribi_t::ribi new_dir = w->get_ribi_unmasked() & ~(ribi_t::backward(dir));

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -3602,6 +3602,7 @@ uint32 convoi_t::calc_available_halt_length_in_vehicle_steps(koord3d front_vehic
 	// find out how many steps I am already in the station
 	uint32 halt_length = 0;
 	grund_t* gr = world()->lookup(front_vehicle_pos);
+	const koord3d start_pos_ref = front_vehicle_pos;// to avoid loop
 	const halthandle_t halt = gr ? gr->get_halt() : halthandle_t();
 	if(  !halt.is_bound()  ) {
 		// We are not on the valid halt tiles?
@@ -3628,7 +3629,7 @@ uint32 convoi_t::calc_available_halt_length_in_vehicle_steps(koord3d front_vehic
 		is_last_diagonal = ribi_t::is_bend(way_dir);
 		halt_length += is_last_diagonal ? diagonal_tile_length : straight_tile_length;
 		open_dir = way_dir & ~(ribi_t::backward(open_dir));
-		if(  !ribi_t::is_single(open_dir)  ||  !gr->get_neighbour(gr, waytype, open_dir)  ) {
+		if(  !ribi_t::is_single(open_dir)  ||  !gr->get_neighbour(gr, waytype, open_dir)  ||  gr->get_pos() == start_pos_ref  ) {
 			break;
 		}
 	}

--- a/simtool.cc
+++ b/simtool.cc
@@ -7079,7 +7079,7 @@ const char *tool_stop_mover_t::do_work( player_t *player, const koord3d &last_po
 					grund_t *gr = welt->lookup(start_pos);
 					while(true) {
 						gr->get_neighbour(gr, wt, dir);
-						if(!gr  ||  !gr->is_halt()  ||  !gr->get_weg(wt)  || (ribi=gr->get_weg_ribi_unmasked(wt))==0) {
+						if(  !gr  ||  !gr->is_halt()  ||  !gr->get_weg(wt)  || (ribi=gr->get_weg_ribi_unmasked(wt))==0  ||  gr->get_pos()==last_pos  ) {
 							// maybe reach last tile
 							break;
 						}

--- a/simtool.cc
+++ b/simtool.cc
@@ -7060,26 +7060,54 @@ const char *tool_stop_mover_t::do_work( player_t *player, const koord3d &last_po
 				}
 				else {
 					// all connected tiles for start pos
-					uint8 ribi = welt->lookup(last_pos)->get_weg_ribi_unmasked(wt);
-					koord delta = ribi_t::is_straight_ns(ribi) ? koord(0,1) : koord(1,0);
+					ribi_t::ribi ribi = welt->lookup(last_pos)->get_weg_ribi_unmasked(wt);
+					ribi_t::ribi dir = 0;
 					koord3d start_pos=last_pos;
-					while(ribi&12) {
-						koord3d test_pos = start_pos+delta;
-						grund_t *gr = welt->lookup(test_pos);
-						if(!gr  ||  !gr->is_halt()  ||  (ribi=gr->get_weg_ribi_unmasked(wt))==0) {
+					// move to start position of platform
+					// find the initial direction to search.
+					for(uint8 i=0; i<4; i++) {
+						if(  ribi&ribi_t::nesw[i]  ) {
+							dir = ribi_t::nesw[i];
 							break;
 						}
-						start_pos = test_pos;
+					}
+					if(  dir==0  ) {
+						// no connected way!?
+						old_platform.append(last_pos);
+						break;
+					}
+					grund_t *gr = welt->lookup(start_pos);
+					while(true) {
+						gr->get_neighbour(gr, wt, dir);
+						if(!gr  ||  !gr->is_halt()  ||  !gr->get_weg(wt)  || (ribi=gr->get_weg_ribi_unmasked(wt))==0) {
+							// maybe reach last tile
+							break;
+						}
+						const ribi_t::ribi new_dir = ribi & ~(ribi_t::backward(dir));
+						if( new_dir==0 ) {
+							// maybe reach last tile
+							break;
+						}
+						dir = new_dir;
+						start_pos = gr->get_pos();
 					}
 					// now add all of them
-					while(ribi&3) {
-						koord3d test_pos = start_pos-delta;
-						grund_t *gr = welt->lookup(test_pos);
+					dir = ribi_t::backward(dir);
+					gr = welt->lookup(start_pos);
+					while(true) {
 						old_platform.append(start_pos);
-						if(!gr  ||  !gr->is_halt()  ||  (ribi=gr->get_weg_ribi_unmasked(wt))==0) {
+						gr->get_neighbour(gr, wt, dir);
+						if(!gr  ||  !gr->is_halt()  ||  !gr->get_weg(wt)  || (ribi=gr->get_weg_ribi_unmasked(wt))==0) {
+							// maybe reach last tile
 							break;
 						}
-						start_pos = test_pos;
+						const ribi_t::ribi new_dir = ribi & ~(ribi_t::backward(dir));
+						if( new_dir==0 ) {
+							// maybe reach last tile
+							break;
+						}
+						dir = new_dir;
+						start_pos = gr->get_pos();
 					}
 				}
 			}

--- a/simtool.cc
+++ b/simtool.cc
@@ -7094,10 +7094,11 @@ const char *tool_stop_mover_t::do_work( player_t *player, const koord3d &last_po
 					// now add all of them
 					dir = ribi_t::backward(dir);
 					gr = welt->lookup(start_pos);
+					const koord3d end_pos = start_pos;
 					while(true) {
 						old_platform.append(start_pos);
 						gr->get_neighbour(gr, wt, dir);
-						if(!gr  ||  !gr->is_halt()  ||  !gr->get_weg(wt)  || (ribi=gr->get_weg_ribi_unmasked(wt))==0  ||  gr->get_pos()==last_pos  ) {
+						if(!gr  ||  !gr->is_halt()  ||  !gr->get_weg(wt)  || (ribi=gr->get_weg_ribi_unmasked(wt))==0  ||  gr->get_pos()==end_pos  ) {
 							// maybe reach last tile
 							break;
 						}

--- a/simtool.cc
+++ b/simtool.cc
@@ -7097,7 +7097,7 @@ const char *tool_stop_mover_t::do_work( player_t *player, const koord3d &last_po
 					while(true) {
 						old_platform.append(start_pos);
 						gr->get_neighbour(gr, wt, dir);
-						if(!gr  ||  !gr->is_halt()  ||  !gr->get_weg(wt)  || (ribi=gr->get_weg_ribi_unmasked(wt))==0) {
+						if(!gr  ||  !gr->is_halt()  ||  !gr->get_weg(wt)  || (ribi=gr->get_weg_ribi_unmasked(wt))==0  ||  gr->get_pos()==last_pos  ) {
 							// maybe reach last tile
 							break;
 						}


### PR DESCRIPTION
スケジュール移動ツールが斜めタイル駅で使えない問題を修正しました