### PR TITLE
BUG FIX: do not teleport child convoy directly

### DIFF
--- a/documentation/ja.OTRP.tab
+++ b/documentation/ja.OTRP.tab
@@ -299,6 +299,8 @@ Vehicle %s is coupled convoy, so it cannot depart alone!
 %sは先頭の編成ではないので、発車しませんでした。
 Vehicle %s will couple with vehicle %s, but the next stop positions are different!
 %sと%sは連結して発車する予定ですが、次の駅の座標が異なるため連結できません!
+%s is not front convoy.
+%sは先頭の編成ではありません。
 #------その他の翻訳------
 next stop
 次の駅へ

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -5036,6 +5036,12 @@ const char* convoi_t::send_to_depot_immediately(bool local)
 		txt = "%s is already in depot.\n", get_name();
 		return txt;
 	}
+	// If this convoy is not leading, false.
+	if(  is_coupled()  ) {
+		dbg->message("convoi_t::send_to_depot_immediately()","%s is not front convoy.", get_name());
+		txt = "%s is not front convoy.\n", get_name();
+		return txt;
+	}
 	// Second check : the all convoys are same waytype, same owner, etc...
 	convoihandle_t c = get_coupling_convoi();
 	player_t* const owner = get_owner();


### PR DESCRIPTION
路線ウィンドウから全編成を車庫に転送した際、子編成が誤って転送されてしまいバグを引き起こしていました。
子編成は転送されないようにしました。