### PR TITLE
can choose move one tile or whole tiles in same platform in stop_mover

### DIFF
--- a/simtool.cc
+++ b/simtool.cc
@@ -7055,7 +7055,7 @@ const char *tool_stop_mover_t::do_work( player_t *player, const koord3d &last_po
 			}
 			else if(!catch_all_halt) {
 				// builds a coordinate list
-				if(wt==road_wt) {
+				if(is_ctrl_pressed()) {
 					old_platform.append(last_pos);
 				}
 				else {


### PR DESCRIPTION
stop_mover について、ctrlキーを押しながら移動すると1マスだけ移動するようにし、同じホームの別のタイルに停車するべつのスケジュールをまとめて移動するかどうかを選択できるようにします。