### PR TITLE
BUG FIX: avoid crash when search non-exists next line

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -5507,8 +5507,12 @@ void convoi_t::calc_sum_friction_weight() {
 void convoi_t::change_line_to_next_if_needed() 
 {
 	linehandle_t l = get_schedule()->get_next_line();
+	if( !l.is_bound() ) {
+		// return safely
+		return;
+	}
 	// check and update next_line
-	if(  l.is_bound() && l->get_schedule()->get_count()>1 && l->get_schedule()->at(0).pos!=get_schedule()->at(get_schedule()->get_count()-1).pos ) {
+	if(  l->get_schedule()->get_count()>1 && l->get_schedule()->at(0).pos!=get_schedule()->at(get_schedule()->get_count()-1).pos ) {
 		if(  get_line().is_bound()  ) {
 			get_line()->get_schedule()->set_next_line(l);
 		}


### PR DESCRIPTION
ジャンプ先の路線を消した場合などに、クラッシュする可能性があったため対応しました。