### PR TITLE
unified longblocksignal calculation and delete convoi_t::longblock_signal_judge

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -177,7 +177,6 @@ void convoi_t::init(player_t *player)
 	request_cross_ticks = 0;
 	prev_tiles_overtaking = 0;
 
-	longblock_signal_request.valid = false;
 	crossing_reservation_index.clear();
 	recalc_min_top_speed = true;
 	recalc_friction_weight = true;
@@ -1530,15 +1529,6 @@ void convoi_t::step()
 			return; // must not continue method after deleting this object
 
 		case DRIVING:
-			if(fahr[0]->get_waytype()==track_wt  ||  fahr[0]->get_waytype()==monorail_wt  ||  fahr[0]->get_waytype()==maglev_wt  ||  fahr[0]->get_waytype()==narrowgauge_wt) {
-				rail_vehicle_t* v = dynamic_cast<rail_vehicle_t*>(fahr[0]);
-				if(  v  &&  longblock_signal_request.valid  ) {
-					// process longblock signal judgement request
-					sint32 dummy = -1;
-					v->check_longblock_signal(longblock_signal_request.sig, longblock_signal_request.next_block, dummy);
-					set_longblock_signal_judge_request_invalid();
-				}
-			}
 			break;
 
 		case WAITING_FOR_LEAVING_DEPOT:
@@ -5225,11 +5215,6 @@ void convoi_t::set_next_cross_lane(bool n) {
 	}
 }
 
-void convoi_t::request_longblock_signal_judge(signal_t *sig, uint16 next_block) {
-	longblock_signal_request.sig = sig;
-	longblock_signal_request.next_block = next_block;
-	longblock_signal_request.valid = true;
-}
 
 void convoi_t::clear_reserved_tiles(){
 	if(  reserved_tiles.get_count()==0  ) {

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -351,12 +351,7 @@ private:
 
 	bool in_delay_recovery;
 
-	typedef struct {
-		bool valid;
-		signal_t* sig;
-		uint16 next_block;
-	} longblock_signal_request_t;
-	longblock_signal_request_t longblock_signal_request;
+
 
 	/**
 	 * struct holds new financial history for convoi
@@ -1038,9 +1033,6 @@ public:
 	void set_next_cross_lane(bool);
 
 	virtual void refresh(sint8,sint8) OVERRIDE;
-
-	void request_longblock_signal_judge(signal_t *sig, uint16 next_block);
-	void set_longblock_signal_judge_request_invalid() { longblock_signal_request.valid = false; };
 
 	void calc_crossing_reservation();
 	vector_tpl<std::pair< uint16, uint16> > get_crossing_reservation_index() const { return crossing_reservation_index; }

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -3552,7 +3552,7 @@ bool rail_vehicle_t::is_coupling_target(const grund_t *gr, const grund_t *prev_g
 }
 
 
-bool rail_vehicle_t::check_longblock_signal(signal_t *sig, uint16 next_block, sint32 &restart_speed)
+bool rail_vehicle_t::is_longblock_signal_clear(signal_t *sig, uint16 next_block, sint32 &restart_speed)
 {
 	// longblock signal: first check, whether there is a signal coming up on the route => just like normal signal
 	uint16 next_signal, next_crossing;
@@ -3591,7 +3591,7 @@ bool rail_vehicle_t::check_longblock_signal(signal_t *sig, uint16 next_block, si
 	schedule_t* schedule = cnv->get_schedule();
 	uint8 schedule_index = cnv->get_schedule()->get_current_stop()+1;
 	route_t target_rt;
-	koord3d cur_pos = cnv->get_route()->back();
+	koord3d cur_pos = cnv->get_route()->at(next_block);
 	uint16 dummy;
 	uint16 next_next_signal = route_t::INVALID_INDEX;
 	
@@ -3661,22 +3661,6 @@ bool rail_vehicle_t::check_longblock_signal(signal_t *sig, uint16 next_block, si
 		cnv->set_next_stop_index( cnv->get_route()->get_count()-1 );
 	}
 	return true;
-}
-
-bool rail_vehicle_t::is_longblock_signal_clear(signal_t *sig, uint16 next_block, sint32 &restart_speed)
-{
-	if(  cnv->is_waiting()  ) {
-		// we are in a step. do that.
-		const bool res = check_longblock_signal(sig, next_block, restart_speed);
-		cnv->set_longblock_signal_judge_request_invalid();
-		return res;
-	}
-	else {
-		// we are in a sync_step. request to do this in a step.
-		cnv->request_longblock_signal_judge(sig, next_block);
-		restart_speed = 0;
-		return false;
-	}
 }
 
 

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -3570,6 +3570,13 @@ bool rail_vehicle_t::is_longblock_signal_clear(signal_t *sig, uint16 next_block,
 		return true;
 	}
 
+	if(  !cnv->is_waiting()  ) {
+		// we are in a sync_step. request to do this in a step.
+		block_reserver( cnv->get_route(), next_block+1, next_signal, next_crossing, 0, false, false);
+		restart_speed = 0;
+		return false;
+	}
+
 	// now we have to maintain reservation with reserved_tiles, that is slower than using next_reservation_index
 	// copy all tiles that are already reserved
 	bool add_pos = false;
@@ -3591,7 +3598,7 @@ bool rail_vehicle_t::is_longblock_signal_clear(signal_t *sig, uint16 next_block,
 	schedule_t* schedule = cnv->get_schedule();
 	uint8 schedule_index = cnv->get_schedule()->get_current_stop()+1;
 	route_t target_rt;
-	koord3d cur_pos = cnv->get_route()->at(next_block);
+	koord3d cur_pos = cnv->get_route()->at(next_block);//cnv->get_route()->back();
 	uint16 dummy;
 	uint16 next_next_signal = route_t::INVALID_INDEX;
 	
@@ -3831,11 +3838,14 @@ bool rail_vehicle_t::is_pre_signal_clear(signal_t *sig, uint16 next_block, sint3
 	uint16 next_signal, next_crossing;
 	if(  block_reserver( cnv->get_route(), next_block+1, next_signal, next_crossing, 0, true, false )  ) {
 		if(next_signal == route_t::INVALID_INDEX ||
-           cnv->get_route()->at(next_signal) == cnv->get_route()->back() ||
-           is_signal_clear( next_signal, restart_speed )) {
+           cnv->get_route()->at(next_signal) == cnv->get_route()->back()) {
 			// ok, end of route => we can go
 			sig->set_state( roadsign_t::STATE_GREEN );
 			cnv->set_next_stop_index( min( next_signal, next_crossing ) );
+			return true;
+		} else if ( is_signal_clear( next_signal, restart_speed ) ) {
+			// ok, next signal clear
+			sig->set_state( roadsign_t::STATE_GREEN );
 			return true;
 		}
 		// when we reached here, the way is apparently not free => release reservation and set state to next free

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -3573,7 +3573,7 @@ bool rail_vehicle_t::is_longblock_signal_clear(signal_t *sig, uint16 next_block,
 	if(  !cnv->is_waiting()  ) {
 		// we are in a sync_step. request to do this in a step.
 		block_reserver( cnv->get_route(), next_block+1, next_signal, next_crossing, 0, false, false);
-		restart_speed = 0;
+		restart_speed = -1;
 		return false;
 	}
 

--- a/vehicle/simvehicle.h
+++ b/vehicle/simvehicle.h
@@ -611,9 +611,6 @@ public:
 	void set_convoi(convoi_t *c) OVERRIDE;
 
 	virtual schedule_t * generate_new_schedule() const OVERRIDE;
-
-	// step() routine called by convoy
-	bool check_longblock_signal(signal_t *sig, uint16 start_index, sint32 &restart_speed);
 };
 
 


### PR DESCRIPTION
ロングブロックシグナルがis_signal_clear()で予約計算を行わないため、プレシグナルやプライオリティシグナルと相性が悪いという問題がありました