### PR TITLE
simtool.ccに関する複数市内建築物範囲建設処理の挙動変更

### DIFF
--- a/simtool.cc
+++ b/simtool.cc
@@ -6338,7 +6338,7 @@ void tool_build_house_t::set_buildings(vector_tpl<const building_desc_t*> bldg) 
 	buildings.clear();
 	srand((unsigned int)time(NULL));
 	for(  uint32 i=0;  i<bldg.get_count();  i++  ) {
-		buildings.append(bldg[rand() % bldg.get_count() + 1]);
+		buildings.append(bldg[rand() % bldg.get_count()]);
 	}
 }
 

--- a/simtool.cc
+++ b/simtool.cc
@@ -7,6 +7,10 @@
 #include <string.h>
 #include <math.h>
 
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+
 #include "simdebug.h"
 #include "simevent.h"
 #include "simcity.h"
@@ -6332,8 +6336,9 @@ const char *tool_build_house_t::do_work( player_t *player, const koord3d &start,
 
 void tool_build_house_t::set_buildings(vector_tpl<const building_desc_t*> bldg) {
 	buildings.clear();
+	srand((unsigned int)time(NULL));
 	for(  uint32 i=0;  i<bldg.get_count();  i++  ) {
-		buildings.append(bldg[i]);
+		buildings.append(bldg[rand() % (bldg.get_count() - 1) + 1]);
 	}
 }
 

--- a/simtool.cc
+++ b/simtool.cc
@@ -6364,7 +6364,7 @@ void tool_build_house_t::rdwr_custom_data(memory_rw_t *packet)
 		// writing
 		for(  uint32 i=0;  i<count;  i++  ) {
 			ps = plainstring(buildings[i]->get_name());
-			printf(ps);
+			buf.printf(ps);
 			packet->rdwr_str(ps);
 		}
 	}

--- a/simtool.cc
+++ b/simtool.cc
@@ -6364,7 +6364,7 @@ void tool_build_house_t::rdwr_custom_data(memory_rw_t *packet)
 		// writing
 		for(  uint32 i=0;  i<count;  i++  ) {
 			ps = plainstring(buildings[i]->get_name());
-			printf(ps);
+			DBG_MESSAGE(ps);
 			packet->rdwr_str(ps);
 		}
 	}

--- a/simtool.cc
+++ b/simtool.cc
@@ -6364,7 +6364,7 @@ void tool_build_house_t::rdwr_custom_data(memory_rw_t *packet)
 		// writing
 		for(  uint32 i=0;  i<count;  i++  ) {
 			ps = plainstring(buildings[i]->get_name());
-			DBG_MESSAGE("tool_build_house_t:",ps);
+			dbg->message("tool_build_house_t:","OK");
 			packet->rdwr_str(ps);
 		}
 	}

--- a/simtool.cc
+++ b/simtool.cc
@@ -6364,7 +6364,7 @@ void tool_build_house_t::rdwr_custom_data(memory_rw_t *packet)
 		// writing
 		for(  uint32 i=0;  i<count;  i++  ) {
 			ps = plainstring(buildings[i]->get_name());
-			DBG_MESSAGE(ps);
+			DBG_MESSAGE("tool_build_house_t:",ps);
 			packet->rdwr_str(ps);
 		}
 	}

--- a/simtool.cc
+++ b/simtool.cc
@@ -6364,7 +6364,7 @@ void tool_build_house_t::rdwr_custom_data(memory_rw_t *packet)
 		// writing
 		for(  uint32 i=0;  i<count;  i++  ) {
 			ps = plainstring(buildings[i]->get_name());
-			buf.printf(ps);
+			dbg->message("tool_build_house_t::rdwr_custom_data()",ps);
 			packet->rdwr_str(ps);
 		}
 	}

--- a/simtool.cc
+++ b/simtool.cc
@@ -6362,11 +6362,16 @@ void tool_build_house_t::rdwr_custom_data(memory_rw_t *packet)
 		}
 	} else {
 		// writing
-		for(  uint32 i=0;  i<count;  i++  ) {
-			ps = plainstring(buildings[i]->get_name());
-			dbg->message("tool_build_house_t:","OK");
-			packet->rdwr_str(ps);
-		}
+		srand((unsigned int)time(NULL)); 
+		if (count > 0) {
+   			for (uint32 i = 0; i < count; i++) {
+        		uint32 rand_index = rand() % count;
+       			ps = plainstring(buildings[rand_index]->get_name());
+        		packet->rdwr_str(ps);
+			}
+    }
+}
+
 	}
 }
 

--- a/simtool.cc
+++ b/simtool.cc
@@ -6364,7 +6364,7 @@ void tool_build_house_t::rdwr_custom_data(memory_rw_t *packet)
 		// writing
 		for(  uint32 i=0;  i<count;  i++  ) {
 			ps = plainstring(buildings[i]->get_name());
-			dbg->message("tool_build_house_t::rdwr_custom_data()",ps);
+			printf(ps);
 			packet->rdwr_str(ps);
 		}
 	}

--- a/simtool.cc
+++ b/simtool.cc
@@ -6338,7 +6338,7 @@ void tool_build_house_t::set_buildings(vector_tpl<const building_desc_t*> bldg) 
 	buildings.clear();
 	srand((unsigned int)time(NULL));
 	for(  uint32 i=0;  i<bldg.get_count();  i++  ) {
-		buildings.append(bldg[rand() % (bldg.get_count() - 1) + 1]);
+		buildings.append(bldg[rand() % bldg.get_count() + 1]);
 	}
 }
 

--- a/simtool.cc
+++ b/simtool.cc
@@ -7,9 +7,6 @@
 #include <string.h>
 #include <math.h>
 
-#include <stdlib.h>
-#include <time.h>
-
 #include "simdebug.h"
 #include "simevent.h"
 #include "simcity.h"

--- a/simtool.cc
+++ b/simtool.cc
@@ -7,9 +7,9 @@
 #include <string.h>
 #include <math.h>
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
-#include <unistd.h>
 
 #include "simdebug.h"
 #include "simevent.h"
@@ -6336,9 +6336,8 @@ const char *tool_build_house_t::do_work( player_t *player, const koord3d &start,
 
 void tool_build_house_t::set_buildings(vector_tpl<const building_desc_t*> bldg) {
 	buildings.clear();
-	srand((unsigned int)time(NULL));
 	for(  uint32 i=0;  i<bldg.get_count();  i++  ) {
-		buildings.append(bldg[rand() % bldg.get_count()]);
+		buildings.append(i]);
 	}
 }
 
@@ -6365,6 +6364,7 @@ void tool_build_house_t::rdwr_custom_data(memory_rw_t *packet)
 		// writing
 		for(  uint32 i=0;  i<count;  i++  ) {
 			ps = plainstring(buildings[i]->get_name());
+			printf(ps)
 			packet->rdwr_str(ps);
 		}
 	}

--- a/simtool.cc
+++ b/simtool.cc
@@ -7,7 +7,6 @@
 #include <string.h>
 #include <math.h>
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
 

--- a/simtool.cc
+++ b/simtool.cc
@@ -6359,6 +6359,11 @@ void tool_build_house_t::rdwr_custom_data(memory_rw_t *packet)
 				buildings.append(tile->get_desc());
 			}
 		}
+	} else if(env_t::server){
+		for(  uint32 i=0;  i<count;  i++  ) {
+			ps = plainstring(buildings[i]->get_name());
+			packet->rdwr_str(ps);
+		}
 	} else {
 		// writing
         if (count > 0) {

--- a/simtool.cc
+++ b/simtool.cc
@@ -15,6 +15,7 @@
 #include "simcity.h"
 #include "simmesg.h"
 #include "simconvoi.h"
+
 #include "gui/simwin.h"
 #include "display/viewport.h"
 
@@ -6367,14 +6368,14 @@ void tool_build_house_t::rdwr_custom_data(memory_rw_t *packet)
 	} else {
 		// writing
         if (count > 0) {
-            srand((unsigned int)time(NULL)); 
+			dbg->message("tool_build_house_t::rdwr_custom_data()","randbuildingset");
             uint32 i = 0;
             bool* used_flags = new bool[count];
             for( uint32 j = 0; j < count; j++) {
                 used_flags[j] = false;
             }
             while (i < count) {
-                uint32 rand_index = rand() % count;
+                uint32 rand_index = sim_async_rand(count);
                 if(used_flags[rand_index]){
 					continue;
 				}

--- a/simtool.cc
+++ b/simtool.cc
@@ -6337,7 +6337,7 @@ const char *tool_build_house_t::do_work( player_t *player, const koord3d &start,
 void tool_build_house_t::set_buildings(vector_tpl<const building_desc_t*> bldg) {
 	buildings.clear();
 	for(  uint32 i=0;  i<bldg.get_count();  i++  ) {
-		buildings.append(i]);
+		buildings.append([i]);
 	}
 }
 
@@ -6364,7 +6364,7 @@ void tool_build_house_t::rdwr_custom_data(memory_rw_t *packet)
 		// writing
 		for(  uint32 i=0;  i<count;  i++  ) {
 			ps = plainstring(buildings[i]->get_name());
-			printf(ps)
+			printf(ps);
 			packet->rdwr_str(ps);
 		}
 	}

--- a/simtool.cc
+++ b/simtool.cc
@@ -6337,7 +6337,7 @@ const char *tool_build_house_t::do_work( player_t *player, const koord3d &start,
 void tool_build_house_t::set_buildings(vector_tpl<const building_desc_t*> bldg) {
 	buildings.clear();
 	for(  uint32 i=0;  i<bldg.get_count();  i++  ) {
-		buildings.append([i]);
+		buildings.append(bldg[i]);
 	}
 }
 

--- a/simtool.cc
+++ b/simtool.cc
@@ -6361,14 +6361,25 @@ void tool_build_house_t::rdwr_custom_data(memory_rw_t *packet)
 		}
 	} else {
 		// writing
-		srand((unsigned int)time(NULL)); 
-		if (count > 0) {
-   			for (uint32 i = 0; i < count; i++) {
-        		uint32 rand_index = rand() % count;
-       			ps = plainstring(buildings[rand_index]->get_name());
-        		packet->rdwr_str(ps);
-			}
-   		}
+        if (count > 0) {
+            srand((unsigned int)time(NULL)); 
+            uint32 i = 0;
+            bool* used_flags = new bool[count];
+            for( uint32 j = 0; j < count; j++) {
+                used_flags[j] = false;
+            }
+            while (i < count) {
+                uint32 rand_index = rand() % count;
+                if(used_flags[rand_index]){
+					continue;
+				}
+                ps = plainstring(buildings[rand_index]->get_name());
+                packet->rdwr_str(ps);
+				used_flags[rand_index] = true;
+                i++;
+            }
+			delete[] used_flags;
+        }
 	}
 }
 

--- a/simtool.cc
+++ b/simtool.cc
@@ -6369,9 +6369,7 @@ void tool_build_house_t::rdwr_custom_data(memory_rw_t *packet)
        			ps = plainstring(buildings[rand_index]->get_name());
         		packet->rdwr_str(ps);
 			}
-    }
-}
-
+   		}
 	}
 }
 


### PR DESCRIPTION
NS時、複数の市内建築物を範囲建設をする際に、実行時に対象建築物の配列を抽選して順序変更してからpacketに追加する処理に変更。