### PR TITLE
Force static linking on github workflow mac build

### DIFF
--- a/.github/build-mac.sh
+++ b/.github/build-mac.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
 # builds for macOS
 
+# remove dynamic libraries to force static linking
+rm /opt/homebrew/opt/freetype/lib/libfreetype.dylib
+rm /opt/homebrew/opt/libpng/lib/libpng16.dylib
+rm /opt/homebrew/opt/zstd/lib/libzstd.dylib
+rm /opt/homebrew/opt/sdl2/lib/libSDL2.dylib 
+
 # normal build
 echo "BACKEND = sdl2" >config.default
 echo "OSTYPE = mac" >>config.default
@@ -8,11 +14,12 @@ echo "COLOUR_DEPTH =16" >>config.default
 echo "DEBUG = 0" >>config.default
 echo "MSG_LEVEL = 3" >>config.default
 echo "OPTIMISE = 1" >>config.default
+echo "STATIC = 1" >>config.default
 echo "MULTI_THREAD = 1" >>config.default
 echo "USE_ZSTD = 1" >>config.default
 echo "USE_FREETYPE = 1" >>config.default
-echo "WITH_REVISION = $(svn info --show-item revision svn://servers.simutrans.org/simutrans)" >>config.default
+echo "WITH_REVISION = 9281" >>config.default
 echo "AV_FOUNDATION = 1" >>config.default
 echo "FLAGS = -std=c++20" >>config.default
-make -j
+make -j4
 mv build/default/sim sim-mac-OTRP


### PR DESCRIPTION
GitHub actions workflowで動作するmac版バイナリのビルドにおいてstatic linkを強制します。これにより、生成されるバイナリは以下のようになります。

- 必要な依存がバイナリに含まれているので、ユーザは別途依存ライブラリをインストールする必要がありません。
- arm64専用バイナリです。Intel macでは動きません。

動作確認: https://github.com/teamhimeh/simutrans/actions/runs/18317760283

```
% otool -L sim-mac-OTRP
sim-mac-OTRP:
	/usr/lib/libbz2.1.0.dylib (compatibility version 1.0.0, current version 1.0.8)
	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.12)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1351.0.0)
	/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation (compatibility version 300.0.0, current version 3502.1.255)
	/System/Library/Frameworks/AVFoundation.framework/Versions/A/AVFoundation (compatibility version 1.0.0, current version 2.0.0)
	/System/Library/Frameworks/CoreAudio.framework/Versions/A/CoreAudio (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox (compatibility version 1.0.0, current version 1000.0.0)
	/System/Library/Frameworks/CoreHaptics.framework/Versions/A/CoreHaptics (compatibility version 1.0.0, current version 1.0.0, weak)
	/System/Library/Frameworks/GameController.framework/Versions/A/GameController (compatibility version 1.0.0, current version 12.5.3, weak)
	/System/Library/Frameworks/ForceFeedback.framework/Versions/A/ForceFeedback (compatibility version 1.0.0, current version 1.0.2)
	/usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
	/System/Library/Frameworks/CoreVideo.framework/Versions/A/CoreVideo (compatibility version 1.2.0, current version 1.5.0)
	/System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa (compatibility version 1.0.0, current version 24.0.0)
	/System/Library/Frameworks/Carbon.framework/Versions/A/Carbon (compatibility version 2.0.0, current version 170.0.0)
	/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit (compatibility version 1.0.0, current version 275.0.0)
	/System/Library/Frameworks/QuartzCore.framework/Versions/A/QuartzCore (compatibility version 1.2.0, current version 1.11.0, weak)
	/System/Library/Frameworks/Metal.framework/Versions/A/Metal (compatibility version 1.0.0, current version 368.12.0, weak)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1900.180.0)
	/System/Library/Frameworks/AVFAudio.framework/Versions/A/AVFAudio (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit (compatibility version 45.0.0, current version 2575.60.5)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 3502.1.255)
	/System/Library/Frameworks/CoreGraphics.framework/Versions/A/CoreGraphics (compatibility version 64.0.0, current version 1889.5.3)
	/System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices (compatibility version 1.0.0, current version 1226.0.0)
```