### PR TITLE
add city name in new factory's name

### DIFF
--- a/bauer/fabrikbauer.cc
+++ b/bauer/fabrikbauer.cc
@@ -549,6 +549,13 @@ fabrik_t* factory_builder_t::build_factory(koord3d* parent, const factory_desc_t
 				}
 			}
 		}
+		// set factory name with nearest city name
+		stadt_t *stadt = welt->find_nearest_city(pos.get_2d());
+		if(  stadt  ) {
+			cbuffer_t buf;
+			buf.printf("%s %s", stadt->get_name(), translator::translate(info->get_name(), welt->get_settings().get_name_language_id()));
+			fab->set_name(buf);
+		}
 	}
 
 	// add passenger to pax>0, (so no suicide diver at the fish swarm)

--- a/bauer/fabrikbauer.cc
+++ b/bauer/fabrikbauer.cc
@@ -553,7 +553,7 @@ fabrik_t* factory_builder_t::build_factory(koord3d* parent, const factory_desc_t
 		stadt_t *stadt = welt->find_nearest_city(pos.get_2d());
 		if(  stadt  ) {
 			cbuffer_t buf;
-			buf.printf("%s(%s)", translator::translate(info->get_name(), welt->get_settings().get_name_language_id()), stadt->get_name());
+			buf.printf("%s %s", stadt->get_name(), translator::translate(info->get_name(), welt->get_settings().get_name_language_id()));
 			fab->set_name(buf);
 		}
 	}

--- a/bauer/fabrikbauer.cc
+++ b/bauer/fabrikbauer.cc
@@ -553,7 +553,7 @@ fabrik_t* factory_builder_t::build_factory(koord3d* parent, const factory_desc_t
 		stadt_t *stadt = welt->find_nearest_city(pos.get_2d());
 		if(  stadt  ) {
 			cbuffer_t buf;
-			buf.printf("%s %s", stadt->get_name(), translator::translate(info->get_name(), welt->get_settings().get_name_language_id()));
+			buf.printf("%s(%s)", translator::translate(info->get_name(), welt->get_settings().get_name_language_id()), stadt->get_name());
 			fab->set_name(buf);
 		}
 	}

--- a/documentation/ja.OTRP.tab
+++ b/documentation/ja.OTRP.tab
@@ -318,3 +318,5 @@ hl_btn_sort_waiting_percentage
 待機率
 transfers
 ご利用
+Factory Type
+産業の種類

--- a/gui/factorylist_frame_t.cc
+++ b/gui/factorylist_frame_t.cc
@@ -19,7 +19,8 @@ const char *factorylist_frame_t::sort_text[factorylist::SORT_MODES] = {
 	"Output",
 	"Produktion",
 	"Rating",
-	"Power"
+	"Power",
+	"Factory Type"
 };
 
 class playername_const_scroll_item_t : public gui_scrolled_list_t::const_text_scrollitem_t {

--- a/gui/factorylist_stats_t.cc
+++ b/gui/factorylist_stats_t.cc
@@ -139,7 +139,11 @@ bool factorylist_stats_t::compare(const gui_component_t *aa, const gui_component
 		case factorylist::by_name:
 			cmp = 0;
 			break;
-
+		case factorylist::by_desc_name:
+		{	
+			cmp = STRICMP(a->get_desc()->get_name(), b->get_desc()->get_name());
+			break;
+		}
 		case factorylist::by_input:
 		{
 			int a_in = a->get_input().empty() ? -1 : (int)a->get_total_in();

--- a/gui/factorylist_stats_t.cc
+++ b/gui/factorylist_stats_t.cc
@@ -141,7 +141,7 @@ bool factorylist_stats_t::compare(const gui_component_t *aa, const gui_component
 			break;
 		case factorylist::by_desc_name:
 		{	
-			cmp = STRICMP(a->get_desc()->get_name(), b->get_desc()->get_name());
+			cmp = STRICMP(translator::translate(a->get_desc()->get_name()), translator::translate(b->get_desc()->get_name()));
 			break;
 		}
 		case factorylist::by_input:

--- a/gui/factorylist_stats_t.h
+++ b/gui/factorylist_stats_t.h
@@ -24,6 +24,7 @@ namespace factorylist {
 		by_maxprod,
 		by_status,
 		by_power,
+		by_desc_name,
 		SORT_MODES,
 
 		// the last two are unused


### PR DESCRIPTION
産業新設時に、地上の産業は最寄りの都市名を自動的に付与します
ただし、海上産業、町が1つもない状態のマップ等では付与しません