### PR TITLE
道路の属性に"NO_BUILDING"を追加

### DIFF
--- a/boden/wege/strasse.h
+++ b/boden/wege/strasse.h
@@ -24,10 +24,10 @@ public:
 	static bool show_reservations;
 	
 	enum {
-		AVOID_CITYROAD   = 0x01, // this street avoid becoming cityroad.
-		CITYCAR_NO_ENTRY = 0x02, // citycar cannot enter this road.
-		USE_GIVEN_HEIGHT = 0x04, // this flag is used only for construction
-		NO_BUILDING      = 0x08  // no building can be built adjacent to this road
+		AVOID_CITYROAD   = 1U << 0, // this street avoid becoming cityroad.
+		CITYCAR_NO_ENTRY = 1U << 1, // citycar cannot enter this road.
+		USE_GIVEN_HEIGHT = 1U << 2, // this flag is used only for construction
+		NO_BUILDING      = 1U << 3  // no building can be built adjacent to this road
 	};
 
 private:

--- a/boden/wege/strasse.h
+++ b/boden/wege/strasse.h
@@ -26,7 +26,8 @@ public:
 	enum {
 		AVOID_CITYROAD   = 0x01, // this street avoid becoming cityroad.
 		CITYCAR_NO_ENTRY = 0x02, // citycar cannot enter this road.
-		USE_GIVEN_HEIGHT = 0x04  // this flag is used only for construction
+		USE_GIVEN_HEIGHT = 0x04, // this flag is used only for construction
+		NO_BUILDING      = 0x08  // no building can be built adjacent to this road
 	};
 
 private:
@@ -140,6 +141,8 @@ public:
 	void set_avoid_cityroad(bool s) { s ? street_flags |= AVOID_CITYROAD : street_flags &= ~AVOID_CITYROAD; }
 	bool get_citycar_no_entry() const { return street_flags&CITYCAR_NO_ENTRY; }
 	void set_citycar_no_entry(bool s) { s ? street_flags |= CITYCAR_NO_ENTRY : street_flags &= ~CITYCAR_NO_ENTRY; }
+	bool get_no_building() const { return street_flags&NO_BUILDING; }
+	void set_no_building(bool s) { s ? street_flags |= NO_BUILDING : street_flags &= ~NO_BUILDING; }
 
 };
 

--- a/boden/wege/weg.cc
+++ b/boden/wege/weg.cc
@@ -334,6 +334,10 @@ void weg_t::info(cbuffer_t & buf) const
 		if(  str->get_citycar_no_entry()  ) {
 			buf.printf("%s\n", translator::translate("Citycars are excluded."));
 		}
+
+		if(  str->get_no_building()  ) {
+			buf.printf("%s\n", translator::translate("No building adjacent."));
+		}
 	}
 
 	if(has_sign()) {

--- a/boden/wege/weg.cc
+++ b/boden/wege/weg.cc
@@ -336,7 +336,7 @@ void weg_t::info(cbuffer_t & buf) const
 		}
 
 		if(  str->get_no_building()  ) {
-			buf.printf("%s\n", translator::translate("No building adjacent."));
+			buf.printf("%s\n", translator::translate("No buildings along roadside."));
 		}
 	}
 

--- a/documentation/ja.OTRP.tab
+++ b/documentation/ja.OTRP.tab
@@ -23,6 +23,8 @@ halt mode
 追越車線にも停車
 avoid becoming cityroad
 市道化を禁止する
+no building adjacent
+建物を接道しない
 Overtaking:
 追越設定:
 Can be cityroad:

--- a/documentation/ja.OTRP.tab
+++ b/documentation/ja.OTRP.tab
@@ -23,7 +23,7 @@ halt mode
 追越車線にも停車
 avoid becoming cityroad
 市道化を禁止する
-no building adjacent
+No buildings along roadside.
 建物を接道しない
 Overtaking:
 追越設定:

--- a/gui/overtaking_mode.cc
+++ b/gui/overtaking_mode.cc
@@ -75,7 +75,14 @@ void overtaking_mode_frame_t::init( player_t* player_, overtaking_mode_t overtak
 	citycar_no_entry_button.add_listener(this);
 	citycar_no_entry_button.pressed = street_flag_&strasse_t::CITYCAR_NO_ENTRY;
 	add_component(&citycar_no_entry_button);
-	
+
+	no_building_button.init( button_t::square_state, "no building adjacent");
+	no_building_button.add_listener(this);
+	no_building_button.pressed = street_flag_&strasse_t::NO_BUILDING;
+	// NO_BUILDING is only meaningful when AVOID_CITYROAD is true
+	no_building_button.enable( street_flag_&strasse_t::AVOID_CITYROAD );
+	add_component(&no_building_button);
+
 	if(  tool_class==0  &&  !show_avoid_cityroad  ) {
 		// the way is elevated. height offset setting is displayed.
 		add_component(&divider[1]);
@@ -120,9 +127,17 @@ bool overtaking_mode_frame_t::action_triggered( gui_action_creator_t *komp, valu
 		num = 5;
 	}else if(  komp==&avoid_cityroad_button  ) {
 		avoid_cityroad_button.pressed = !(avoid_cityroad_button.pressed);
+		// NO_BUILDING is only meaningful when AVOID_CITYROAD is true
+		no_building_button.enable( avoid_cityroad_button.pressed );
+		if(  !avoid_cityroad_button.pressed  ) {
+			no_building_button.pressed = false;
+		}
 	}
 	else if(  komp==&citycar_no_entry_button  ) {
 		citycar_no_entry_button.pressed = !(citycar_no_entry_button.pressed);
+	}
+	else if(  komp==&no_building_button  ) {
+		no_building_button.pressed = !(no_building_button.pressed);
 	}
 	else if(  komp==&height_offset  ) {
 		if(  tool_class==0  ) {
@@ -144,6 +159,7 @@ bool overtaking_mode_frame_t::action_triggered( gui_action_creator_t *komp, valu
 	uint8 flag = 0;
 	if(  avoid_cityroad_button.pressed  ) { flag |= strasse_t::AVOID_CITYROAD; }
 	if(  citycar_no_entry_button.pressed  ) { flag |= strasse_t::CITYCAR_NO_ENTRY; }
+	if(  no_building_button.pressed  ) { flag |= strasse_t::NO_BUILDING; }
 	switch(  tool_class  ) {
 		case 0:
 		tool_w->set_overtaking_mode(overtaking_mode);

--- a/gui/overtaking_mode.h
+++ b/gui/overtaking_mode.h
@@ -32,6 +32,7 @@ private:
 	gui_divider_t divider[2];
 	button_t avoid_cityroad_button;
 	button_t citycar_no_entry_button;
+	button_t no_building_button;
 	gui_numberinput_t height_offset;
 	gui_label_t height_offset_label;
 	void init(player_t *player, overtaking_mode_t overtaking_mode, uint8 street_flag, bool show_avoid_cityroad);

--- a/simcity.cc
+++ b/simcity.cc
@@ -195,10 +195,20 @@ bool stadt_t::bewerte_loc(const koord pos, const rule_t &regel, int rotation)
 			case 's':
 				// road?
 				if (!gr->hat_weg(road_wt)) return false;
+				// roads with NO_BUILDING flag should not be treated as roads for building placement
+				if (const strasse_t* str = (const strasse_t*)gr->get_weg(road_wt)) {
+					if (str->get_no_building()) return false;
+				}
 				break;
 			case 'S':
 				// not road?
-				if (gr->hat_weg(road_wt)) return false;
+				// roads with NO_BUILDING flag are treated as "not road"
+				if (gr->hat_weg(road_wt)) {
+					if (const strasse_t* str = (const strasse_t*)gr->get_weg(road_wt)) {
+						if (str->get_no_building()) break; // NO_BUILDING road is treated as "not road", so continue
+					}
+					return false;
+				}
 				break;
 			case 'h':
 				// is house
@@ -2298,7 +2308,11 @@ class building_place_with_road_finder: public building_placefinder_t
 						}
 						// but near a road if possible
 						if (!next_to_road) {
-							next_to_road = gr->hat_weg(road_wt);
+							// roads with NO_BUILDING flag should not be treated as roads for building placement
+							const strasse_t* str = (const strasse_t*)gr->get_weg(road_wt);
+							if (  str  &&  !str->get_no_building()  ) {
+								next_to_road = true;
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Discord thread: https://discord.com/channels/973792214696202271/1429430459019825346/1429430459019825346

道路に建物を接道させないオプションを追加。

都市間高速道路などを引いていると、市道化防止をしていても沿道に気がついたら建物が生えているので、これを生えなくするオプションを追加した。

- セーブデータ互換性: major version up不要（既存変数の空きbitを使うため）
- NS互換性: 下位バージョンと互換性なし