### PR TITLE
BUG FIX: wayobj speed setting/reference

### DIFF
--- a/bauer/wegbauer.cc
+++ b/bauer/wegbauer.cc
@@ -2537,7 +2537,7 @@ bool way_builder_t::build_tunnel_tile()
 					// respect max speed of catenary
 					waytype_t waytype = tunnel_desc->get_waytype();
 					wayobj_t const* const wo = gr->get_wayobj(waytype);
-					if(wo && waytype == track_wt){
+					if(wo && (waytype != water_wt && waytype != air_wt)){
 						weg->set_max_wayobj_speed(wo->get_desc()->get_topspeed());
 					}
 					else if (wo  &&  wo->get_desc()->get_topspeed() < weg->get_max_speed()) {
@@ -2760,7 +2760,7 @@ void way_builder_t::build_track()
 					// respect max speed of catenary
 					waytype_t waytype = desc->get_wtyp();
 					wayobj_t const* const wo = gr->get_wayobj(waytype);
-					if(wo && waytype == track_wt){
+					if(wo && (waytype != water_wt && waytype != air_wt)){
 						weg->set_max_wayobj_speed(wo->get_desc()->get_topspeed());
 					}
 					else if (wo  &&  wo->get_desc()->get_topspeed() < weg->get_max_speed()) {

--- a/boden/wege/weg.cc
+++ b/boden/wege/weg.cc
@@ -290,7 +290,7 @@ void weg_t::info(cbuffer_t & buf) const
 	obj_t::info(buf);
 
 	buf.printf("%s %u%s", translator::translate("Max. speed:"), max_speed, translator::translate("km/h\n"));
-	if( get_waytype() == track_wt && max_wayobj_speed ){
+	if( (get_waytype() != water_wt && get_waytype() != air_wt) && max_wayobj_speed ){
 		buf.printf("%s %u%s", translator::translate("Max. wayobj speed:"), max_wayobj_speed, translator::translate("km/h\n"));
 	}
 	buf.printf("%s%u",    translator::translate("\nRibi (unmasked)"), get_ribi_unmasked());

--- a/obj/wayobj.cc
+++ b/obj/wayobj.cc
@@ -92,7 +92,7 @@ wayobj_t::~wayobj_t()
 					}
 				}
 				// Updating way's max speed is needed unless the way is a railway track.
-				if(  wt!=track_wt  ) {
+				if(  wt == water_wt || wt == air_wt  ) {
 					weg->set_max_speed(max_speed);
 				}
 				weg->set_max_wayobj_speed(0);
@@ -218,7 +218,7 @@ void wayobj_t::finish_rd()
 		if(weg) {
 			// Weg wieder freigeben, wenn das Signal nicht mehr da ist.
 			weg->set_electrify(true);
-			if(wt == track_wt){
+			if((wt != water_wt && wt != air_wt)){
 				weg->set_max_wayobj_speed(desc->get_topspeed());
 			}
 			else if(weg->get_max_speed()>desc->get_topspeed()) {


### PR DESCRIPTION
モノレールほかにおいて、wayとwayobjの最高速度を切り替えた際、wayobjの最高速度が適切に更新されない問題を修正しました