### PR TITLE
No overtake flag in schedule_entry

### DIFF
--- a/dataobj/schedule.cc
+++ b/dataobj/schedule.cc
@@ -654,6 +654,10 @@ void construct_schedule_entry_attributes(cbuffer_t& buf, schedule_entry_t const&
 		str[cnt] = 'T';
 		cnt++;
 	}
+	if(  entry.is_no_overtake()  ) {
+		str[cnt] = 'N';
+		cnt++;
+	}
 	// there are at least one attributes.
 	if(  cnt>1  ) {
 		str[cnt] = ']';

--- a/dataobj/schedule_entry.h
+++ b/dataobj/schedule_entry.h
@@ -50,7 +50,7 @@ public:
 		REVERSE_CONVOY	  = 1U << 8, // convoy reverses the order of its vehicles.
 		REVERSE_COUPLING  = 1U << 9, // The convoy reverses the parent-child relationship of the convoy coupling.
 		WAIT_COUPLING_DONE= 1U << 10,// Do not reserve departure slot until coupling done.
-		NO_OVERTAKE       = 1U << 14,// Do not overtake(for road)
+		NO_OVERTAKE       = 1U << 11// Do not overtake(for road)
 	};
 
 	/**
@@ -143,8 +143,8 @@ public:
 	uint16 get_stop_flags() const { return stop_flags; }
 	void set_stop_flags(uint16 f) { stop_flags = f; }
 	void set_wait_coupling_done(bool y) {y? stop_flags|= WAIT_COUPLING_DONE : stop_flags &= ~WAIT_COUPLING_DONE; }
-	bool is_wait_coupling_done() const {return (stop_flags&WAIT_COUPLING_DONE) ; }
-	bool is_no_overtake() const {return (stop_flags&NO_OVERTAKE) ;}
+	bool is_wait_coupling_done() const {return (stop_flags&WAIT_COUPLING_DONE)>0 ; }
+	bool is_no_overtake() const {return (stop_flags&NO_OVERTAKE)>0 ;}
 	void set_no_overtake(bool y) { y? stop_flags|=NO_OVERTAKE : stop_flags &= ~NO_OVERTAKE;}
 
 	void set_spacing(uint16 a, uint16 b, uint16 c) {

--- a/dataobj/schedule_entry.h
+++ b/dataobj/schedule_entry.h
@@ -50,6 +50,7 @@ public:
 		REVERSE_CONVOY	  = 1U << 8, // convoy reverses the order of its vehicles.
 		REVERSE_COUPLING  = 1U << 9, // The convoy reverses the parent-child relationship of the convoy coupling.
 		WAIT_COUPLING_DONE= 1U << 10,// Do not reserve departure slot until coupling done.
+		NO_OVERTAKE       = 1U << 14,// Do not overtake(for road)
 	};
 
 	/**
@@ -143,6 +144,8 @@ public:
 	void set_stop_flags(uint16 f) { stop_flags = f; }
 	void set_wait_coupling_done(bool y) {y? stop_flags|= WAIT_COUPLING_DONE : stop_flags &= ~WAIT_COUPLING_DONE; }
 	bool is_wait_coupling_done() const {return (stop_flags&WAIT_COUPLING_DONE) ; }
+	bool is_no_overtake() const {return (stop_flags&NO_OVERTAKE) ;}
+	void set_no_overtake(bool y) { y? stop_flags|=NO_OVERTAKE : stop_flags &= ~NO_OVERTAKE;}
 
 	void set_spacing(uint16 a, uint16 b, uint16 c) {
 		spacing = a;

--- a/documentation/ja.OTRP.tab
+++ b/documentation/ja.OTRP.tab
@@ -203,6 +203,10 @@ Overwrite max speed of convoy
 編成最高速度を上書きする
 Overwrite max speed of convoy here.
 この地点に到達した編成の最高速度を設定した値で上書きします．
+No overtake
+追い越し禁止
+Do not overtake other cars until this stop.
+この駅に向かう間はほかの車を追い越しません．
 #------円表記------
 $
  円

--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -550,7 +550,7 @@ void schedule_gui_t::init(schedule_t* schedule_, player_t* player, convoihandle_
 	add_component(&bt_same_dep_time);
 
 	bt_no_overtake.init(button_t::square_automatic, "No overtake");
-	bt_no_overtake.set_tooltip("Do not overtake other cars");
+	bt_no_overtake.set_tooltip("Do not overtake other cars until next stop");
 	bt_no_overtake.add_listener(this);
 	add_component(&bt_no_overtake);
 
@@ -1112,6 +1112,12 @@ dbg->message("schedule_gui_t::action_triggered()","comp=%p combo=%p",comp,&line_
 		stats->update_schedule();
 		update_selection();
 	}
+	else if(comp == &bt_no_overtake) {
+		if (!schedule->empty()) {
+			schedule->at(schedule->get_current_stop()).set_no_overtake(bt_no_overtake.pressed);
+			update_selection();
+		}
+	}
 	else if(  comp == &name_filter_input  ) {
 		if(  strcmp(old_schedule_filter,schedule_filter)  ) {
 			init_line_selector();
@@ -1126,12 +1132,6 @@ dbg->message("schedule_gui_t::action_triggered()","comp=%p combo=%p",comp,&line_
 		}
 		else {
 			schedule->set_new_departure_slot_group_id();
-		}
-	}
-	else if(comp == &bt_no_overtake) {
-		if (!schedule->empty()) {
-			schedule->at(schedule->get_current_stop()).set_no_overtake(!bt_no_overtake.pressed);
-			update_selection();
 		}
 	}
 	// recheck lines
@@ -1393,5 +1393,5 @@ void schedule_gui_t::extract_advanced_settings(bool yesno) {
 	bt_reverse_convoy.set_visible(reversible_waytype  &&  yesno);
 	bt_reverse_coupling.set_visible(reversible_waytype  &&  yesno);
 	bt_wait_coupling_done.set_visible(coupling_waytype && yesno);
-	bt_no_overtake.set_visible(schedule->get_waytype()==road_wt); // only for road vehicle
+	bt_no_overtake.set_visible(schedule->get_waytype()==road_wt && yesno); // only for road vehicle
 }

--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -549,6 +549,11 @@ void schedule_gui_t::init(schedule_t* schedule_, player_t* player, convoihandle_
 	bt_same_dep_time.pressed = schedule->is_same_dep_time();
 	add_component(&bt_same_dep_time);
 
+	bt_no_overtake.init(button_t::square_automatic, "No overtake");
+	bt_no_overtake.set_tooltip("Do not overtake other cars");
+	bt_no_overtake.add_listener(this);
+	add_component(&bt_no_overtake);
+
 	if(  !cnv.is_bound()  ) {
 		lb_departure_slot_group.set_tooltip(translator::translate("Shares the departure time slot with the selected line here."));
 		add_component(&lb_departure_slot_group);
@@ -683,6 +688,7 @@ void schedule_gui_t::update_selection()
 	bt_transfer_interval.disable();
 	bt_reverse_convoy.disable();
 	bt_reverse_coupling.disable();
+	bt_no_overtake.disable();
 
 	if(  !schedule->empty()  ) {
 		schedule->set_current_stop( min(schedule->get_count()-1,schedule->get_current_stop()) );
@@ -691,6 +697,8 @@ void schedule_gui_t::update_selection()
 		bt_reverse_convoy.pressed = schedule->at(current_stop).is_reverse_convoy();
 		bt_reverse_coupling.enable();
 		bt_reverse_coupling.pressed = schedule->at(current_stop).is_reverse_convoi_coupling();
+		bt_no_overtake.enable();
+		bt_no_overtake.pressed = schedule->at(current_stop).is_no_overtake();
     
 		// if the next_line is set, the last entry is same as the next_line->get_schedule()->at(0)
 		// so, the flags of last entry can not be editted.
@@ -1120,6 +1128,12 @@ dbg->message("schedule_gui_t::action_triggered()","comp=%p combo=%p",comp,&line_
 			schedule->set_new_departure_slot_group_id();
 		}
 	}
+	else if(comp == &bt_no_overtake) {
+		if (!schedule->empty()) {
+			schedule->at(schedule->get_current_stop()).set_no_overtake(!bt_no_overtake.pressed);
+			update_selection();
+		}
+	}
 	// recheck lines
 	if(  cnv.is_bound()  ) {
 		// unequal to line => remove from line ...
@@ -1379,4 +1393,5 @@ void schedule_gui_t::extract_advanced_settings(bool yesno) {
 	bt_reverse_convoy.set_visible(reversible_waytype  &&  yesno);
 	bt_reverse_coupling.set_visible(reversible_waytype  &&  yesno);
 	bt_wait_coupling_done.set_visible(coupling_waytype && yesno);
+	bt_no_overtake.set_visible(schedule->get_waytype()==road_wt); // only for road vehicle
 }

--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -550,7 +550,7 @@ void schedule_gui_t::init(schedule_t* schedule_, player_t* player, convoihandle_
 	add_component(&bt_same_dep_time);
 
 	bt_no_overtake.init(button_t::square_automatic, "No overtake");
-	bt_no_overtake.set_tooltip("Do not overtake other cars until next stop");
+	bt_no_overtake.set_tooltip("Do not overtake other cars until this stop.");
 	bt_no_overtake.add_listener(this);
 	add_component(&bt_no_overtake);
 

--- a/gui/schedule_gui.h
+++ b/gui/schedule_gui.h
@@ -65,7 +65,7 @@ class schedule_gui_t : public gui_frame_t, public action_listener_t
 	button_t bt_find_parent, bt_wait_for_child; // convoy coupling
 	button_t bt_no_load, bt_no_unload, bt_tmp_schedule, bt_wait_for_time, 
 		bt_same_dep_time, bt_full_load_acceleration, bt_full_load_time,bt_unload_all,bt_transfer_interval,
-		bt_load_before_departure, bt_reverse_convoy, bt_reverse_coupling, bt_wait_coupling_done;
+		bt_load_before_departure, bt_reverse_convoy, bt_reverse_coupling, bt_wait_coupling_done, bt_no_overtake;
 	gui_numberinput_t numimp_spacing, numimp_spacing_shift, 
 		numimp_delay_tolerance, numimp_max_speed, numimp_tbgr_waiting_time;
 	gui_label_t lb_spacing, lb_spacing_shift, lb_title1, lb_title2, lb_max_speed, lb_tbgr_waiting_time, lb_next_line;

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -2441,7 +2441,7 @@ bool road_vehicle_t::can_enter_tile(const grund_t *gr, sint32 &restart_speed, ui
 		// At an intersection, decide whether the convoi should go on passing lane.
 		// side road -> main road from passing lane side: vehicle should enter passing lane on main road.
 		next_lane = 0;
-		if(  (str->get_ribi_unmasked() == ribi_t::all  ||  ribi_t::is_threeway(str->get_ribi_unmasked()))  &&  str->get_overtaking_mode() <= oneway_mode  ) {
+		if(  !cnv->get_schedule()->get_current_entry().is_no_overtake()  &&  (str->get_ribi_unmasked() == ribi_t::all  ||  ribi_t::is_threeway(str->get_ribi_unmasked()))  &&  str->get_overtaking_mode() <= oneway_mode  ) {
 			const strasse_t* str_prev = route_index == 0 ? NULL : (strasse_t *)welt->lookup(r.at(route_index - 1u))->get_weg(road_wt);
 			const grund_t* gr_next = route_index < r.get_count() - 1u ? welt->lookup(r.at(route_index + 1u)) : NULL;
 			const strasse_t* str_next = gr_next ? (strasse_t*)gr_next -> get_weg(road_wt) : NULL;
@@ -2704,10 +2704,10 @@ bool road_vehicle_t::can_enter_tile(const grund_t *gr, sint32 &restart_speed, ui
 			sint8 overtaking_mode = str->get_overtaking_mode();
 			if(  overtaking_mode <= oneway_mode  ) {
 				// road is one-way.
-				bool can_judge_overtaking = (test_index == route_index + 1u);
+				bool can_judge_overtaking = !cnv->get_schedule()->get_current_entry().is_no_overtake()  &&  (test_index == route_index + 1u);
 				// The overtaking judge method itself works only when test_index==route_index+1, that means the front tile is not an intersection.
 				// However, with halt_mode we want to simulate a bus terminal. Overtaking in a intersection is essential. So we make a exception to the test_index==route_index+1 condition, although it is not clear that this exception is safe or not!
-				if(  !can_judge_overtaking  &&  test_index == route_index + 2u  &&  overtaking_mode == halt_mode  ) {
+				if(  !cnv->get_schedule()->get_current_entry().is_no_overtake()  &&  !can_judge_overtaking  &&  test_index == route_index + 2u  &&  overtaking_mode == halt_mode  ) {
 					can_judge_overtaking = true;
 				}
 				if(  can_judge_overtaking  ) {


### PR DESCRIPTION
`road_wt`の`schedule_entry`に対して、`no_overtake`フラグを追加します。
このフラグがオンの場合、自動車は、その駅に向かう間は追い越しをしなくなります。
ただし、分岐手前で道路標識が指定する場合、対向車線通行指定がある場合は追い越し車線を走行します。