### PR TITLE
merge tram and train departure slot

### DIFF
--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -1241,6 +1241,20 @@ void schedule_gui_t::init_departure_slot_group_selector()
 		}
 		vector_tpl<linehandle_t> lines;
 		player->simlinemgmt.get_lines(schedule->get_type(), &lines);
+		if(schedule->get_type()==schedule_t::train_schedule) {
+			vector_tpl<linehandle_t> tram_lines;
+			player->simlinemgmt.get_lines(schedule_t::tram_schedule, &tram_lines);
+			FOR(  vector_tpl<linehandle_t>, tram_line, tram_lines  ) {
+				lines.append(tram_line);
+			}
+		}
+		if(schedule->get_type()==schedule_t::tram_schedule) {
+			vector_tpl<linehandle_t> track_lines;
+			player->simlinemgmt.get_lines(schedule_t::train_schedule, &track_lines);
+			FOR(  vector_tpl<linehandle_t>, track_line, track_lines  ) {
+				lines.append(track_line);
+			}
+		}
 		FOR(  vector_tpl<linehandle_t>, const line,  lines  ) {
 			if(  schedule->matches(world(), line->get_schedule())  ) {
 				this_schedule_index = departure_slot_group_selector.count_elements();


### PR DESCRIPTION
路面電車`tram_schedule`と鉄道`train_schedule`の発車枠を共有できるようにしました