### PR TITLE
check parent convoy in convoi_t::hat_gehalten()

### DIFF
--- a/dataobj/schedule_entry.h
+++ b/dataobj/schedule_entry.h
@@ -123,6 +123,8 @@ public:
 	void set_wait_for_coupling() { stop_flags |= WAIT_FOR_COUPLING; stop_flags &= ~TRY_COUPLING; }
 	void set_try_coupling() { stop_flags |= TRY_COUPLING; stop_flags &= ~WAIT_FOR_COUPLING; }
 	void reset_coupling() { stop_flags &= ~TRY_COUPLING; stop_flags &= ~WAIT_FOR_COUPLING; }
+	bool is_wait_for_coupling() const { return stop_flags&WAIT_FOR_COUPLING; }
+	bool is_try_coupling() const { return stop_flags&TRY_COUPLING; }
 	bool is_no_load() const { return (stop_flags&NO_LOAD)>0; }
 	void set_no_load(bool y) { y ? stop_flags |= NO_LOAD : stop_flags &= ~NO_LOAD; }
 	bool is_no_unload() const { return (stop_flags&NO_UNLOAD)>0; }

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -3734,13 +3734,19 @@ void calc_reachable_halts(vector_tpl<haltestelle_t::reachable_halt_t>& reachable
 void convoi_t::hat_gehalten(halthandle_t halt, uint32 halt_length_in_vehicle_steps)
 {
 	convoihandle_t c = self;
+
+
 	if(  get_coupling_convoi().is_bound() && !is_coupled()  ) {
 		convoihandle_t const temp_parent_convoi = self;
 		bool coupled_at_this_stop = false;
 		while(  c->get_coupling_convoi().is_bound()  ) {
+			// if this convoy is trying coupling, we must check the direction and reverse if needed.
+			// THIS CHECK IS ONLY ONECE IN ONE COUPLING!
 			c = c->get_coupling_convoi();
 			coupled_at_this_stop |= ( c->get_schedule()->get_current_entry().is_try_coupling() && c->is_coupling_done() );
-			if(c->get_schedule()->get_current_entry().is_try_coupling()) {c->set_coupling_done(false);}
+			if(c->get_schedule()->get_current_entry().is_try_coupling()) {
+				c->set_coupling_done(false);
+			}
 		}
 		if(  coupled_at_this_stop && c->get_schedule()->get_count()>1  ) {
 			dbg->message("convoi_t::hat_gehalten()","%s coupling at this stop. check the direction at %s",get_name(),temp_parent_convoi->front()->get_pos().get_str());

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -3743,16 +3743,14 @@ void convoi_t::hat_gehalten(halthandle_t halt, uint32 halt_length_in_vehicle_ste
 			if(c->get_schedule()->get_current_entry().is_try_coupling()) {c->set_coupling_done(false);}
 		}
 		if(  coupled_at_this_stop && c->get_schedule()->get_count()>1  ) {
-			dbg->message("convoi_t::hat_gehalten()","coupling at this stop. check the direction");
+			dbg->message("convoi_t::hat_gehalten()","%s coupling at this stop. check the direction at %s",get_name(),temp_parent_convoi->front()->get_pos().get_str());
 			// chage the order if next direction is backward of "self"
 			// Attention! reverse_convoy_coupling() must be called when loading!
 			// if we call it before stop, the convoys will be reversed immediately, and it makes position calculation bug. 
 			// the direction of the waiting vehicle is same? opposite?
 			route_t r;
-			route_t r_cnv;
 			route_t::route_result_t res = r.calc_route(welt, c->front()->get_pos(), c->get_schedule()->get_next_entry().pos, front(), speed_to_kmh(min_top_speed), 8888);
-			route_t::route_result_t res_cnv = r_cnv.calc_route(welt, c->front()->get_pos(), temp_parent_convoi->front()->get_pos(), front(), speed_to_kmh(min_top_speed), 8888);
-			bool const should_this_convoy_be_parent = (res==route_t::no_route || r.get_count()<2) ? false : ((res_cnv==route_t::no_route || r_cnv.get_count()<2) ? ((ribi_type(r.at(0), r.at(1)) & front()->get_direction()) == 0 ? true : false) : ((ribi_type(r.at(0), r.at(1)) & ribi_type(r_cnv.at(0),r_cnv.at(1))) == 0 ? true: false));
+			bool const should_this_convoy_be_parent = (res==route_t::no_route || r.get_count()<2) ? false : ((ribi_type(r.at(0), r.at(1)) & c->front()->get_direction()) == 0 ? true : false);
 			if(  should_this_convoy_be_parent  ) {
 				temp_parent_convoi->reverse_convoy_coupling();
 			}

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -3741,7 +3741,7 @@ void convoi_t::hat_gehalten(halthandle_t halt, uint32 halt_length_in_vehicle_ste
 		bool coupled_at_this_stop = false;
 		while(  c->get_coupling_convoi().is_bound()  ) {
 			// if this convoy is trying coupling, we must check the direction and reverse if needed.
-			// THIS CHECK IS ONLY ONECE IN ONE COUPLING!
+			// THIS CHECK IS ONLY ONECE IN ONE COUPLING! We use a coupling_done flag in try_coupling convoy to know.
 			c = c->get_coupling_convoi();
 			coupled_at_this_stop |= ( c->get_schedule()->get_current_entry().is_try_coupling() && c->is_coupling_done() );
 			if(c->get_schedule()->get_current_entry().is_try_coupling()) {

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -1926,17 +1926,7 @@ void convoi_t::ziel_erreicht()
 				set_next_coupling(route_t::INVALID_INDEX, 0);
 				v->get_convoi()->set_coupling_done(true);
 				coupling_done = true;
-				// then, chage the order if next direction is backward of "self"
-				// Attention! reverse_convoy_coupling() must be called when loading!
-				// if we call it before stop, the convoys will be reversed immediately, and it makes position calculation bug. 
-				// the direction of the waiting vehicle is same? opposite?
-				route_t r;
 				check_electrification();
-				route_t::route_result_t res = r.calc_route(welt, front()->get_pos(), schedule->get_next_entry().pos, front(), speed_to_kmh(min_top_speed), 8888);
-				bool const should_this_convoy_be_parent = (res==route_t::no_route || r.get_count()<2) ? false : (ribi_type(r.at(0), r.at(1)) & front()->get_direction()) == 0 ? true : false;
-				if(  should_this_convoy_be_parent  ) {
-					temp_parent_convoi->reverse_convoy_coupling();
-				}
 				return;
 			}
 		}
@@ -3743,6 +3733,31 @@ void calc_reachable_halts(vector_tpl<haltestelle_t::reachable_halt_t>& reachable
  */
 void convoi_t::hat_gehalten(halthandle_t halt, uint32 halt_length_in_vehicle_steps)
 {
+	convoihandle_t c = self;
+	if(  get_coupling_convoi().is_bound() && !is_coupled()  ) {
+		convoihandle_t const temp_parent_convoi = self;
+		bool coupled_at_this_stop = false;
+		while(  c->get_coupling_convoi().is_bound()  ) {
+			c = c->get_coupling_convoi();
+			coupled_at_this_stop |= ( c->get_schedule()->get_current_entry().is_try_coupling() && c->is_coupling_done() );
+			if(c->get_schedule()->get_current_entry().is_try_coupling()) {c->set_coupling_done(false);}
+		}
+		if(  coupled_at_this_stop && c->get_schedule()->get_count()>1  ) {
+			dbg->message("convoi_t::hat_gehalten()","coupling at this stop. check the direction");
+			// chage the order if next direction is backward of "self"
+			// Attention! reverse_convoy_coupling() must be called when loading!
+			// if we call it before stop, the convoys will be reversed immediately, and it makes position calculation bug. 
+			// the direction of the waiting vehicle is same? opposite?
+			route_t r;
+			route_t r_cnv;
+			route_t::route_result_t res = r.calc_route(welt, c->front()->get_pos(), c->get_schedule()->get_next_entry().pos, front(), speed_to_kmh(min_top_speed), 8888);
+			route_t::route_result_t res_cnv = r_cnv.calc_route(welt, c->front()->get_pos(), temp_parent_convoi->front()->get_pos(), front(), speed_to_kmh(min_top_speed), 8888);
+			bool const should_this_convoy_be_parent = (res==route_t::no_route || r.get_count()<2) ? false : ((res_cnv==route_t::no_route || r_cnv.get_count()<2) ? ((ribi_type(r.at(0), r.at(1)) & front()->get_direction()) == 0 ? true : false) : ((ribi_type(r.at(0), r.at(1)) & ribi_type(r_cnv.at(0),r_cnv.at(1))) == 0 ? true: false));
+			if(  should_this_convoy_be_parent  ) {
+				temp_parent_convoi->reverse_convoy_coupling();
+			}
+		}
+	}
 	// Count how many vehicles can load and unload.
 	uint8 vehicles_loading = 0;
 	uint32 convoy_length_step = 0;
@@ -3883,7 +3898,7 @@ void convoi_t::hat_gehalten(halthandle_t halt, uint32 halt_length_in_vehicle_ste
 		return;
 	}
 
-	convoihandle_t c = self;
+	c = self;
 	if(  !is_coupled()  &&  recalc_min_top_speed  ) {
 		check_electrification();
 		calc_min_top_speed();


### PR DESCRIPTION
`ziel_erreicht()`内で計算していた、連結時の親編成の判断について、`hat_gehalten()`内で計算するよう変更しました