### PR TITLE
GitHub Actionsのビルド成果物名にタグ名/ブランチ名を含める

### DIFF
--- a/.github/workflows/otrp-macos.yml
+++ b/.github/workflows/otrp-macos.yml
@@ -30,9 +30,20 @@ jobs:
 
     - name: CI-Build
       run: sh ./.github/build-mac.sh
-      
+
+    - name: Set suffix for file naming
+      run: |
+        if [[ $GITHUB_REF == refs/tags/* ]]; then
+          echo "SUFFIX=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+        else
+          echo "SUFFIX=_${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+        fi
+
+    - name: Rename executable
+      run: mv sim-mac-OTRP sim-mac-OTRP${{ env.SUFFIX }}
+
     - name: Upload the executable
       uses: actions/upload-artifact@v4
       with:
-        name: sim-mac-OTRP
-        path: ./sim-mac-OTRP
+        name: sim-mac-OTRP${{ env.SUFFIX }}
+        path: ./sim-mac-OTRP${{ env.SUFFIX }}

--- a/.github/workflows/otrp-ubuntu.yml
+++ b/.github/workflows/otrp-ubuntu.yml
@@ -46,9 +46,25 @@ jobs:
     - name: make
       run: |
         make -j
-      
+
+    - name: Set suffix for file naming
+      run: |
+        if [[ $GITHUB_REF == refs/tags/* ]]; then
+          echo "SUFFIX=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+        else
+          echo "SUFFIX=" >> $GITHUB_ENV
+        fi
+
+    - name: Rename executable
+      run: |
+        if [ -n "${{ env.SUFFIX }}" ]; then
+          mv sim sim-linux-OTRP${{ env.SUFFIX }}
+        else
+          mv sim sim-linux-OTRP
+        fi
+
     - name: Upload the executable
       uses: actions/upload-artifact@v4
       with:
-        name: sim-linux-OTRP
-        path: ./sim
+        name: sim-linux-OTRP${{ env.SUFFIX }}
+        path: ./sim-linux-OTRP${{ env.SUFFIX }}

--- a/.github/workflows/otrp-windows-64.yml
+++ b/.github/workflows/otrp-windows-64.yml
@@ -24,8 +24,24 @@ jobs:
         run: sh ./.github/build64.sh
         shell: msys2 {0}
 
+      - name: Set suffix for file naming
+        run: |
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            echo "SUFFIX=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+          else
+            echo "SUFFIX=" >> $GITHUB_ENV
+          fi
+        shell: msys2 {0}
+
+      - name: Rename executable
+        run: |
+          if [ -n "${{ env.SUFFIX }}" ]; then
+            mv sim-WinGDI-OTRP.exe sim-WinGDI-OTRP${{ env.SUFFIX }}.exe
+          fi
+        shell: msys2 {0}
+
       - name: Upload sim.exe
         uses: actions/upload-artifact@v4
         with:
-          name: sim-WinGDI-OTRP.exe
-          path: ./sim-WinGDI-OTRP.exe
+          name: sim-WinGDI-OTRP${{ env.SUFFIX }}.exe
+          path: ./sim-WinGDI-OTRP${{ env.SUFFIX }}.exe


### PR DESCRIPTION
https://discord.com/channels/973792214696202271/1442809672041103370/1442809672041103370

GitHub Actionsでビルドする際の成果物名に、タグ名またはブランチ名を含めるように変更しました。

**変更内容:**
- タグ付きコミット（例: v48）でビルド時: `sim-mac-OTRPv48`, `sim-linux-OTRPv48`, `sim-WinGDI-OTRPv48.exe` のようにタグ名を含める
- 手動実行（workflow_dispatch）時: `sim-mac-OTRP_<ブランチ名>` のようにブランチ名を含める（macOSのみ）
- Pull Request時: 従来通り `sim-linux-OTRP` のまま（Ubuntuのみ）

**対象ファイル:**
- `.github/workflows/otrp-macos.yml`
- `.github/workflows/otrp-ubuntu.yml`
- `.github/workflows/otrp-windows-64.yml`

**互換性:**
セーブデータ互換性: 影響なし
ネットワーク同期互換性: 影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>