### PR TITLE
BUG FIX: work check_longblock_signal with pre-signal or priority_signal

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -177,7 +177,7 @@ void convoi_t::init(player_t *player)
 	request_cross_ticks = 0;
 	prev_tiles_overtaking = 0;
 
-	longblock_signal_request.valid = false;
+	longblock_signal_request = false;
 	crossing_reservation_index.clear();
 	recalc_min_top_speed = true;
 	recalc_friction_weight = true;
@@ -1538,7 +1538,7 @@ void convoi_t::step()
 		case DRIVING:
 			if(fahr[0]->get_waytype()==track_wt  ||  fahr[0]->get_waytype()==monorail_wt  ||  fahr[0]->get_waytype()==maglev_wt  ||  fahr[0]->get_waytype()==narrowgauge_wt) {
 				rail_vehicle_t* v = dynamic_cast<rail_vehicle_t*>(fahr[0]);
-				if(  v  &&  longblock_signal_request.valid  ) {
+				if(  v  &&  longblock_signal_request  ) {
 					// process longblock signal judgement request
 					sint32 dummy = -1;
 					v->is_signal_clear(get_next_stop_index()-1, dummy, true);
@@ -5265,11 +5265,11 @@ void convoi_t::set_next_cross_lane(bool n) {
 	}
 }
 
-void convoi_t::request_longblock_signal_judge(signal_t *sig, uint16 next_block) {
-	longblock_signal_request.sig = sig;
-	longblock_signal_request.next_block = next_block;
-	longblock_signal_request.valid = true;
-}
+// void convoi_t::request_longblock_signal_judge(signal_t *sig, uint16 next_block) {
+// 	longblock_signal_request.sig = sig;
+// 	longblock_signal_request.next_block = next_block;
+// 	longblock_signal_request.valid = true;
+// }
 
 void convoi_t::clear_reserved_tiles(){
 	if(  reserved_tiles.get_count()==0  ) {

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -1541,7 +1541,7 @@ void convoi_t::step()
 				if(  v  &&  longblock_signal_request.valid  ) {
 					// process longblock signal judgement request
 					sint32 dummy = -1;
-					v->check_longblock_signal(longblock_signal_request.sig, longblock_signal_request.next_block, dummy);
+					v->is_signal_clear(get_next_stop_index()-1, dummy, true);
 					set_longblock_signal_judge_request_invalid();
 				}
 			}

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -5265,11 +5265,6 @@ void convoi_t::set_next_cross_lane(bool n) {
 	}
 }
 
-// void convoi_t::request_longblock_signal_judge(signal_t *sig, uint16 next_block) {
-// 	longblock_signal_request.sig = sig;
-// 	longblock_signal_request.next_block = next_block;
-// 	longblock_signal_request.valid = true;
-// }
 
 void convoi_t::clear_reserved_tiles(){
 	if(  reserved_tiles.get_count()==0  ) {

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -1541,7 +1541,7 @@ void convoi_t::step()
 				if(  v  &&  longblock_signal_request  ) {
 					// process longblock signal judgement request
 					sint32 dummy = -1;
-					v->is_signal_clear(get_next_stop_index()-1, dummy, true);
+					v->is_signal_clear(get_next_reservation_index()-1, dummy, true);
 					set_longblock_signal_judge_request_invalid();
 				}
 			}

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -351,12 +351,13 @@ private:
 
 	bool in_delay_recovery;
 
-	typedef struct {
-		bool valid;
-		signal_t* sig;
-		uint16 next_block;
-	} longblock_signal_request_t;
-	longblock_signal_request_t longblock_signal_request;
+	// typedef struct {
+	// 	bool valid;
+	// 	signal_t* sig;
+	// 	uint16 next_block;
+	// } longblock_signal_request_t;
+	// longblock_signal_request_t longblock_signal_request;
+	bool longblock_signal_request;
 
 	/**
 	 * struct holds new financial history for convoi
@@ -1047,8 +1048,8 @@ public:
 
 	virtual void refresh(sint8,sint8) OVERRIDE;
 
-	void request_longblock_signal_judge(signal_t *sig, uint16 next_block);
-	void set_longblock_signal_judge_request_invalid() { longblock_signal_request.valid = false; };
+	void request_longblock_signal_judge() {longblock_signal_request = true;} //signal_t *sig, uint16 next_block);
+	void set_longblock_signal_judge_request_invalid() { longblock_signal_request = false; };
 
 	void calc_crossing_reservation();
 	vector_tpl<std::pair< uint16, uint16> > get_crossing_reservation_index() const { return crossing_reservation_index; }

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -351,12 +351,6 @@ private:
 
 	bool in_delay_recovery;
 
-	// typedef struct {
-	// 	bool valid;
-	// 	signal_t* sig;
-	// 	uint16 next_block;
-	// } longblock_signal_request_t;
-	// longblock_signal_request_t longblock_signal_request;
 	bool longblock_signal_request;
 
 	/**
@@ -1048,7 +1042,7 @@ public:
 
 	virtual void refresh(sint8,sint8) OVERRIDE;
 
-	void request_longblock_signal_judge() {longblock_signal_request = true;} //signal_t *sig, uint16 next_block);
+	void request_longblock_signal_judge() {longblock_signal_request = true;}
 	void set_longblock_signal_judge_request_invalid() { longblock_signal_request = false; };
 
 	void calc_crossing_reservation();

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -3632,14 +3632,14 @@ bool rail_vehicle_t::check_longblock_signal(signal_t *sig, uint16 next_block, si
 			sint32 start_idx;
 			for(  start_idx=0;  start_idx<(sint32)cnv->get_reserved_tiles().get_count()  &&  cnv->get_reserved_tiles()[start_idx]!=cnv->get_route()->at(next_block+1);  start_idx++  );
 			// tiles on which this convoy is must not be unreserved.
-			vector_tpl<koord3d> tiles_convoy_on;
+			vector_tpl<koord3d> tiles_already_reserved;
 			for(  uint16 i=0;  i<cnv->get_vehicle_count();  i++  ) {
-				tiles_convoy_on.append_unique(cnv->get_vehikel(i)->get_pos());
+				tiles_already_reserved.append_unique(cnv->get_vehikel(i)->get_pos());
 			}
 			// already reserved tiles by other signals should not be release 
 			if(  cnv->front()->get_route_index()<start_block+1  ) {
 				for(  uint16 i=cnv->front()->get_route_index();  i<start_block+1; i++  ) {
-					tiles_convoy_on.append_unique(cnv->get_route()->at(i));
+					tiles_already_reserved.append_unique(cnv->get_route()->at(i));
 					dbg->message("rail_vehicle_t::check_longblock_signal_clear()","%i tiles will be kept", i);
 				}
 			}
@@ -3647,7 +3647,7 @@ bool rail_vehicle_t::check_longblock_signal(signal_t *sig, uint16 next_block, si
 			for(  sint32 i=cnv->get_reserved_tiles().get_count()-1;  i>=start_idx;  i--  ) {
 				grund_t* gr = welt->lookup(cnv->get_reserved_tiles()[i]);
 				schiene_t* sch1 = gr ? (schiene_t*)gr->get_weg(get_waytype()) : NULL;
-				if(  sch1  &&  !tiles_convoy_on.is_contained(gr->get_pos())  ) {
+				if(  sch1  &&  !tiles_already_reserved.is_contained(gr->get_pos())  ) {
 					sch1->unreserve(cnv->self);
 				}
 				cnv->get_reserved_tiles().remove_at(i);

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -3901,7 +3901,7 @@ bool rail_vehicle_t::is_priority_signal_clear(signal_t *sig, uint16 next_block, 
 		}
 		cnv->set_next_stop_index( min( next_signal, next_crossing ) );
 
-		return false;
+		return true;
 	}
 
 	// if we end up here, there was not even the next block free

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -3557,6 +3557,7 @@ bool rail_vehicle_t::is_coupling_target(const grund_t *gr, const grund_t *prev_g
 
 bool rail_vehicle_t::check_longblock_signal(signal_t *sig, uint16 next_block, sint32 &restart_speed)
 {
+	uint16 const start_point = next_block;
 	// longblock signal: first check, whether there is a signal coming up on the route => just like normal signal
 	uint16 next_signal, next_crossing;
 	if(  !block_reserver( cnv->get_route(), next_block+1, next_signal, next_crossing, 0, true, false, true )  ) {
@@ -3634,6 +3635,13 @@ bool rail_vehicle_t::check_longblock_signal(signal_t *sig, uint16 next_block, si
 			vector_tpl<koord3d> tiles_convoy_on;
 			for(  uint16 i=0;  i<cnv->get_vehicle_count();  i++  ) {
 				tiles_convoy_on.append_unique(cnv->get_vehikel(i)->get_pos());
+			}
+			// already reserved tiles by other signals should not be release 
+			if(  cnv->front()->get_route_index()<start_point+1  ) {
+				for(  uint16 i=cnv->front()->get_route_index();  i<start_point+1; i++  ) {
+					tiles_convoy_on.append_unique(cnv->get_route()->at(i));
+					dbg->message("rail_vehicle_t::check_longblock_signal_clear()","%i tiles will be kept", i);
+				}
 			}
 			// now we unreserve the tiles
 			for(  sint32 i=cnv->get_reserved_tiles().get_count()-1;  i>=start_idx;  i--  ) {

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -3666,9 +3666,9 @@ bool rail_vehicle_t::check_longblock_signal(signal_t *sig, uint16 next_block, si
 	return true;
 }
 
-bool rail_vehicle_t::is_longblock_signal_clear(signal_t *sig, uint16 next_block, sint32 &restart_speed)
+bool rail_vehicle_t::is_longblock_signal_clear(signal_t *sig, uint16 next_block, sint32 &restart_speed, const bool check_longblock)
 {
-	if(  cnv->is_waiting()  ) {
+	if(  cnv->is_waiting() || check_longblock  ) {
 		// we are in a step. do that.
 		const bool res = check_longblock_signal(sig, next_block, restart_speed);
 		cnv->set_longblock_signal_judge_request_invalid();
@@ -3847,7 +3847,7 @@ skip_choose:
 }
 
 
-bool rail_vehicle_t::is_pre_signal_clear(signal_t *sig, uint16 next_block, sint32 &restart_speed)
+bool rail_vehicle_t::is_pre_signal_clear(signal_t *sig, uint16 next_block, sint32 &restart_speed, bool const check_longblock)
 {
 	// parse to next signal; if needed recurse, since we allow cascading
 	uint16 next_signal, next_crossing;
@@ -3858,7 +3858,7 @@ bool rail_vehicle_t::is_pre_signal_clear(signal_t *sig, uint16 next_block, sint3
 			sig->set_state( roadsign_t::STATE_GREEN );
 			cnv->set_next_stop_index( min( next_signal, next_crossing ) );
 			return true;
-		} else if ( is_signal_clear( next_signal, restart_speed ) ) {
+		} else if ( is_signal_clear( next_signal, restart_speed, check_longblock ) ) {
 			// ok, next signal clear
 			sig->set_state( roadsign_t::STATE_GREEN );
 			return true;
@@ -3877,13 +3877,13 @@ bool rail_vehicle_t::is_pre_signal_clear(signal_t *sig, uint16 next_block, sint3
 
 
 
-bool rail_vehicle_t::is_priority_signal_clear(signal_t *sig, uint16 next_block, sint32 &restart_speed)
+bool rail_vehicle_t::is_priority_signal_clear(signal_t *sig, uint16 next_block, sint32 &restart_speed, bool const check_longblock)
 {
 	// parse to next signal; if needed recurse, since we allow cascading
 	uint16 next_signal, next_crossing;
 
 	if(  block_reserver( cnv->get_route(), next_block+1, next_signal, next_crossing, 0, true, false )  ) {
-		if(  next_signal == route_t::INVALID_INDEX  ||  cnv->get_route()->at(next_signal) == cnv->get_route()->back()  ||  is_signal_clear( next_signal, restart_speed )  ) {
+		if(  next_signal == route_t::INVALID_INDEX  ||  cnv->get_route()->at(next_signal) == cnv->get_route()->back()  ||  is_signal_clear( next_signal, restart_speed, check_longblock )  ) {
 			// ok, end of route => we can go
 			sig->set_state( roadsign_t::STATE_GREEN );
 			cnv->set_next_stop_index( min( next_signal, next_crossing ) );
@@ -3912,7 +3912,7 @@ bool rail_vehicle_t::is_priority_signal_clear(signal_t *sig, uint16 next_block, 
 }
 
 
-bool rail_vehicle_t::is_signal_clear(uint16 next_block, sint32 &restart_speed)
+bool rail_vehicle_t::is_signal_clear(uint16 next_block, sint32 &restart_speed, bool const check_longblock=false)
 {
 	// called, when there is a signal; will call other signal routines if needed
 	grund_t *gr_next_block = welt->lookup(cnv->get_route()->at(next_block));
@@ -3946,15 +3946,15 @@ bool rail_vehicle_t::is_signal_clear(uint16 next_block, sint32 &restart_speed)
 	}
 
 	if(  sig_desc->is_pre_signal()  ) {
-		return is_pre_signal_clear( sig, next_block, restart_speed );
+		return is_pre_signal_clear( sig, next_block, restart_speed, check_longblock );
 	}
 
 	if (  sig_desc->is_priority_signal()  ) {
-		return is_priority_signal_clear( sig, next_block, restart_speed );
+		return is_priority_signal_clear( sig, next_block, restart_speed, check_longblock );
 	}
 
 	if(  sig_desc->is_longblock_signal()  ) {
-		return is_longblock_signal_clear( sig, next_block, restart_speed );
+		return is_longblock_signal_clear( sig, next_block, restart_speed, check_longblock );
 	}
 
 	if(  sig_desc->is_choose_sign()  ) {

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -3557,7 +3557,7 @@ bool rail_vehicle_t::is_coupling_target(const grund_t *gr, const grund_t *prev_g
 
 bool rail_vehicle_t::check_longblock_signal(signal_t *sig, uint16 next_block, sint32 &restart_speed)
 {
-	uint16 const start_point = next_block;
+	uint16 const start_block = next_block;
 	// longblock signal: first check, whether there is a signal coming up on the route => just like normal signal
 	uint16 next_signal, next_crossing;
 	if(  !block_reserver( cnv->get_route(), next_block+1, next_signal, next_crossing, 0, true, false, true )  ) {
@@ -3637,8 +3637,8 @@ bool rail_vehicle_t::check_longblock_signal(signal_t *sig, uint16 next_block, si
 				tiles_convoy_on.append_unique(cnv->get_vehikel(i)->get_pos());
 			}
 			// already reserved tiles by other signals should not be release 
-			if(  cnv->front()->get_route_index()<start_point+1  ) {
-				for(  uint16 i=cnv->front()->get_route_index();  i<start_point+1; i++  ) {
+			if(  cnv->front()->get_route_index()<start_block+1  ) {
+				for(  uint16 i=cnv->front()->get_route_index();  i<start_block+1; i++  ) {
 					tiles_convoy_on.append_unique(cnv->get_route()->at(i));
 					dbg->message("rail_vehicle_t::check_longblock_signal_clear()","%i tiles will be kept", i);
 				}

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -3676,7 +3676,7 @@ bool rail_vehicle_t::is_longblock_signal_clear(signal_t *sig, uint16 next_block,
 	}
 	else {
 		// we are in a sync_step. request to do this in a step.
-		cnv->request_longblock_signal_judge(sig, next_block);
+		cnv->request_longblock_signal_judge();
 		restart_speed = 0;
 		return false;
 	}

--- a/vehicle/simvehicle.h
+++ b/vehicle/simvehicle.h
@@ -570,10 +570,9 @@ protected:
 
 	void enter_tile(grund_t*) OVERRIDE;
 
-	bool is_signal_clear(uint16 start_index, sint32 &restart_speed);
-	bool is_pre_signal_clear(signal_t *sig, uint16 start_index, sint32 &restart_speed);
-	bool is_priority_signal_clear(signal_t *sig, uint16 start_index, sint32 &restart_speed);
-	bool is_longblock_signal_clear(signal_t *sig, uint16 start_index, sint32 &restart_speed);
+	bool is_pre_signal_clear(signal_t *sig, uint16 start_index, sint32 &restart_speed, bool const check_longblock);
+	bool is_priority_signal_clear(signal_t *sig, uint16 start_index, sint32 &restart_speed, bool const check_longblock);
+	bool is_longblock_signal_clear(signal_t *sig, uint16 start_index, sint32 &restart_speed, bool const check_longblock);
 	bool is_choose_signal_clear(signal_t *sig, uint16 start_index, sint32 &restart_speed);
 
 public:
@@ -614,6 +613,7 @@ public:
 
 	// step() routine called by convoy
 	bool check_longblock_signal(signal_t *sig, uint16 start_index, sint32 &restart_speed);
+	bool is_signal_clear(uint16 start_index, sint32 &restart_speed, bool const check_longblock);
 };
 
 /**


### PR DESCRIPTION
`step()`で呼び出す`rail_vehicle_t::check_longblock_signal()`について、`is_signal_clear()`を呼び出す形に変更し、pre-signalおよびpriolity-signalとの動作を改善しました