### PR TITLE
[所要時間ベース経路検索] 仮旅行時間の値を5倍にする

### DIFF
--- a/dataobj/schedule.cc
+++ b/dataobj/schedule.cc
@@ -917,5 +917,6 @@ uint32 schedule_t::get_median_journey_time(uint8 index, uint32 max_speed_kmh) co
 	 * (derived from gui_departure_board_t::calc_ticks_until_arrival())
 	 */
 	const uint32 max_speed = max(kmh_to_speed(max_speed_kmh), 1);
-	return sint64(koord_distance(pos, prev_pos) << 20) / max_speed;
+	// In case of estimated time, multiply by 5 to avoid underestimation.
+	return 5 * sint64(koord_distance(pos, prev_pos) << 20) / max_speed;
 }


### PR DESCRIPTION
https://discord.com/channels/973792214696202271/1446843473268310129/1446843473268310129

現状所要時間の実績が存在しない区間については、ユークリッド距離と最高速度を用いて仮の所要時間を算出しているが、これが過剰に短いと所要時間の実績が記録されるまでの間その路線に過剰に需要が集中する。
これを防ぐため、仮旅行時間は5倍とする。