### PR TITLE
add length_coupling_done number in gimme_stop_name()

### DIFF
--- a/dataobj/schedule.cc
+++ b/dataobj/schedule.cc
@@ -705,6 +705,9 @@ void schedule_t::gimme_stop_name(cbuffer_t& buf, karte_t* welt, player_t const* 
 					buf.printf("NOLIMIT ");
 				}
 			}
+			if(  entry.length_coupling_done != 0) {
+				buf.printf("%dtiles ", entry.length_coupling_done);
+			}
 		}
 		p = halt->get_name();
 	}


### PR DESCRIPTION
連結終了タイル数をスケジュールに表示されるようにしました