### PR TITLE
simplify the searching method of most_parent_convoi

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -4256,12 +4256,7 @@ void convoi_t::self_destruct()
 		return;
 	}
 	else if(  is_coupled()  ) {
-		// find parent convoy and try uncoupling.
-		FOR(vector_tpl<convoihandle_t>, const& c, world()->convoys()) {
-			if(  c->get_coupling_convoi()==self  ) {
-				c->uncouple_convoi();
-			}
-		}
+		parent_convoi->uncouple_convoi();
 	}
 	state = SELF_DESTRUCT;
 	wait_lock = 0;

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -5686,29 +5686,6 @@ void convoi_t::reverse_convoy_coupling()
 }
 
 
-convoihandle_t convoi_t::find_most_parent_convoi() const {
-	if(  !is_coupled()  ) {
-		return self;
-	}
-	// it does not know who is the most parent convoi. search it. 
-	convoihandle_t tc = self;
-	while(  tc->is_coupled()  ) {
-		bool found = false;
-		FOR(vector_tpl<convoihandle_t>, const& c, world()->convoys()) {
-			if(  c->get_coupling_convoi()==tc  ) {
-				tc = c;
-				found = true;
-				break;
-			}
-		}
-		if(  !found  ) {
-			dbg->error("convoi_t::find_most_parent_convoi", "could not find the parent for %s", tc->get_name());
-			return self;
-		}
-	}
-	return tc;
-}
-
 convoihandle_t convoi_t::find_parent_convoi() const {
 	if(  !is_coupled()  ) {
 		return self;

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -163,6 +163,7 @@ void convoi_t::init(player_t *player)
 	uncouple_done = false;
 
 	coupling_convoi = convoihandle_t();
+	most_parent_convoi = convoihandle_t();
 
 	line_update_pending = linehandle_t();
 
@@ -5683,10 +5684,9 @@ void convoi_t::reverse_convoy_coupling()
 
 convoihandle_t convoi_t::find_most_parent_convoi() const {
 	if(  !is_coupled()  ) {
-		most_parent_convoi = self;
 		return self;
 	}
-	if(  most_parent_convoi.is_bound()  ) {
+	if(  most_parent_convoi.is_bound() && !most_parent_convoi.is_coupled() && most_parent_convoi != self  ) {
 		// this convoy might already know who is its most parent convoi
 		// check it is real parent or not.
 		convoihandle_t c = most_parent_convoi;
@@ -5711,11 +5711,9 @@ convoihandle_t convoi_t::find_most_parent_convoi() const {
 		}
 		if(  !found  ) {
 			dbg->error("convoi_t::find_most_parent_convoi", "could not find the parent for %s", tc->get_name());
-			most_parent_convoi = self;
 			return self;
 		}
 	}
-	most_parent_convoi = tc;
 	return tc;
 }
 

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -581,6 +581,7 @@ DBG_MESSAGE("convoi_t::finish_rd()","next_stop_index=%d", next_stop_index );
 		register_stops();
 	}
 
+	// only for leading convoy
 	if(  state!=COUPLED && state!=COUPLED_LOADING  ) {
 		check_electrification();
 		calc_min_top_speed();

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -163,7 +163,7 @@ void convoi_t::init(player_t *player)
 	uncouple_done = false;
 
 	coupling_convoi = convoihandle_t();
-	most_parent_convoi = convoihandle_t();
+	parent_convoi = convoihandle_t();
 
 	line_update_pending = linehandle_t();
 
@@ -561,7 +561,7 @@ DBG_MESSAGE("convoi_t::finish_rd()","next_stop_index=%d", next_stop_index );
 	if(  state==COUPLED  ||  state==COUPLED_LOADING  ) {
 		front()->set_leading(false);
 		// set most parent convoy
-		most_parent_convoi = find_most_parent_convoi();
+		parent_convoi = find_parent_convoi();
 	}
 	// If this has a child convoi, the last car is not the last of the entire convoi.
 	if(  coupling_convoi.is_bound()  ) {
@@ -1941,7 +1941,7 @@ void convoi_t::ziel_erreicht()
 					temp_parent_convoi = v->get_convoi()->find_most_child_convoi();
 					v->get_convoi()->reverse_convoy_coupling();
 				} else {
-					temp_parent_convoi = v->get_convoi()->find_most_parent_convoi();
+					temp_parent_convoi = v->get_convoi()->get_most_parent_convoi();
 				}
 				v->get_convoi()->couple_convoi(self);
 				unset_convoi_coupling_in_progress();
@@ -2020,7 +2020,7 @@ bool convoi_t::reverse_convoy_coupling_at_waypoint()
 	}
 	dbg->message("convoi_t::ziel_erreicht()","reversing coupling in waypoint");
 	self->reverse_convoy_coupling();
-	c = find_most_parent_convoi();
+	c = get_most_parent_convoi();
 	while(  c.is_bound()  ) {
 		if(c->get_schedule()->get_current_entry().is_reverse_convoy()) {
 			c->reverse_vehicles_on_user_request();
@@ -2029,7 +2029,7 @@ bool convoi_t::reverse_convoy_coupling_at_waypoint()
 		c = c->get_coupling_convoi();
 	}
 	// if the next stop position is different, uncouple
-	c = find_most_parent_convoi();
+	c = get_most_parent_convoi();
 	convoihandle_t child = get_coupling_convoi(); 
 	while(  child.is_bound()  ) {
 		if( c->get_schedule()->get_current_entry().pos != child->get_schedule()->get_current_entry().pos ) {
@@ -2038,7 +2038,7 @@ bool convoi_t::reverse_convoy_coupling_at_waypoint()
 		c = child;
 		child = child->get_coupling_convoi();
 	}
-	find_most_parent_convoi()->state=EDIT_SCHEDULE;
+	get_most_parent_convoi()->state=EDIT_SCHEDULE;
 	//reversing done
 	return true;
 }
@@ -3839,7 +3839,7 @@ void convoi_t::hat_gehalten(halthandle_t halt, uint32 halt_length_in_vehicle_ste
 	const goods_desc_t* cargo_type_prev = NULL;
 	bool loading_needed = !no_load  &&  !next_depot;
 	// When load_before_departure is enabled, load cargos only when the departure time condition is satisfied.
-	convoihandle_t leading_convoy = find_most_parent_convoi();
+	convoihandle_t leading_convoy = get_most_parent_convoi();
 	if(  leading_convoy->schedule->get_current_entry().get_wait_for_time()  &&  schedule->get_current_entry().is_load_before_departure()  ) {
 		loading_needed &= (leading_convoy->scheduled_departure_time!=0  &&  is_first_ticks_bigger(welt->get_ticks(), leading_convoy->scheduled_departure_time - time));
 	}
@@ -5365,13 +5365,13 @@ bool convoi_t::couple_convoi(convoihandle_t coupled) {
 	convoihandle_t c = coupled;
 	while( c.is_bound() ) {
 		c->set_state(COUPLED_LOADING);
-		c->most_parent_convoi = most_parent_convoi;
 		c = c->get_coupling_convoi();
 	}
 	if(  !is_coupled()  ) {
 		set_state(LOADING);
 	}
 	coupling_convoi = coupled;
+	coupled->parent_convoi = self;
 	coupling_convoi->front()->set_leading(false);
 	back()->set_last(false);
 	must_recalc_min_top_speed();
@@ -5387,7 +5387,7 @@ convoihandle_t convoi_t::uncouple_convoi() {
 	coupling_convoi->set_state(is_loading() ? LOADING : ROUTING_1);
 	coupling_convoi->front()->set_leading(true);
 	back()->set_last(true);
-	coupling_convoi->most_parent_convoi=coupling_convoi;
+	coupling_convoi->parent_convoi = coupling_convoi;
 	// for child convoy, recalculate is_electric and min_top_speed immediately.
 	coupling_convoi->check_electrification();
 	coupling_convoi->must_recalc_friction_weight();
@@ -5395,14 +5395,13 @@ convoihandle_t convoi_t::uncouple_convoi() {
 	convoihandle_t c = coupling_convoi->get_coupling_convoi();
 	// broadcast min_top_speed
 	while(  c.is_bound()  ) {
-		c->most_parent_convoi=coupling_convoi;
 		c->set_min_top_speed(mts);
 		c = c->get_coupling_convoi();
 	}
 	coupling_convoi = convoihandle_t();
-	find_most_parent_convoi()->must_recalc_min_top_speed();
-	find_most_parent_convoi()->check_electrification();
-	find_most_parent_convoi()->must_recalc_friction_weight();
+	get_most_parent_convoi()->must_recalc_min_top_speed();
+	get_most_parent_convoi()->check_electrification();
+	get_most_parent_convoi()->must_recalc_friction_weight();
 	return ret;
 }
 
@@ -5484,7 +5483,7 @@ bool convoi_t::is_waiting_for_coupling() const {
 
 bool convoi_t::check_electrification() {
 	is_electric = false;
-	const convoihandle_t most_parent_convoi = find_most_parent_convoi();
+	const convoihandle_t most_parent_convoi = get_most_parent_convoi();
 	convoihandle_t c = most_parent_convoi;
 	// Are there electric cars?
 	while(  c.is_bound()  &&  !is_electric  ) {
@@ -5630,7 +5629,7 @@ void convoi_t::reverse_vehicles_on_user_request()
 	}
 	reversing_needed = true;
 	// trigger repositioning on the most parent convoy
-	find_most_parent_convoi()->set_state(EDIT_SCHEDULE);
+	get_most_parent_convoi()->set_state(EDIT_SCHEDULE);
 }
 
 void convoi_t::reverse_vehicles_at_halt_if_needed()
@@ -5691,18 +5690,6 @@ convoihandle_t convoi_t::find_most_parent_convoi() const {
 	if(  !is_coupled()  ) {
 		return self;
 	}
-	if(  most_parent_convoi.is_bound() && !most_parent_convoi->is_coupled() && most_parent_convoi != self  ) {
-		// this convoy might already know who is its most parent convoi
-		// check it is real parent or not.
-		convoihandle_t c = most_parent_convoi;
-		while(  c.is_bound()  ) {
-			c = c->get_coupling_convoi();
-			if(  c.is_bound() && c == self  ) {
-				// find me! this convoy is realy its parent!
-				return most_parent_convoi;
-			}
-		}
-	}
 	// it does not know who is the most parent convoi. search it. 
 	convoihandle_t tc = self;
 	while(  tc->is_coupled()  ) {
@@ -5720,6 +5707,34 @@ convoihandle_t convoi_t::find_most_parent_convoi() const {
 		}
 	}
 	return tc;
+}
+
+convoihandle_t convoi_t::find_parent_convoi() const {
+	if(  !is_coupled()  ) {
+		return self;
+	}
+	// it does not know who is the most parent convoi. search it. 
+	convoihandle_t tc = self;
+	FOR(vector_tpl<convoihandle_t>, const& c, world()->convoys()) {
+		if(  c->get_coupling_convoi()==tc  ) {
+			tc = c;
+			break;
+		}
+	}
+	return tc;
+}
+
+convoihandle_t convoi_t::get_most_parent_convoi() const
+{
+	convoihandle_t c = self;
+	while(c.is_bound() && c->is_coupled()) {
+		c = c->get_parent_convoi();
+	}
+	if(c.is_bound()) {
+		return c;
+	} else {
+		return self;
+	}
 }
 
 convoihandle_t convoi_t::find_most_child_convoi() const
@@ -5767,11 +5782,7 @@ bool convoi_t::couple_convoi_during_running(convoihandle_t coupled) {
 	coupled->set_state(COUPLED);
 	// couplilng
 	coupling_convoi = coupled;
-	convoihandle_t c = coupled;
-	while(c.is_bound()) {
-		c->most_parent_convoi = most_parent_convoi;
-		c=c->get_coupling_convoi();
-	}
+	coupled->parent_convoi = self;
 	coupling_convoi->front()->set_leading(false);
 	back()->set_last(false);
 	must_recalc_min_top_speed();
@@ -5782,7 +5793,7 @@ bool convoi_t::couple_convoi_during_running(convoihandle_t coupled) {
 uint16 convoi_t::get_length_coupling_done() const {
 	convoihandle_t c = self;
 	if( c->is_coupled() ) {
-		c = find_most_parent_convoi();
+		c = get_most_parent_convoi();
 	}
 	uint16 length_coupling_done = 0;
 	while( c.is_bound() ) {

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -560,6 +560,8 @@ DBG_MESSAGE("convoi_t::finish_rd()","next_stop_index=%d", next_stop_index );
 	// If this is a coupled convoi, the front car is not a leading car of the entire convoi.
 	if(  state==COUPLED  ||  state==COUPLED_LOADING  ) {
 		front()->set_leading(false);
+		// set most parent convoy
+		most_parent_convoi = find_most_parent_convoi();
 	}
 	// If this has a child convoi, the last car is not the last of the entire convoi.
 	if(  coupling_convoi.is_bound()  ) {

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -163,7 +163,7 @@ void convoi_t::init(player_t *player)
 	uncouple_done = false;
 
 	coupling_convoi = convoihandle_t();
-	parent_convoi = convoihandle_t();
+	parent_convoi = self;
 
 	line_update_pending = linehandle_t();
 

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -5363,6 +5363,7 @@ bool convoi_t::couple_convoi(convoihandle_t coupled) {
 	convoihandle_t c = coupled;
 	while( c.is_bound() ) {
 		c->set_state(COUPLED_LOADING);
+		c->most_parent_convoi = most_parent_convoi;
 		c = c->get_coupling_convoi();
 	}
 	if(  !is_coupled()  ) {
@@ -5384,6 +5385,7 @@ convoihandle_t convoi_t::uncouple_convoi() {
 	coupling_convoi->set_state(is_loading() ? LOADING : ROUTING_1);
 	coupling_convoi->front()->set_leading(true);
 	back()->set_last(true);
+	coupling_convoi->most_parent_convoi=coupling_convoi;
 	// for child convoy, recalculate is_electric and min_top_speed immediately.
 	coupling_convoi->check_electrification();
 	coupling_convoi->must_recalc_friction_weight();
@@ -5391,6 +5393,7 @@ convoihandle_t convoi_t::uncouple_convoi() {
 	convoihandle_t c = coupling_convoi->get_coupling_convoi();
 	// broadcast min_top_speed
 	while(  c.is_bound()  ) {
+		c->most_parent_convoi=coupling_convoi;
 		c->set_min_top_speed(mts);
 		c = c->get_coupling_convoi();
 	}
@@ -5686,13 +5689,13 @@ convoihandle_t convoi_t::find_most_parent_convoi() const {
 	if(  !is_coupled()  ) {
 		return self;
 	}
-	if(  most_parent_convoi.is_bound() && !most_parent_convoi.is_coupled() && most_parent_convoi != self  ) {
+	if(  most_parent_convoi.is_bound() && !most_parent_convoi->is_coupled() && most_parent_convoi != self  ) {
 		// this convoy might already know who is its most parent convoi
 		// check it is real parent or not.
 		convoihandle_t c = most_parent_convoi;
 		while(  c.is_bound()  ) {
 			c = c->get_coupling_convoi();
-			if(  c == self  ) {
+			if(  c.is_bound() && c == self  ) {
 				// find me! this convoy is realy its parent!
 				return most_parent_convoi;
 			}
@@ -5762,6 +5765,11 @@ bool convoi_t::couple_convoi_during_running(convoihandle_t coupled) {
 	coupled->set_state(COUPLED);
 	// couplilng
 	coupling_convoi = coupled;
+	convoihandle_t c = coupled;
+	while(c.is_bound()) {
+		c->most_parent_convoi = most_parent_convoi;
+		c=c->get_coupling_convoi();
+	}
 	coupling_convoi->front()->set_leading(false);
 	back()->set_last(false);
 	must_recalc_min_top_speed();

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -560,12 +560,15 @@ DBG_MESSAGE("convoi_t::finish_rd()","next_stop_index=%d", next_stop_index );
 	// If this is a coupled convoi, the front car is not a leading car of the entire convoi.
 	if(  state==COUPLED  ||  state==COUPLED_LOADING  ) {
 		front()->set_leading(false);
-		// set most parent convoy
-		parent_convoi = find_parent_convoi();
 	}
 	// If this has a child convoi, the last car is not the last of the entire convoi.
 	if(  coupling_convoi.is_bound()  ) {
 		back()->set_last(false);
+		if(  state!=INITIAL  ) {
+			// set parent convoy if not in depot
+			dbg->message("convoi_t::finish_rd()","set parent convoy for my child");
+			coupling_convoi->parent_convoi = self;
+		}
 	}
 	// remove wrong freight
 	check_freight();
@@ -578,8 +581,10 @@ DBG_MESSAGE("convoi_t::finish_rd()","next_stop_index=%d", next_stop_index );
 		register_stops();
 	}
 
-	check_electrification();
-	calc_min_top_speed();
+	if(  state!=COUPLED && state!=COUPLED_LOADING  ) {
+		check_electrification();
+		calc_min_top_speed();
+	}
 	calc_speedbonus_kmh();
 }
 
@@ -5683,22 +5688,6 @@ void convoi_t::reverse_convoy_coupling()
 	} else {
 		new_parent_convoy->couple_convoi_during_running(self);
 	}
-}
-
-
-convoihandle_t convoi_t::find_parent_convoi() const {
-	if(  !is_coupled()  ) {
-		return self;
-	}
-	// it does not know who is the most parent convoi. search it. 
-	convoihandle_t tc = self;
-	FOR(vector_tpl<convoihandle_t>, const& c, world()->convoys()) {
-		if(  c->get_coupling_convoi()==tc  ) {
-			tc = c;
-			break;
-		}
-	}
-	return tc;
 }
 
 convoihandle_t convoi_t::get_most_parent_convoi() const

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -5682,6 +5682,23 @@ void convoi_t::reverse_convoy_coupling()
 
 
 convoihandle_t convoi_t::find_most_parent_convoi() const {
+	if(  !is_coupled()  ) {
+		most_parent_convoi = self;
+		return self;
+	}
+	if(  most_parent_convoi.is_bound()  ) {
+		// this convoy might already know who is its most parent convoi
+		// check it is real parent or not.
+		convoihandle_t c = most_parent_convoi;
+		while(  c.is_bound()  ) {
+			c = c->get_coupling_convoi();
+			if(  c == self  ) {
+				// find me! this convoy is realy its parent!
+				return most_parent_convoi;
+			}
+		}
+	}
+	// it does not know who is the most parent convoi. search it. 
 	convoihandle_t tc = self;
 	while(  tc->is_coupled()  ) {
 		bool found = false;
@@ -5694,9 +5711,11 @@ convoihandle_t convoi_t::find_most_parent_convoi() const {
 		}
 		if(  !found  ) {
 			dbg->error("convoi_t::find_most_parent_convoi", "could not find the parent for %s", tc->get_name());
+			most_parent_convoi = self;
 			return self;
 		}
 	}
+	most_parent_convoi = tc;
 	return tc;
 }
 

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -163,7 +163,7 @@ void convoi_t::init(player_t *player)
 	uncouple_done = false;
 
 	coupling_convoi = convoihandle_t();
-	parent_convoi = self;
+	parent_convoi = convoihandle_t();
 
 	line_update_pending = linehandle_t();
 
@@ -5393,7 +5393,7 @@ convoihandle_t convoi_t::uncouple_convoi() {
 	coupling_convoi->set_state(is_loading() ? LOADING : ROUTING_1);
 	coupling_convoi->front()->set_leading(true);
 	back()->set_last(true);
-	coupling_convoi->parent_convoi = coupling_convoi;
+	coupling_convoi->parent_convoi = convoihandle_t();
 	// for child convoy, recalculate is_electric and min_top_speed immediately.
 	coupling_convoi->check_electrification();
 	coupling_convoi->must_recalc_friction_weight();

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -230,7 +230,7 @@ private:
 	convoihandle_t coupling_convoi;
 
 	/**
-	* a convoy that pull me.
+	* a convoy that pulls me.
 	*/
 	convoihandle_t parent_convoi;
 
@@ -1108,9 +1108,7 @@ public:
 	uint32 calc_available_halt_length_in_vehicle_steps(koord3d front_vehicle_pos, ribi_t::ribi front_vehicle_dir) const;
 
 	// Returns the root parent convoi of this convoy. Returns this convoy if not coupled.
-	// Warning: The calculation cost is O(n) where n is the number of convoys in the world.
-	convoihandle_t find_parent_convoi() const;
-	convoihandle_t get_parent_convoi() const {return parent_convoi;}
+	convoihandle_t get_parent_convoi() const {return parent_convoi.is_bound()? parent_convoi: self;}
 	convoihandle_t get_most_parent_convoi() const;
 
 	// Returns the most child convoi of this convoy.

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -230,6 +230,11 @@ private:
 	convoihandle_t coupling_convoi;
 
 	/**
+	* a convoy that pull me.
+	*/
+	convoihandle_t most_parent_convoi;
+
+	/**
 	* a convoy that is coupling now.
 	*/
 	convoihandle_t convoi_coupling_in_progress;

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -1107,7 +1107,7 @@ public:
 	static uint32 calc_available_halt_length_in_vehicle_steps(koord3d front_vehicle_pos, ribi_t::ribi front_vehicle_dir, const waytype_t waytype);
 	uint32 calc_available_halt_length_in_vehicle_steps(koord3d front_vehicle_pos, ribi_t::ribi front_vehicle_dir) const;
 
-	// Returns the root parent convoi of this convoy. Returns this convoy if not coupled.
+	// Returns the parent and root parent convoi of this convoy. Returns this convoy if not coupled.
 	convoihandle_t get_parent_convoi() const {return parent_convoi.is_bound()? parent_convoi: self;}
 	convoihandle_t get_most_parent_convoi() const;
 

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -232,7 +232,7 @@ private:
 	/**
 	* a convoy that pull me.
 	*/
-	convoihandle_t most_parent_convoi;
+	convoihandle_t parent_convoi;
 
 	/**
 	* a convoy that is coupling now.
@@ -1110,6 +1110,9 @@ public:
 	// Returns the root parent convoi of this convoy. Returns this convoy if not coupled.
 	// Warning: The calculation cost is O(n) where n is the number of convoys in the world.
 	convoihandle_t find_most_parent_convoi() const;
+	convoihandle_t find_parent_convoi() const;
+	convoihandle_t get_parent_convoi() const {return parent_convoi;}
+	convoihandle_t get_most_parent_convoi() const;
 
 	// Returns the most child convoi of this convoy.
 	convoihandle_t find_most_child_convoi() const;

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -1109,7 +1109,6 @@ public:
 
 	// Returns the root parent convoi of this convoy. Returns this convoy if not coupled.
 	// Warning: The calculation cost is O(n) where n is the number of convoys in the world.
-	convoihandle_t find_most_parent_convoi() const;
 	convoihandle_t find_parent_convoi() const;
 	convoihandle_t get_parent_convoi() const {return parent_convoi;}
 	convoihandle_t get_most_parent_convoi() const;


### PR DESCRIPTION
`most_parent_convoi`を各編成が保持することとしました
- `find_most_parent_convoi()`の計算回数をO(全編成数)からO(連結編成数)に抑える
- ただし連結/連結解放/連結反転の処理が複雑に発生することから、保持している`most_parent_convoi`が正しい編成かどうかを常にチェックする
- pak欠損時等のバグの可能性を考慮し、`most_parent_convoi`は`rdwr`しない