### PR TITLE
BUG FIX: fix is_first_ticks_bigger()

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -3611,13 +3611,11 @@ bool can_depart(convoihandle_t cnv, halthandle_t halt, uint32 arrived_time, uint
 		sint64 slot = (calibrated_arrived_time<0 ?((sint64)(1U<<32)+calibrated_arrived_time) : calibrated_arrived_time) * (sint64)current_entry.spacing / (sint64)world()->ticks_per_world_month + (sint64)1;
 		// go_on_ticks = slot * spacing + spacing_shift
 		go_on_ticks = slot * world()->ticks_per_world_month / current_entry.spacing + spacing_shift;
-		dbg->message("convoi_t::can_depart()","calibrated arrived time:%ld, slot %ld, go_on_ticks %u",calibrated_arrived_time,slot,go_on_ticks);
 		// book the departure slot.
 		while(  !halt->book_departure(arrived_time, go_on_ticks, go_on_ticks + 2 * world()->ticks_per_world_month / current_entry.spacing, cnv)  ) {
 			// If the reservation request is denied, increment slot.
 			slot++;
 			go_on_ticks = slot * world()->ticks_per_world_month / current_entry.spacing + spacing_shift;
-			dbg->message("convoi_t::can_depart()","go on tick:%u, slot %ld",go_on_ticks,slot);
 		}
 		dbg->message("convoi_t::can_depart()","%s will be depart at %i, now %i", cnv->get_name(), go_on_ticks, world()->get_ticks());
 		return is_first_ticks_bigger(world()->get_ticks(), go_on_ticks - time_to_load);

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -3608,14 +3608,16 @@ bool can_depart(convoihandle_t cnv, halthandle_t halt, uint32 arrived_time, uint
 		const uint32 delay_tolerance = (uint64)current_entry.delay_tolerance * world()->ticks_per_world_month / world()->get_settings().get_spacing_shift_divisor();
 		// slot = (arrived_time - delay_tolerance - spacing_shift) / spacing + 1
 		const sint64 calibrated_arrived_time = (sint64)arrived_time - (sint64)delay_tolerance - (sint64)spacing_shift + (sint64)time_to_load;
-		sint64 slot = (calibrated_arrived_time<0 ?(1U<<32+calibrated_arrived_time) : calibrated_arrived_time) * (sint64)current_entry.spacing / (sint64)world()->ticks_per_world_month + (sint64)1;
+		sint64 slot = (calibrated_arrived_time<0 ?((sint64)(1U<<32)+calibrated_arrived_time) : calibrated_arrived_time) * (sint64)current_entry.spacing / (sint64)world()->ticks_per_world_month + (sint64)1;
 		// go_on_ticks = slot * spacing + spacing_shift
 		go_on_ticks = slot * world()->ticks_per_world_month / current_entry.spacing + spacing_shift;
+		dbg->message("convoi_t::can_depart()","calibrated arrived time:%ld, slot %ld, go_on_ticks %u",calibrated_arrived_time,slot,go_on_ticks);
 		// book the departure slot.
 		while(  !halt->book_departure(arrived_time, go_on_ticks, go_on_ticks + 2 * world()->ticks_per_world_month / current_entry.spacing, cnv)  ) {
 			// If the reservation request is denied, increment slot.
 			slot++;
 			go_on_ticks = slot * world()->ticks_per_world_month / current_entry.spacing + spacing_shift;
+			dbg->message("convoi_t::can_depart()","go on tick:%u, slot %ld",go_on_ticks,slot);
 		}
 		dbg->message("convoi_t::can_depart()","%s will be depart at %i, now %i", cnv->get_name(), go_on_ticks, world()->get_ticks());
 		return is_first_ticks_bigger(world()->get_ticks(), go_on_ticks - time_to_load);

--- a/simworld.h
+++ b/simworld.h
@@ -1873,7 +1873,8 @@ private:
 
 // a helper function to compare two ticks considering ticks overflow
 inline bool is_first_ticks_bigger(uint32 v1, uint32 v2) {
-	return (v1 != v2) && ((v1 > v2) ^ ((v1&0x80000000) != (v2&0x80000000)));
+	// we treat inverse order if |v1-v2|>(1U<<31) because ticks value changes periodicaly
+	return (v1 != v2) && ((v1 > v2)? v1-v2<(1U<<31): v2-v1>(1U<<31));
 }
 
 #endif

--- a/simworld.h
+++ b/simworld.h
@@ -1874,7 +1874,7 @@ private:
 // a helper function to compare two ticks considering ticks overflow
 inline bool is_first_ticks_bigger(uint32 v1, uint32 v2) {
 	// we treat inverse order if |v1-v2|>(1U<<31) because ticks value changes periodicaly
-	return (v1 != v2) && ((v1 > v2)? v1-v2<(1U<<31): v2-v1>(1U<<31));
+	return (v1 != v2) && ((v1 > v2)? v1-v2<(uint32)(1U<<31): v2-v1>(uint32)(1U<<31));
 }
 
 #endif


### PR DESCRIPTION
ticksが`1U<<31`を跨ぐときに`is_first_ticks_bigger`の処理が不正確であり早発・`1U<<(32-bpm)`月待機など発車時刻の不正確な予約につながっていました
そこで、`is_first_ticks_bigger(v1,v2)`について、`|v1-v2|>1U<<31`のときは値が`1U<<32`を跨いだものとみなして大小関係を反転することとします