### PR TITLE
avoid overflow for speed_magnification,acceleration_magnification

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -184,8 +184,8 @@ void convoi_t::init(player_t *player)
 	recalc_min_top_speed = true;
 	recalc_friction_weight = true;
 
-	speed_magnification = atoi(translator::translate("speed_magnification"))!=0 ? atoi(translator::translate("speed_magnification")) : 100;
-	acceleration_magnification = atoi(translator::translate("acceleration_magnification"))!=0 ? atoi(translator::translate("acceleration_magnification")) : 100;
+	speed_magnification = atoi(translator::translate("speed_magnification"))!=0 ? min(atoi(translator::translate("speed_magnification")), 255) : 100;
+	acceleration_magnification = atoi(translator::translate("acceleration_magnification"))!=0 ? min(atoi(translator::translate("acceleration_magnification")), 255) : 100;
 
 	in_delay_recovery = false;
 	reversed = false;


### PR DESCRIPTION
uint8なので256以上の値を指定した場合にオーバーフローしていました