### PR TITLE
BUG FIX:set use electric update at choose-signal

### DIFF
--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -3852,7 +3852,9 @@ skip_choose:
 			cnv->set_use_electric(cnv->is_electrification());
 			if (  !route_found  ) {
 				route_found = target_rt.find_route( welt, cnv->get_route()->at(start_block), this, speed_to_kmh(cnv->get_min_top_speed()), richtung, welt->get_settings().get_max_choose_route_steps(), cnv->needs_electrification(), true );
-				cnv->set_use_electric(false);
+				if(  route_found  ) {
+					cnv->set_use_electric(false);
+				}
 			}
 		}
 		if(  !route_found  &&  (!sig->is_guide_signal()  ||  !try_coupling)  ) {
@@ -3860,7 +3862,9 @@ skip_choose:
 			cnv->set_use_electric(cnv->is_electrification());
 			if(  !route_found  ) {
 				route_found = target_rt.find_route( welt, cnv->get_route()->at(start_block), this, speed_to_kmh(cnv->get_min_top_speed()), richtung, welt->get_settings().get_max_choose_route_steps(), cnv->needs_electrification(), false );
-				cnv->set_use_electric(false);
+				if(  route_found  ) {
+					cnv->set_use_electric(false);
+				}
 			}
 			try_coupling = false;
 		}


### PR DESCRIPTION
振分信号で空きホームがない場合に`use_electric`となり再加速時の出力が極端に落ちます