### PR TITLE
check use_electric calculation only when load before v49

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -602,8 +602,8 @@ DBG_MESSAGE("convoi_t::finish_rd()","next_stop_index=%d", next_stop_index );
 		}
 		// update all child's use_electric flag
 		convoihandle_t c = get_coupling_convoi();
-		while( c.is_bound() ){
-			c->use_electric |= use_electric;
+		while( use_electric && c.is_bound() ){
+			c->use_electric = use_electric;
 			c = c->get_coupling_convoi();
 		}
 		calc_min_top_speed();

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -5596,7 +5596,8 @@ void convoi_t::check_electrification() {
 		}
 		c = c->get_coupling_convoi();
 	}
-	if(  is_electric && !most_parent_convoi->is_loading() && most_parent_convoi->state!=INITIAL && most_parent_convoi->get_route()->get_count()>0  ) {
+	// we only recalculate use_electric when load savedata older than OTRP v49.
+	if(  welt->must_calculate_use_electric_when_loading_data && is_electric && !most_parent_convoi->is_loading() && most_parent_convoi->state!=INITIAL && most_parent_convoi->get_route()->get_count()>0  ) {
 		use_electric = true;
 		for( uint16 i=most_parent_convoi->front()->get_route_index()-1; i<most_parent_convoi->get_route()->get_count(); i++) {
 			grund_t* gr = welt->lookup(most_parent_convoi->get_route()->at(i));
@@ -5608,6 +5609,7 @@ void convoi_t::check_electrification() {
 			}
 		}
 	}
+	// calculation done! update flags. 
 	c = most_parent_convoi;
 	while(  c.is_bound()  ) {
 		c->is_electric = is_electric;

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -363,7 +363,7 @@ uint32 convoi_t::move_to(uint16 const start_index)
 }
 
 
-void convoi_t::finish_rd()
+void convoi_t::finish_rd(const uint8 loaded_OTRP_version)
 {
 	if(schedule==NULL) {
 		if(  state!=INITIAL  ) {
@@ -587,6 +587,25 @@ DBG_MESSAGE("convoi_t::finish_rd()","next_stop_index=%d", next_stop_index );
 	// only for leading convoy
 	if(  state!=COUPLED && state!=COUPLED_LOADING  ) {
 		check_electrification();
+		// we only recalculate use_electric when load savedata older than OTRP v49.
+		if(  loaded_OTRP_version<49 && is_electric && !is_loading() && state!=INITIAL && get_route()->get_count()>0  ) {
+			use_electric = true;
+			for( uint16 i=front()->get_route_index()-1; i<get_route()->get_count(); i++) {
+				grund_t* gr = welt->lookup(get_route()->at(i));
+				if(  gr  ) {
+					schiene_t const* const sch = obj_cast<schiene_t>(gr->get_weg(front()->get_waytype()));
+					if(  sch && !sch->is_electrified()  ){
+						use_electric = false;
+					}
+				}
+			}
+		}
+		// update all child's use_electric flag
+		convoihandle_t c = get_coupling_convoi();
+		while( c.is_bound() ){
+			c->use_electric |= use_electric;
+			c = c->get_coupling_convoi();
+		}
 		calc_min_top_speed();
 	}
 	calc_speedbonus_kmh();
@@ -5596,25 +5615,11 @@ void convoi_t::check_electrification() {
 		}
 		c = c->get_coupling_convoi();
 	}
-	// we only recalculate use_electric when load savedata older than OTRP v49.
-	if(  welt->must_calculate_use_electric_when_loading_data && is_electric && !most_parent_convoi->is_loading() && most_parent_convoi->state!=INITIAL && most_parent_convoi->get_route()->get_count()>0  ) {
-		use_electric = true;
-		for( uint16 i=most_parent_convoi->front()->get_route_index()-1; i<most_parent_convoi->get_route()->get_count(); i++) {
-			grund_t* gr = welt->lookup(most_parent_convoi->get_route()->at(i));
-			if(  gr  ) {
-				schiene_t const* const sch = obj_cast<schiene_t>(gr->get_weg(front()->get_waytype()));
-				if(  sch && !sch->is_electrified()  ){
-					use_electric = false;
-				}
-			}
-		}
-	}
 	// calculation done! update flags. 
 	c = most_parent_convoi;
 	while(  c.is_bound()  ) {
 		c->is_electric = is_electric;
 		c->need_electric = need_electric;
-		c->use_electric |= use_electric;
 		c = c->get_coupling_convoi();
 	}
 	return;

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -653,7 +653,7 @@ public:
 	 */
 	static void rdwr_convoihandle_t(loadsave_t *file, convoihandle_t &cnv);
 
-	void finish_rd();
+	void finish_rd( const uint8 loaded_OTRP_version );
 
 	void rotate90( const sint16 y_size );
 

--- a/simworld.cc
+++ b/simworld.cc
@@ -5443,7 +5443,10 @@ DBG_MESSAGE("karte_t::load()", "%d factories loaded", fab_list.get_count());
 	}
 
 	ls.set_progress( (get_size().y*3)/2+256+(get_size().y*3)/8 );
-
+	if(  file->get_OTRP_version()<49  ) {
+		// we must recalc convoi_t::use_electric in convoi_t::check_electrification()
+		must_calculate_use_electric_when_loading_data = true;
+	}
 	// adding lines and other stuff for convois
 	for(unsigned i=0;  i<convoi_array.get_count();  i++ ) {
 		convoihandle_t cnv = convoi_array[i];
@@ -5453,6 +5456,9 @@ DBG_MESSAGE("karte_t::load()", "%d factories loaded", fab_list.get_count());
 			i--;
 		}
 	}
+	// end convoit_t:: use_electric calculation
+	must_calculate_use_electric_when_loading_data = false;
+
 	haltestelle_t::end_load_game();
 
 	// register all line stops and change line types, if needed

--- a/simworld.cc
+++ b/simworld.cc
@@ -5443,22 +5443,15 @@ DBG_MESSAGE("karte_t::load()", "%d factories loaded", fab_list.get_count());
 	}
 
 	ls.set_progress( (get_size().y*3)/2+256+(get_size().y*3)/8 );
-	if(  file->get_OTRP_version()<49  ) {
-		// we must recalc convoi_t::use_electric in convoi_t::check_electrification()
-		must_calculate_use_electric_when_loading_data = true;
-	}
 	// adding lines and other stuff for convois
 	for(unsigned i=0;  i<convoi_array.get_count();  i++ ) {
 		convoihandle_t cnv = convoi_array[i];
-		cnv->finish_rd();
+		cnv->finish_rd( file->get_OTRP_version() );
 		// was deleted during loading => use same position again
 		if(!cnv.is_bound()) {
 			i--;
 		}
 	}
-	// end convoit_t:: use_electric calculation
-	must_calculate_use_electric_when_loading_data = false;
-
 	haltestelle_t::end_load_game();
 
 	// register all line stops and change line types, if needed

--- a/simworld.cc
+++ b/simworld.cc
@@ -5443,6 +5443,7 @@ DBG_MESSAGE("karte_t::load()", "%d factories loaded", fab_list.get_count());
 	}
 
 	ls.set_progress( (get_size().y*3)/2+256+(get_size().y*3)/8 );
+
 	// adding lines and other stuff for convois
 	for(unsigned i=0;  i<convoi_array.get_count();  i++ ) {
 		convoihandle_t cnv = convoi_array[i];

--- a/simworld.h
+++ b/simworld.h
@@ -1400,6 +1400,11 @@ public:
 	uint32 load_version;
 
 	/**
+	 * when load savedata older than OTRP v49, we must recalc convoi_t::use_electric 
+	 */
+	bool must_calculate_use_electric_when_loading_data=false;
+
+	/**
 	 * Checks if the planquadrat (tile) at coordinate (x,y)
 	 * can be lowered at the specified height.
 	 */

--- a/simworld.h
+++ b/simworld.h
@@ -1400,11 +1400,6 @@ public:
 	uint32 load_version;
 
 	/**
-	 * when load savedata older than OTRP v49, we must recalc convoi_t::use_electric 
-	 */
-	bool must_calculate_use_electric_when_loading_data=false;
-
-	/**
 	 * Checks if the planquadrat (tile) at coordinate (x,y)
 	 * can be lowered at the specified height.
 	 */


### PR DESCRIPTION
#239 453c54cの計算回数を減らし、原則として`convoi_t::use_electric`はロード時およびルート計算時のみ計算するようにします