### PR TITLE
change power value in convoi_detail_t when no use_electric

### DIFF
--- a/gui/convoi_detail_t.cc
+++ b/gui/convoi_detail_t.cc
@@ -75,7 +75,7 @@ public:
 			// power
 			if(v->get_desc()->get_power()>0) {
 				l = new_component<gui_label_buf_t>();
-				l->buf().printf("%s %i kW, %s %.2f", translator::translate("Power:"), v->get_desc()->get_power(), translator::translate("Gear:"), v->get_desc()->get_gear()/64.0 );
+				l->buf().printf("%s %i kW, %s %.2f", translator::translate("Power:"), (v->get_desc()->get_engine_type()==vehicle_desc_t::electric&&!v->get_convoi()->get_use_electric())?0:v->get_desc()->get_power(), translator::translate("Gear:"), v->get_desc()->get_gear()/64.0 );
 				l->update();
 			}
 			// friction

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -569,6 +569,7 @@ public:
 	bool is_electrification() const {return is_electric;}
 	void check_electrification();
 	void set_use_electric(bool y);
+	bool get_use_electric() const {return use_electric;}
 
 	/**
 	* set line


### PR DESCRIPTION
`convoi_t::use_electric==false`のときに、`convoi_detail_t`における電車の`power`値を0にします