### PR TITLE
treat wtyp==tram_wt of wayobj and roadsign as wtyp==track_wt

### DIFF
--- a/descriptor/reader/roadsign_reader.cc
+++ b/descriptor/reader/roadsign_reader.cc
@@ -118,6 +118,9 @@ obj_desc_t * roadsign_reader_t::read_node(FILE *fp, obj_node_info_t &node)
 		// do not shift these signs to the left for compatibility
 		desc->offset_left = 0;
 	}
+	if(desc->wtyp==tram_wt) {
+		desc->wtyp=track_wt;
+	}
 
 	DBG_DEBUG("roadsign_reader_t::read_node()",
 		"version=%i, min_speed=%i, price=%" PRId64 ", maintenance=%" PRId64 ",flags=%x, wtyp=%i, offset_left=%i, intro=%i/%i, retire=%i/%i",

--- a/descriptor/reader/way_obj_reader.cc
+++ b/descriptor/reader/way_obj_reader.cc
@@ -71,6 +71,9 @@ obj_desc_t * way_obj_reader_t::read_node(FILE *fp, obj_node_info_t &node)
 	else {
 		dbg->fatal( "way_obj_reader_t::read_node()", "Cannot handle too new node version %i", version );
 	}
+	if(desc->wtyp==tram_wt) {
+		desc->wtyp=track_wt;
+	}
 	DBG_DEBUG("way_obj_reader_t::read_node()",
 	     "version=%d price=%d maintenance=%d topspeed=%d wtype=%d own_wtype=%d intro=%i/%i, retire=%i/%i",
 	     version,


### PR DESCRIPTION
路面軌道のwayobjとroadsignはcalc_routeができず設置できないor連続設置しようとするとクラッシュするバグがあるため、pak読み込み時に強制的に上書きすることとします