### PR TITLE
セーブ/ロードを挟むと所要時間が記録されない問題を修正

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -3316,6 +3316,10 @@ void convoi_t::rdwr(loadsave_t *file)
 		need_electric = is_electric;
 		use_electric = is_electric;
 	}
+	if(  file->get_OTRP_version()>=50  ) {
+		// TODO: Remove this and use arrived_time instead after resolving the desync issue.
+		file->rdwr_long( time_last_arrived );
+	}
 
 	if(  file->is_loading()  ) {
 		reserve_route();


### PR DESCRIPTION
## 概要

セーブ/ロードを挟むと、`time_last_arrived` が失われることにより所要時間が記録されない問題を修正します。これにより、オートセーブが有効なNSで停車駅間の長い路線において、オートセーブ間隔が駅間所要時間より短いと所要時間が記録されない問題を解決します。

この問題は本来 `time_last_arrived` を廃止して、同じ役割を持つ `arrived_time` で代替することで解決すべきですが、 307f5baba4bf7e1ab93b97fca48dfbf0b9abc25d を導入したところNSでdesyncが発生するようになり、この原因が特定できません。そこで、`time_last_arrived` を保存することでとりあえず問題を解決させるものです。

この修正が有効になるにはmajor versionを50にインクリメントすることが必要です。

## 動作確認

手元でmajor versionを50にインクリメントした上で、路線に所属した編成を走らせてロード/セーブを挟んでも到着時に所要時間が記録されることを確認。