### PR TITLE
not append unique for reserved_tiles

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -2705,6 +2705,9 @@ void convoi_t::vorfahren()
 				vehicle_t const& v = *inspecting->fahr[i];
 				if (schiene_t* const sch0 = obj_cast<schiene_t>(welt->lookup(v.get_pos())->get_weg(v.get_waytype()))) {
 					sch0->reserve(self,ribi_t::none);
+					if(  v.get_pos()!=front()->get_pos()  ) {
+						unreserve_pos(v.get_pos());
+					}
 				}
 				else {
 					break;

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -990,7 +990,7 @@ public:
 	 * @author THLeaderH
 	 */
 	void unreserve_pos(koord3d pos) { reserved_tiles.remove(pos); }
-	void reserve_pos(koord3d pos) {reserved_tiles.append_unique(pos); }
+	void reserve_pos(koord3d pos) {reserved_tiles.append(pos); }
 	bool is_reservation_empty() const { return reserved_tiles.empty(); }
 	vector_tpl<koord3d>& get_reserved_tiles() { return reserved_tiles; }
 	void clear_reserved_tiles();


### PR DESCRIPTION
longblocksignalで折り返しのある区間を予約する際に、従来は`append_unique`していたために折り返し時に予約区間がリセットされていました。