### PR TITLE
BUG FIX: avoid self_destruct when withdraw convoy's freight_level<1%

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -4059,9 +4059,18 @@ void convoi_t::hat_gehalten(halthandle_t halt, uint32 halt_length_in_vehicle_ste
 		uncouple_convoi();
 	}
 
-	if(  !is_coupled()  &&  !coupling_convoi.is_bound()  &&  withdraw  &&  (loading_level == 0  ||  goods_catg_index.empty())  ) {
+	if(  !is_coupled()  &&  !coupling_convoi.is_bound()  &&  withdraw  ) {
 		// destroy when empty, alone
-		self_destruct();
+		uint32 total_freight=0;
+		for(  uint8 i=0; i<anz_vehikel; i++  ) {
+			total_freight+=get_vehikel(i)->get_total_cargo();
+			if(total_freight>0){
+				break;
+			}
+		}
+		if (total_freight == 0  ||  goods_catg_index.empty()) {
+			self_destruct();
+		}
 		return;
 	}
 

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -4844,7 +4844,6 @@ void convoi_t::set_withdraw(bool new_withdraw)
 			if (  empty  ) {
 				self_destruct();
 			}
-			self_destruct();
 		}
 	}
 }

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -4061,14 +4061,19 @@ void convoi_t::hat_gehalten(halthandle_t halt, uint32 halt_length_in_vehicle_ste
 
 	if(  !is_coupled()  &&  !coupling_convoi.is_bound()  &&  withdraw  ) {
 		// destroy when empty, alone
-		uint32 total_freight=0;
+		if(  goods_catg_index.empty()  ) {
+			self_destruct();
+			return;
+		}
+		// because loading_level is int value, we must check empty
+		bool empty=true;
 		for(  uint8 i=0; i<anz_vehikel; i++  ) {
-			total_freight+=get_vehikel(i)->get_total_cargo();
-			if(total_freight>0){
+			empty&=(get_vehikel(i)->get_total_cargo()==0);
+			if(!empty){
 				break;
 			}
 		}
-		if (total_freight == 0  ||  goods_catg_index.empty()) {
+		if (  empty  ) {
 			self_destruct();
 		}
 		return;

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -4815,7 +4815,7 @@ void convoi_t::set_withdraw(bool new_withdraw)
 {
 	withdraw = new_withdraw;
 	// coupling convoy must not be withdrawn.
-	if(  withdraw  &&  (loading_level==0  ||  goods_catg_index.empty())  &&  !is_coupled()  &&  !coupling_convoi.is_bound()  ) {
+	if(  withdraw  &&  !is_coupled()  &&  !coupling_convoi.is_bound()  ) {
 		// test if convoi in depot and not driving
 		grund_t *gr = welt->lookup( get_pos());
 		if(  gr  &&  gr->get_depot()  &&  state == INITIAL  ) {
@@ -4829,6 +4829,21 @@ void convoi_t::set_withdraw(bool new_withdraw)
 #endif
 		}
 		else {
+			if(  goods_catg_index.empty()  ) {
+				self_destruct();
+				return;
+			}
+			// because loading_level is int value, we must check empty
+			bool empty=true;
+			for(  uint8 i=0; i<anz_vehikel; i++  ) {
+				empty&=(get_vehikel(i)->get_total_cargo()==0);
+				if(!empty){
+					break;
+				}
+			}
+			if (  empty  ) {
+				self_destruct();
+			}
 			self_destruct();
 		}
 	}


### PR DESCRIPTION
乗車率が1％未満で積載がある「引退」設定した編成が下車完了前に除去される不具合を修正しました（確実に空車でないと除去されません）