### PR TITLE
build height=1 elevated way if no other way avove or below

### DIFF
--- a/bauer/wegbauer.cc
+++ b/bauer/wegbauer.cc
@@ -583,7 +583,7 @@ bool way_builder_t::is_allowed_step(const grund_t *from, const grund_t *to, sint
 				*costs += 4;
 			}
 			// absolutely nothing allowed here for set which want double clearance
-			if(  welt->get_settings().get_way_height_clearance()==2  &&  welt->lookup( to->get_pos()+koord3d(0,0,1+height_offset) )  ) {
+			if(  welt->get_settings().get_way_height_clearance()==2  &&  welt->lookup( to->get_pos()+koord3d(0,0,1+max(height_offset,0)) )  ) {
 				return false;
 			}
 			// up to now 'to' and 'from' referred to the ground one height step below the elevated way
@@ -628,12 +628,12 @@ bool way_builder_t::is_allowed_step(const grund_t *from, const grund_t *to, sint
 
 	if(  welt->get_settings().get_way_height_clearance()==2  ) {
 		// cannot build if conversion factor 2, we aren't powerline and way with maximum speed > 0 or powerline 1 tile below
-		grund_t *to2 = welt->lookup( to->get_pos() + koord3d(0, 0, -1+height_offset) );
+		grund_t *to2 = welt->lookup( to->get_pos() + koord3d(0, 0, -1+max(height_offset,0)) );
 		if(  to2 && (((bautyp&bautyp_mask)!=leitung  &&  to2->get_weg_nr(0)  &&  to2->get_weg_nr(0)->get_desc()->get_topspeed()>0) || to2->get_leitung())  ) {
 			return false;
 		}
 		// tile above cannot have way unless we are a way (not powerline) with a maximum speed of 0, or be surface if we are underground
-		to2 = welt->lookup( to->get_pos() + koord3d(0, 0, 1+height_offset) );
+		to2 = welt->lookup( to->get_pos() + koord3d(0, 0, 1+max(height_offset,0)) );
 		if(  to2  &&  ((to2->get_weg_nr(0)  &&  (desc->get_topspeed()>0  ||  (bautyp&bautyp_mask)==leitung))  ||  (bautyp & tunnel_flag) != 0)  ) {
 			return false;
 		}

--- a/bauer/wegbauer.cc
+++ b/bauer/wegbauer.cc
@@ -583,6 +583,7 @@ bool way_builder_t::is_allowed_step(const grund_t *from, const grund_t *to, sint
 				*costs += 4;
 			}
 			// absolutely nothing allowed here for set which want double clearance
+			// we only check clearance at the top -> check above when height_offset = -1
 			if(  welt->get_settings().get_way_height_clearance()==2  &&  welt->lookup( to->get_pos()+koord3d(0,0,1+max(height_offset,0)) )  ) {
 				return false;
 			}
@@ -628,11 +629,13 @@ bool way_builder_t::is_allowed_step(const grund_t *from, const grund_t *to, sint
 
 	if(  welt->get_settings().get_way_height_clearance()==2  ) {
 		// cannot build if conversion factor 2, we aren't powerline and way with maximum speed > 0 or powerline 1 tile below
+		// if height_offset=-1, we check 1 tile below.
 		grund_t *to2 = welt->lookup( to->get_pos() + koord3d(0, 0, -1+max(height_offset,0)) );
 		if(  to2 && (((bautyp&bautyp_mask)!=leitung  &&  to2->get_weg_nr(0)  &&  to2->get_weg_nr(0)->get_desc()->get_topspeed()>0) || to2->get_leitung())  ) {
 			return false;
 		}
 		// tile above cannot have way unless we are a way (not powerline) with a maximum speed of 0, or be surface if we are underground
+		// if height_offset=-1, we check 1 tile above.
 		to2 = welt->lookup( to->get_pos() + koord3d(0, 0, 1+max(height_offset,0)) );
 		if(  to2  &&  ((to2->get_weg_nr(0)  &&  (desc->get_topspeed()>0  ||  (bautyp&bautyp_mask)==leitung))  ||  (bautyp & tunnel_flag) != 0)  ) {
 			return false;

--- a/bauer/wegbauer.h
+++ b/bauer/wegbauer.h
@@ -130,7 +130,7 @@ private:
 	 * Only for elevated way
 	 * @author THLeaderH
 	 */
-	uint8 height_offset;
+	sint8 height_offset;
 
 	/**
 	 * If a way is built on top of another way, should the type
@@ -218,7 +218,7 @@ public:
 
 	void set_overtaking_mode(overtaking_mode_t o) { overtaking_mode = o; }
 	void set_street_flag(uint8 a) { street_flag = a; }
-	void set_height_offset(uint8 a) { height_offset = a; }
+	void set_height_offset(sint8 a) { height_offset = a; }
 
 	way_builder_t(player_t *player);
 

--- a/gui/overtaking_mode.cc
+++ b/gui/overtaking_mode.cc
@@ -97,7 +97,7 @@ void overtaking_mode_frame_t::init( player_t* player_, overtaking_mode_t overtak
 			height_offset_label.set_text("height offset");
 			add_component( &height_offset_label );
 			
-			height_offset.set_limits( 0, 32 );
+			height_offset.set_limits( 1-world()->get_settings().get_way_height_clearance(), 32 );
 			height_offset.set_value( tool_w->get_height_offset() );
 			height_offset.wrap_mode( false );
 			height_offset.add_listener( this );

--- a/gui/simple_number_input.cc
+++ b/gui/simple_number_input.cc
@@ -14,7 +14,7 @@
 
 #define L_DIALOG_WIDTH (200)
 
-simple_number_input_frame_t::simple_number_input_frame_t (const char* frame_title, const char* label_text, uint8 min_val, uint8 max_val, uint8 default_val) :
+simple_number_input_frame_t::simple_number_input_frame_t (const char* frame_title, const char* label_text, sint8 min_val, sint8 max_val, sint8 default_val) :
  	gui_frame_t( translator::translate(frame_title) ),
 	label(label_text)
 {
@@ -50,16 +50,16 @@ wayobj_spacing_frame_t::wayobj_spacing_frame_t(player_t* /*player_*/, tool_build
 	tool = tool_;
 }
 
-void wayobj_spacing_frame_t::register_val(uint8 v) {
+void wayobj_spacing_frame_t::register_val(sint8 v) {
 	tool->set_spacing(v);
 }
 
 height_offset_frame_t::height_offset_frame_t(player_t* /*player_*/, tool_build_way_t* tool_) :
-	simple_number_input_frame_t( translator::translate("set height offset"), translator::translate("height offset"), 0, 32, tool_->get_height_offset() )
+	simple_number_input_frame_t( translator::translate("set height offset"), translator::translate("height offset"), 1-world()->get_settings().get_way_height_clearance(), 32, tool_->get_height_offset() )
 {
 	tool = tool_;
 }
 
-void height_offset_frame_t::register_val(uint8 v) {
-	tool->set_height_offset(v);
+void height_offset_frame_t::register_val(sint8 v) {
+	tool->set_height_offset((sint8)v);
 }

--- a/gui/simple_number_input.cc
+++ b/gui/simple_number_input.cc
@@ -61,5 +61,5 @@ height_offset_frame_t::height_offset_frame_t(player_t* /*player_*/, tool_build_w
 }
 
 void height_offset_frame_t::register_val(sint8 v) {
-	tool->set_height_offset((sint8)v);
+	tool->set_height_offset(v);
 }

--- a/gui/simple_number_input.h
+++ b/gui/simple_number_input.h
@@ -18,14 +18,14 @@ class player_t;
 class simple_number_input_frame_t : public gui_frame_t, private action_listener_t
 {
 private:
-	uint8 val;
+	sint8 val;
 	gui_numberinput_t input;
 	gui_label_t label;
 
 public:
-	simple_number_input_frame_t(const char* frame_title, const char* label_text, uint8 min_val, uint8 max_val, uint8 default_val);
+	simple_number_input_frame_t(const char* frame_title, const char* label_text, sint8 min_val, sint8 max_val, sint8 default_val);
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
-	virtual void register_val(uint8 v) = 0;
+	virtual void register_val(sint8 v) = 0;
 };
 
 class wayobj_spacing_frame_t : public simple_number_input_frame_t
@@ -34,7 +34,7 @@ private:
 	tool_build_wayobj_t* tool;
 public:
 	wayobj_spacing_frame_t( player_t *, tool_build_wayobj_t * );
-	void register_val(uint8 v) OVERRIDE;
+	void register_val(sint8 v) OVERRIDE;
 	const char * get_help_filename() const OVERRIDE { return "wayobj_spacing.txt"; }
 };
 
@@ -44,7 +44,7 @@ private:
 	tool_build_way_t* tool;
 public:
 	height_offset_frame_t( player_t *, tool_build_way_t * );
-	void register_val(uint8 v) OVERRIDE;
+	void register_val(sint8 v) OVERRIDE;
 	const char * get_help_filename() const OVERRIDE { return "height_offset.txt"; }
 };
 

--- a/simtool.cc
+++ b/simtool.cc
@@ -1518,10 +1518,17 @@ const char *tool_setslope_t::tool_set_slope_work( player_t *player, koord3d pos,
 				gr2 = welt->lookup( new_pos + koord3d(0, 0, 3) );
 			}
 			// slope may alter amount of clearance required
-			if(  gr2  &&  gr2->get_pos().z - new_pos.z + slope_t::min_diff( gr2->get_weg_hang(), new_slope ) < welt->get_settings().get_way_height_clearance()  ) {
-				if(  gr2->get_pos().z - new_pos.z + slope_t::min_diff( gr2->get_weg_hang(), new_slope ) < max(welt->get_settings().get_way_height_clearance()-1,1) || (gr1->get_weg_nr(0)  &&  gr1->get_weg_nr(0)->get_desc()->get_topspeed()>0)   ) {
-					// this ground has a way or almost touch above way.
-					return NOTICE_TILE_FULL;
+			if(  gr2  ) {
+				const sint8 clearance = gr2->get_pos().z - new_pos.z + slope_t::min_diff( gr2->get_weg_hang(), new_slope );
+				const sint8 required_clearance = welt->get_settings().get_way_height_clearance();
+				const sint8 min_clearance = max(required_clearance - 1, 1);
+
+				if( gr2 && clearance < required_clearance ) {
+					const bool has_active_way = gr1->get_weg_nr(0) && gr1->get_weg_nr(0)->get_desc()->get_topspeed() > 0;
+					if( clearance < min_clearance || has_active_way ) {
+						// this ground has a way or almost touch above way.
+						return NOTICE_TILE_FULL;
+					}
 				}
 			}
 		}
@@ -1534,10 +1541,17 @@ const char *tool_setslope_t::tool_set_slope_work( player_t *player, koord3d pos,
 				gr2 = welt->lookup( new_pos + koord3d(0, 0, -3) );
 			}
 			// slope may alter amount of clearance required
-			if(  gr2  &&  new_pos.z - gr2->get_pos().z + slope_t::min_diff( new_slope, gr2->get_weg_hang() ) < welt->get_settings().get_way_height_clearance()  ) {
-				if(  new_pos.z - gr2->get_pos().z + slope_t::min_diff( new_slope, gr2->get_weg_hang() ) < max(welt->get_settings().get_way_height_clearance()-1,1) || (gr2->get_weg_nr(0)  &&  gr2->get_weg_nr(0)->get_desc()->get_topspeed()>0)   ) {
-					// this ground has a way or almost touch above way.
-					return NOTICE_TILE_FULL;
+			if(  gr2  ) {
+				const sint8 clearance = new_pos.z - gr2->get_pos().z + slope_t::min_diff( new_slope, gr2->get_weg_hang() );
+				const sint8 required_clearance = welt->get_settings().get_way_height_clearance();
+				const sint8 min_clearance = max(required_clearance - 1, 1);
+
+				if( gr2 && clearance < required_clearance ) {
+					const bool has_active_way = gr2->get_weg_nr(0) && gr2->get_weg_nr(0)->get_desc()->get_topspeed() > 0;
+					if( clearance < min_clearance || has_active_way ) {
+						// this ground has a way or almost touch above way.
+						return NOTICE_TILE_FULL;
+					}
 				}
 			}
 		}

--- a/simtool.cc
+++ b/simtool.cc
@@ -1519,7 +1519,8 @@ const char *tool_setslope_t::tool_set_slope_work( player_t *player, koord3d pos,
 			}
 			// slope may alter amount of clearance required
 			if(  gr2  &&  gr2->get_pos().z - new_pos.z + slope_t::min_diff( gr2->get_weg_hang(), new_slope ) < welt->get_settings().get_way_height_clearance()  ) {
-				if(  gr2->get_pos().z - new_pos.z + slope_t::min_diff( gr2->get_weg_hang(), new_slope ) < welt->get_settings().get_way_height_clearance()-1 || (gr1->get_weg_nr(0)  &&  gr1->get_weg_nr(0)->get_desc()->get_topspeed()>0)   ) {
+				if(  gr2->get_pos().z - new_pos.z + slope_t::min_diff( gr2->get_weg_hang(), new_slope ) < max(welt->get_settings().get_way_height_clearance()-1,1) || (gr1->get_weg_nr(0)  &&  gr1->get_weg_nr(0)->get_desc()->get_topspeed()>0)   ) {
+					// this ground has a way or almost touch above way.
 					return NOTICE_TILE_FULL;
 				}
 			}
@@ -1534,7 +1535,8 @@ const char *tool_setslope_t::tool_set_slope_work( player_t *player, koord3d pos,
 			}
 			// slope may alter amount of clearance required
 			if(  gr2  &&  new_pos.z - gr2->get_pos().z + slope_t::min_diff( new_slope, gr2->get_weg_hang() ) < welt->get_settings().get_way_height_clearance()  ) {
-				if(  new_pos.z - gr2->get_pos().z + slope_t::min_diff( new_slope, gr2->get_weg_hang() ) < welt->get_settings().get_way_height_clearance()-1 || (gr2->get_weg_nr(0)  &&  gr2->get_weg_nr(0)->get_desc()->get_topspeed()>0)   ) {
+				if(  new_pos.z - gr2->get_pos().z + slope_t::min_diff( new_slope, gr2->get_weg_hang() ) < max(welt->get_settings().get_way_height_clearance()-1,1) || (gr2->get_weg_nr(0)  &&  gr2->get_weg_nr(0)->get_desc()->get_topspeed()>0)   ) {
+					// this ground has a way or almost touch above way.
 					return NOTICE_TILE_FULL;
 				}
 			}

--- a/simtool.cc
+++ b/simtool.cc
@@ -1523,7 +1523,7 @@ const char *tool_setslope_t::tool_set_slope_work( player_t *player, koord3d pos,
 				const sint8 required_clearance = welt->get_settings().get_way_height_clearance();
 				const sint8 min_clearance = max(required_clearance - 1, 1);
 
-				if( gr2 && clearance < required_clearance ) {
+				if( clearance < required_clearance ) {
 					const bool has_active_way = gr1->get_weg_nr(0) && gr1->get_weg_nr(0)->get_desc()->get_topspeed() > 0;
 					if( clearance < min_clearance || has_active_way ) {
 						// this ground has a way or almost touch above way.
@@ -1546,7 +1546,7 @@ const char *tool_setslope_t::tool_set_slope_work( player_t *player, koord3d pos,
 				const sint8 required_clearance = welt->get_settings().get_way_height_clearance();
 				const sint8 min_clearance = max(required_clearance - 1, 1);
 
-				if( gr2 && clearance < required_clearance ) {
+				if( clearance < required_clearance ) {
 					const bool has_active_way = gr2->get_weg_nr(0) && gr2->get_weg_nr(0)->get_desc()->get_topspeed() > 0;
 					if( clearance < min_clearance || has_active_way ) {
 						// this ground has a way or almost touch above way.

--- a/simtool.cc
+++ b/simtool.cc
@@ -1519,7 +1519,9 @@ const char *tool_setslope_t::tool_set_slope_work( player_t *player, koord3d pos,
 			}
 			// slope may alter amount of clearance required
 			if(  gr2  &&  gr2->get_pos().z - new_pos.z + slope_t::min_diff( gr2->get_weg_hang(), new_slope ) < welt->get_settings().get_way_height_clearance()  ) {
-				return NOTICE_TILE_FULL;
+				if(  gr2->get_pos().z - new_pos.z + slope_t::min_diff( gr2->get_weg_hang(), new_slope ) < welt->get_settings().get_way_height_clearance()-1 || (gr1->get_weg_nr(0)  &&  gr1->get_weg_nr(0)->get_desc()->get_topspeed()>0)   ) {
+					return NOTICE_TILE_FULL;
+				}
 			}
 		}
 		if(  new_pos.z <= pos.z  ) {
@@ -1532,7 +1534,9 @@ const char *tool_setslope_t::tool_set_slope_work( player_t *player, koord3d pos,
 			}
 			// slope may alter amount of clearance required
 			if(  gr2  &&  new_pos.z - gr2->get_pos().z + slope_t::min_diff( new_slope, gr2->get_weg_hang() ) < welt->get_settings().get_way_height_clearance()  ) {
-				return NOTICE_TILE_FULL;
+				if(  new_pos.z - gr2->get_pos().z + slope_t::min_diff( new_slope, gr2->get_weg_hang() ) < welt->get_settings().get_way_height_clearance()-1 || (gr2->get_weg_nr(0)  &&  gr2->get_weg_nr(0)->get_desc()->get_topspeed()>0)   ) {
+					return NOTICE_TILE_FULL;
+				}
 			}
 		}
 
@@ -2825,7 +2829,7 @@ bool tool_build_way_t::calc_route( way_builder_t &bauigel, const koord3d &start,
 	}
 	// elevated track?
 	if(desc->get_styp()==type_elevated  &&  desc->get_wtyp()!=air_wt) {
-		uint8 hf = height_offset;
+		sint8 hf = height_offset;
 		tool_build_way_t* toolbar_tool;
 		if(  look_toolbar  &&  (toolbar_tool=get_build_way_tool_from_toolbar(desc))!=NULL  ) {
 			// look toolbar variable indicates this tool is called from a shortcut key. When a tool is called from a shortcut key, we have to use height_offset of the tool in a toolbar.
@@ -2907,7 +2911,7 @@ void tool_build_way_t::rdwr_custom_data(memory_rw_t *packet)
 	two_click_tool_t::rdwr_custom_data(packet);
 	sint8 i = overtaking_mode;
 	uint8 a = street_flag;
-	uint8 b = height_offset;
+	sint8 b = height_offset;
 	// If this tool is called from a shortcut key, overtaking_mode of the tool in a toolbar has to be used.
 	if(  packet->is_saving()  &&  look_toolbar  ) {
 		tool_build_way_t* toolbar_tool = get_build_way_tool_from_toolbar(desc);
@@ -2932,7 +2936,7 @@ void tool_build_way_t::mark_tiles(  player_t *player, const koord3d &start, cons
 	bool route_reversed = calc_route( bauigel, start, end );
 	bool keep_city_roads = is_shift_pressed()  &&  desc->get_styp() == type_flat  &&  desc->get_wtyp() == road_wt;
 
-	uint8 hf = height_offset;
+	sint8 hf = height_offset;
 	tool_build_way_t* toolbar_tool;
 	if(  look_toolbar  &&  (toolbar_tool=get_build_way_tool_from_toolbar(desc))!=NULL  ) {
 		// look toolbar variable indicates this tool is called from a shortcut key. When a tool is called from a shortcut key, we have to use height_offset of the tool in a toolbar.

--- a/simtool.h
+++ b/simtool.h
@@ -305,7 +305,7 @@ protected:
 	overtaking_mode_t overtaking_mode;
 	bool look_toolbar = false;
 	uint8 street_flag;
-	uint8 height_offset;
+	sint8 height_offset;
 
 	virtual way_desc_t const* get_desc(uint16 timeline_year_month) const;
 	bool calc_route( way_builder_t &bauigel, const koord3d &, const koord3d & );
@@ -334,8 +334,8 @@ public:
 	overtaking_mode_t get_overtaking_mode() const { return overtaking_mode; }
 	void set_street_flag (uint8 a) { street_flag = a; }
 	uint8 get_street_flag() const { return street_flag; }
-	void set_height_offset (uint8 a) { height_offset = a; }
-	uint8 get_height_offset() const { return height_offset; }
+	void set_height_offset (sint8 a) { height_offset = a; }
+	sint8 get_height_offset() const { return height_offset; }
 	static void set_mode_str(char* str, overtaking_mode_t overtaking_mode);
 	void set_look_toolbar() { look_toolbar = true; }
 	static uint8 get_flag_color(uint8 flag);

--- a/simtool.h
+++ b/simtool.h
@@ -334,7 +334,10 @@ public:
 	overtaking_mode_t get_overtaking_mode() const { return overtaking_mode; }
 	void set_street_flag (uint8 a) { street_flag = a; }
 	uint8 get_street_flag() const { return street_flag; }
-	void set_height_offset (sint8 a) { height_offset = a; }
+	void set_height_offset (sint8 a) { 
+		const sint8 min_offset = 1 - welt->get_settings().get_way_height_clearance();
+		height_offset = a<min_offset?0:a;
+	}
 	sint8 get_height_offset() const { return height_offset; }
 	static void set_mode_str(char* str, overtaking_mode_t overtaking_mode);
 	void set_look_toolbar() { look_toolbar = true; }


### PR DESCRIPTION
`settings::way_height_clearance==2`において、高架のオフセットを'-1'とすることで高さ1(=ハーフハイト)の高架を建設できます
- 下にwayがない場合のみ建設可能
- 何もない地形については高架の1段下まで上げられるように
- way等がある場合は従来通り2段以上で交差可能