### PR TITLE
BUG FIX: do not remove other city

### DIFF
--- a/simtool.cc
+++ b/simtool.cc
@@ -647,7 +647,7 @@ DBG_MESSAGE("tool_remover()",  "removing tunnel  from %d,%d,%d",gr->get_pos().x,
 
 		// remove town? (when removing townhall)
 		if(gb->is_townhall()) {
-			stadt_t *stadt = welt->find_nearest_city(k);
+			stadt_t *stadt = gb->get_stadt();
 			if(!welt->remove_city( stadt )) {
 				msg = "Das Feld gehoert\neinem anderen Spieler\n";
 				return false;


### PR DESCRIPTION
市役所撤去による都市破壊時、座標から最寄りの都市を判定するために隣接する別の都市が破壊されることがあります。
そのため、市役所の所属都市自体を呼び出すように変更しました