### PR TITLE
BUG FIX: can remove, can build wayobj/signal on 0km/h way by using way_checker_t

### DIFF
--- a/simtool.cc
+++ b/simtool.cc
@@ -4125,19 +4125,11 @@ void tool_build_wayobj_t::draw_after(scr_coord k, bool dirty) const
 
 bool tool_build_wayobj_t::calc_route( route_t &verbindung, player_t *player, const koord3d& start, const koord3d& to )
 {
-	waytype_t waytype = wt;
+	waytype_t waytype = wt==tram_wt? track_wt: wt;
 	if(  waytype == any_wt  ) {
 		waytype = welt->lookup(start)->get_weg(wt)->get_waytype();
 	}
-	// special treatment for deports, since track electrication cannot "drive" into tram depot
-	if(  waytype == track_wt  ) {
-		if(  depot_t  *dp = welt->lookup(start)->get_depot()  ) {
-			waytype = dp->get_waytype();
-		}
-		else if(  depot_t  *dp = welt->lookup(to)->get_depot()  ) {
-			waytype = dp->get_waytype();
-		}
-	}
+	
 	// get a default vehikel
 	test_driver_t *test_driver = new way_checker_t(waytype);
 

--- a/simtool.cc
+++ b/simtool.cc
@@ -3720,6 +3720,18 @@ class electron_t : public test_driver_t {
 	bool is_target(const grund_t *,const grund_t *) const OVERRIDE { return false; }
 };
 
+class way_checker_t : public test_driver_t {
+private:
+	waytype_t wt;
+public:
+	way_checker_t(waytype_t w) : wt(w) {}
+	bool check_next_tile(const grund_t* gr) const OVERRIDE { return gr->hat_weg(wt); }
+	ribi_t::ribi get_ribi(const grund_t* gr) const OVERRIDE { return gr->get_weg_ribi(wt); }
+	waytype_t get_waytype() const OVERRIDE { return wt; }
+	int get_cost(const grund_t*, const weg_t*, const sint32, ribi_t::ribi) const OVERRIDE { return 1; }
+	bool is_target(const grund_t*, const grund_t*) const OVERRIDE { return false; }
+};
+
 class scenario_checker_t : public test_driver_t {
 public:
 	test_driver_t *other;
@@ -3812,9 +3824,7 @@ bool tool_wayremover_t::calc_route( route_t &verbindung, player_t *player, const
 		test_driver_t* test_driver;
 		vehicle_desc_t remover_desc(wt, 500, vehicle_desc_t::diesel ); // must be here even if not needed for powerline
 		if(  wt!=powerline_wt  ) {
-			vehicle_t *driver = vehicle_builder_t::build(start, player, NULL, &remover_desc);
-			driver->set_flag( obj_t::not_on_map );
-			test_driver = driver;
+			test_driver = new way_checker_t(wt);
 		}
 		else {
 			test_driver = new electron_t();

--- a/simtool.cc
+++ b/simtool.cc
@@ -4140,10 +4140,7 @@ bool tool_build_wayobj_t::calc_route( route_t &verbindung, player_t *player, con
 		}
 	}
 	// get a default vehikel
-	vehicle_desc_t remover_desc( waytype, 500, vehicle_desc_t::diesel );
-	vehicle_t* test_vehicle = vehicle_builder_t::build(start, player, NULL, &remover_desc);
-	test_vehicle->set_flag( obj_t::not_on_map );
-	test_driver_t* test_driver = scenario_checker_t::apply(test_vehicle, player, this);
+	test_driver_t *test_driver = new way_checker_t(waytype);
 
 	bool can_built;
 	if( start != to ) {
@@ -5778,10 +5775,8 @@ uint8 tool_build_roadsign_t::is_valid_pos( player_t *player, const koord3d &pos,
 bool tool_build_roadsign_t::calc_route( route_t &verbindung, player_t *player, const koord3d& start, const koord3d& to )
 {
 	// get a default vehikel
-	vehicle_desc_t rs_desc( desc->get_wtyp(), 500, vehicle_desc_t::diesel );
-	vehicle_t* test_vehicle = vehicle_builder_t::build(start, player, NULL, &rs_desc);
-	test_vehicle->set_flag(obj_t::not_on_map);
-	test_driver_t* test_driver = scenario_checker_t::apply(test_vehicle, player, this);
+	waytype_t waytype = desc->get_waytype()==tram_wt? track_wt: desc->get_waytype();
+	test_driver_t *test_driver = new way_checker_t(waytype);
 
 	bool can_built;
 	if( start != to ) {

--- a/simtool.cc
+++ b/simtool.cc
@@ -3822,7 +3822,6 @@ bool tool_wayremover_t::calc_route( route_t &verbindung, player_t *player, const
 	else {
 		// get a default vehikel
 		test_driver_t* test_driver;
-		vehicle_desc_t remover_desc(wt, 500, vehicle_desc_t::diesel ); // must be here even if not needed for powerline
 		if(  wt!=powerline_wt  ) {
 			test_driver = new way_checker_t(wt);
 		}


### PR DESCRIPTION
`way_checker_t`という新しい`test_driver_t`を追加して0km/hのwayを撤去できるようにする方法です
standardと同様