### PR TITLE
tool_pipette_t update:we get way building tool when ctrl pressed

### DIFF
--- a/simtool.cc
+++ b/simtool.cc
@@ -7950,68 +7950,76 @@ const char *tool_pipette_t::work(player_t *pl, koord3d pos)
 	select_and_check(tunnel_t)
 	select_and_check(bruecke_t)
 
-	if (gebaeude_t* gb = gr->find<gebaeude_t>()) {
-		if (const char *err = allow_tool_check(gb, gb->get_tile()->get_desc(), pl)) {
-			return err;
+	if (!gr->get_weg_nr(0)||!is_ctrl_pressed()) {
+		if (gebaeude_t* gb = gr->find<gebaeude_t>()) {
+			if (const char *err = allow_tool_check(gb, gb->get_tile()->get_desc(), pl)) {
+				return err;
+			}
+			const building_desc_t* desc = gb->get_tile()->get_desc();
+			if (!pl->is_public_service()) {
+				// since we are not allowed to create public infrastructure as normal player, we must forbid this too
+				if (desc->is_city_building()  ||  desc->is_attraction()  ||  desc->is_townhall()  ||  desc->is_monument()) {
+					return "Not allowed to copy object.";
+				}
+			}
+			else {
+				if (desc->is_depot()  ||  desc->is_headquarters()  ||  desc->is_townhall()) {
+					return "Not allowed to copy object.";
+				}
+			}
+			// here on factories, monuments, town halls, city buildings and more
+			if (gb->get_fabrik()) {
+				static tool_build_factory_t t = tool_build_factory_t();
+				param_str.clear();
+				param_str.printf("%i%i%i,%s",
+					1, // with climate
+					gb->get_tile()->get_layout(), /*rotation*/
+					gb->get_fabrik()->get_base_production(),
+					gb->get_fabrik()->get_desc()->get_name());
+				t.set_default_param(param_str);
+				t.cursor = tool_t::general_tool[TOOL_BUILD_FACTORY]->cursor;
+				welt->set_tool(&t, pl);
+				return NULL;
+			}
+			else if (desc->is_attraction()  ||  desc->is_city_building()) {
+				static tool_build_house_t t = tool_build_house_t();
+				t.cursor = tool_t::general_tool[TOOL_BUILD_HOUSE]->cursor;
+				param_str.clear();
+				param_str.printf("%d,%s",
+					gb->get_tile()->get_layout(), /*rotation*/
+					gb->get_tile()->get_desc()->get_name());
+				t.set_default_param(param_str);
+				welt->set_tool(&t, pl);
+				return NULL;
+			}
+			else if (tool_t* t = gb->get_tile()->get_desc()->get_builder()) {
+				welt->set_tool(t, pl);
+				return NULL;
+			}
+			return "Not allowed to copy object.";
 		}
-		const building_desc_t* desc = gb->get_tile()->get_desc();
-		if (!pl->is_public_service()) {
-			// since we are not allowed to create public infrastructure as normal player, we must forbid this too
-			if (desc->is_city_building()  ||  desc->is_attraction()  ||  desc->is_townhall()  ||  desc->is_monument()) {
+	}
+
+	if (!is_ctrl_pressed()) {
+		// we do not check depot if ctrl pressed(ctrl -> get way info directly)
+		if (depot_t *depot=gr->get_depot()) {
+			if (pl->is_public_service()) {
 				return "Not allowed to copy object.";
 			}
-		}
-		else {
-			if (desc->is_depot()  ||  desc->is_headquarters()  ||  desc->is_townhall()) {
-				return "Not allowed to copy object.";
-			}
-		}
-		// here on factories, monuments, town halls, city buildings and more
-		if (gb->get_fabrik()) {
-			static tool_build_factory_t t = tool_build_factory_t();
-			param_str.clear();
-			param_str.printf("%i%i%i,%s",
-				1, // with climate
-				gb->get_tile()->get_layout(), /*rotation*/
-				gb->get_fabrik()->get_base_production(),
-				gb->get_fabrik()->get_desc()->get_name());
-			t.set_default_param(param_str);
-			t.cursor = tool_t::general_tool[TOOL_BUILD_FACTORY]->cursor;
-			welt->set_tool(&t, pl);
-			return NULL;
-		}
-		else if (desc->is_attraction()  ||  desc->is_city_building()) {
-			static tool_build_house_t t = tool_build_house_t();
-			t.cursor = tool_t::general_tool[TOOL_BUILD_HOUSE]->cursor;
-			param_str.clear();
-			param_str.printf("%d,%s",
-				gb->get_tile()->get_layout(), /*rotation*/
-				gb->get_tile()->get_desc()->get_name());
-			t.set_default_param(param_str);
-			welt->set_tool(&t, pl);
-			return NULL;
-		}
-		else if (tool_t* t = gb->get_tile()->get_desc()->get_builder()) {
+			tool_t* t = depot->get_tile()->get_desc()->get_builder();
 			welt->set_tool(t, pl);
 			return NULL;
 		}
-		return "Not allowed to copy object.";
-	}
-
-	if (depot_t *depot=gr->get_depot()) {
-		if (pl->is_public_service()) {
-			return "Not allowed to copy object.";
-		}
-		tool_t* t = depot->get_tile()->get_desc()->get_builder();
-		welt->set_tool(t, pl);
-		return NULL;
 	}
 
 	if (gr->get_weg_nr(0)) {
-		// signals > wayobjs > ways
-		select_and_check(signal_t);
-		select_and_check(roadsign_t);
-		select_and_check(wayobj_t);
+		if(!is_ctrl_pressed()) {
+			// signals > wayobjs > ways
+			// if ctrl pressed, we only see way.
+			select_and_check(signal_t);
+			select_and_check(roadsign_t);
+			select_and_check(wayobj_t);
+		}
 		if (tool_t *way_builder = gr->get_weg_nr(0)->get_desc()->get_builder()) {
 			if (const char* err = allow_tool_check(gr->get_weg_nr(0), gr->get_weg_nr(0)->get_desc(), pl)) {
 				return err;


### PR DESCRIPTION
`tool_pipette_t`について、現在は一番上にあるアドオン(線路の上の架線、信号、駅等)を抽出し建設可能にします。そのため、電化路線などで線路を抽出できなくなっています。
`ctrl`キーを押しながら抽出した場合は一番下のアドオン(`way`等)を抽出できるようにします。