### PR TITLE
BUG FIX: scheduled_departure_time is broken when tick is reset

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -1772,6 +1772,11 @@ void convoi_t::new_month()
 	}
 	get_owner()->book_running_costs( sum_fixed_costs, wtyp );
 	jahresgewinn += sum_fixed_costs;
+
+	// update departure slot if ticks is updated (avoid overflow)
+	if(  welt->get_ticks()<welt->ticks_per_world_month && (scheduled_departure_time!=0)  ) {
+		scheduled_departure_time %= welt->ticks_per_world_month;
+	}
 }
 
 
@@ -3698,23 +3703,22 @@ bool can_depart(convoihandle_t cnv, halthandle_t halt, uint32 arrived_time, uint
 		}
 		// consider spacing
 		// subtract wait_lock (time_to_load) from spacing_shift
-		const sint32 spacing_shift = (sint64)current_entry.spacing_shift * world()->ticks_per_world_month / world()->get_settings().get_spacing_shift_divisor();
+		const sint64 spacing_shift = (sint64)current_entry.spacing_shift * world()->ticks_per_world_month / world()->get_settings().get_spacing_shift_divisor();
 		// NOTE: Treating spacing as int causes numerical error due to decimal amount.
 		// const sint32 spacing = world()->ticks_per_world_month / current_entry.spacing;
-		const uint32 delay_tolerance = (uint64)current_entry.delay_tolerance * world()->ticks_per_world_month / world()->get_settings().get_spacing_shift_divisor();
+		const uint64 delay_tolerance = (uint64)current_entry.delay_tolerance * world()->ticks_per_world_month / world()->get_settings().get_spacing_shift_divisor();
 		// slot = (arrived_time - delay_tolerance - spacing_shift) / spacing + 1
 		const sint64 calibrated_arrived_time = (sint64)arrived_time - (sint64)delay_tolerance - (sint64)spacing_shift + (sint64)time_to_load;
-		sint64 slot = (calibrated_arrived_time<0 ?((sint64)(1U<<32)+calibrated_arrived_time) : calibrated_arrived_time) * (sint64)current_entry.spacing / (sint64)world()->ticks_per_world_month + (sint64)1;
+		sint64 slot = calibrated_arrived_time * (sint64)current_entry.spacing / (sint64)world()->ticks_per_world_month + (sint64)(calibrated_arrived_time<0?0:1);
 		// go_on_ticks = slot * spacing + spacing_shift
 		go_on_ticks = slot * world()->ticks_per_world_month / current_entry.spacing + spacing_shift;
 		// book the departure slot.
 		while(  !halt->book_departure(arrived_time, go_on_ticks, go_on_ticks + 2 * world()->ticks_per_world_month / current_entry.spacing, cnv)  ) {
 			// If the reservation request is denied, increment slot.
 			slot++;
-			go_on_ticks = (slot%(1U<<(32-world()->get_settings().get_bits_per_month()))) * world()->ticks_per_world_month / current_entry.spacing + spacing_shift;
+			go_on_ticks = (slot) * world()->ticks_per_world_month / current_entry.spacing + spacing_shift;
 		}
 		go_on_ticks = go_on_ticks == 0 ? go_on_ticks+1:go_on_ticks; // go_on_ticks=0 means this cannot reserve slot!
-		dbg->message("convoi_t::can_depart()","%s reserve %i,%i",cnv->get_name(),go_on_ticks,world()->get_ticks());
 		return is_first_ticks_bigger(world()->get_ticks(), go_on_ticks - time_to_load);
 	}
 
@@ -4167,7 +4171,6 @@ void convoi_t::hat_gehalten(halthandle_t halt, uint32 halt_length_in_vehicle_ste
 
 		// Advance schedule
 		if(  !is_coupled()  ) {
-			dbg->message("convoi_t::hat_gehalten()","%s is depart because departure time arrive: %i, %i",get_name(),scheduled_departure_time,welt->get_ticks());
 			push_goods_waiting_time_if_needed();
 			push_convoy_stopping_time();
 			schedule->advance();

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -3711,8 +3711,9 @@ bool can_depart(convoihandle_t cnv, halthandle_t halt, uint32 arrived_time, uint
 		while(  !halt->book_departure(arrived_time, go_on_ticks, go_on_ticks + 2 * world()->ticks_per_world_month / current_entry.spacing, cnv)  ) {
 			// If the reservation request is denied, increment slot.
 			slot++;
-			go_on_ticks = slot * world()->ticks_per_world_month / current_entry.spacing + spacing_shift;
+			go_on_ticks = (slot%(1U<<(32-world()->get_settings().get_bits_per_month()))) * world()->ticks_per_world_month / current_entry.spacing + spacing_shift;
 		}
+		go_on_ticks = go_on_ticks == 0 ? go_on_ticks+1:go_on_ticks; // go_on_ticks=0 means this cannot reserve slot!
 		return is_first_ticks_bigger(world()->get_ticks(), go_on_ticks - time_to_load);
 	}
 
@@ -4165,6 +4166,7 @@ void convoi_t::hat_gehalten(halthandle_t halt, uint32 halt_length_in_vehicle_ste
 
 		// Advance schedule
 		if(  !is_coupled()  ) {
+			dbg->message("convoi_t::hat_gehalten()","%s is depart because departure time arrive: %i, %i",get_name(),scheduled_departure_time,welt->get_ticks());
 			push_goods_waiting_time_if_needed();
 			push_convoy_stopping_time();
 			schedule->advance();
@@ -4193,8 +4195,8 @@ void convoi_t::hat_gehalten(halthandle_t halt, uint32 halt_length_in_vehicle_ste
 
 	// at least wait the minimum time for loading
 	if(  !is_coupled()  &&  scheduled_departure_time>0  ) {
-		const sint32 ticks_remain = scheduled_departure_time - time - welt->get_ticks();
-		if(  ticks_remain<(sint32)time  ) {
+		const sint64 ticks_remain = (uint64)scheduled_departure_time - (uint64)time - (uint64)welt->get_ticks();
+		if(  ticks_remain<(sint64)time  ) {
 			// this convoy is about to start. we don't want to wait for 2000 ms or more.
 			// just wait for ticks_remain
 			time = max(0, ticks_remain);

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -3622,7 +3622,7 @@ void convoi_t::calc_gewinn()
 sint32 subtract_ticks(uint32 v1, uint32 v2) {
 	const sint64 v1e = (sint64)v1;
 	const sint64 v2e = (sint64)v2;
-	const sint64 uint32_width = UINT32_MAX+1;
+	const sint64 uint32_width = (sint64)UINT32_MAX+1;
 	if(  v2e-v1e>(1<<31)  ) {
 		// assume v1 is over flow
 		return (sint32)(v1e+uint32_width-v2e);
@@ -3714,6 +3714,7 @@ bool can_depart(convoihandle_t cnv, halthandle_t halt, uint32 arrived_time, uint
 			go_on_ticks = (slot%(1U<<(32-world()->get_settings().get_bits_per_month()))) * world()->ticks_per_world_month / current_entry.spacing + spacing_shift;
 		}
 		go_on_ticks = go_on_ticks == 0 ? go_on_ticks+1:go_on_ticks; // go_on_ticks=0 means this cannot reserve slot!
+		dbg->message("convoi_t::can_depart()","%s reserve %i,%i",cnv->get_name(),go_on_ticks,world()->get_ticks());
 		return is_first_ticks_bigger(world()->get_ticks(), go_on_ticks - time_to_load);
 	}
 

--- a/simhalt.cc
+++ b/simhalt.cc
@@ -1397,6 +1397,16 @@ void haltestelle_t::new_month()
 	}
 	// number of waiting should be constant ...
 	financial_history[0][HALT_WAITING] = financial_history[1][HALT_WAITING];
+
+	// update departure slot if ticks is updated (avoid overflow)
+	if(  welt->get_ticks()<welt->ticks_per_world_month  ) {
+		for (uint32 i = 0; i < DST_SIZE; ++i) {
+			for (departure_t &slot : departure_slot_table[i]) {
+				slot.dep_tick %= welt->ticks_per_world_month;
+				slot.exp_tick %= welt->ticks_per_world_month;
+			}
+		}
+	}
 }
 
 


### PR DESCRIPTION
`ticks`がリセットされる際に、出発時刻が狂う不具合を修正しました
- `ticks`をリセットする際に、`haltestelle_t::departure_t`および`convoi_t::scheduled_departure_time`を同様にリセットする(`ticks`は`uint32`の全ての値を使い切る前にリセットされるため)
- `convoi_t::can_depart()`において、負の数を扱う際の`slot`計算を修正