### PR TITLE
base offset of cars are set in env_t

### DIFF
--- a/dataobj/environment.cc
+++ b/dataobj/environment.cc
@@ -632,6 +632,13 @@ void env_t::rdwr(loadsave_t *file)
 	// and could be different on different servers on the same computers
 }
 
+// Graphical offsets for cars driving left
+// the reading method is in setting_t, and these parameters are used in vehicle_t.
+sint8 env_t::driveleft_base_offsets[8][2];
+// Graphical offsets for overtaking vehicles
+// the reading method is in setting_t, and these parameters are used in vehicle_t.
+sint8 env_t::overtaking_base_offsets[8][2];
+
 // Graphical offsets for reverseing vehicles
 // the reading method is in setting_t, and these parameters are used in vehicle_t.
 sint8 env_t::reverse_base_offsets[8][3];

--- a/dataobj/environment.h
+++ b/dataobj/environment.h
@@ -532,6 +532,12 @@ public:
 
 	static bool send_tax_public;
 
+	// drivelelft offset
+	static sint8 driveleft_base_offsets[8][2];
+
+	// overtaking offset
+	static sint8 overtaking_base_offsets[8][2];
+
 	// Graphical offsets for reverseing vehicles
 	// [directions][offsets]
 	// directions:{"south", "west", "southwest", "southeast", "north", "east", "northeast", "northwest"}

--- a/dataobj/settings.cc
+++ b/dataobj/settings.cc
@@ -1141,6 +1141,40 @@ void settings_t::parse_simuconf( tabfile_t& simuconf, sint16& disp_width, sint16
 	// setting default reverse or not when next direction is opposite
 	default_reverse = contents.get_int( "reverse_by_default", default_reverse )!=0;
 
+	// setting driving left and overtaking offsets
+	// a tile has the internal size of
+	const sint8 default_xoff = 12;
+	const sint8 default_yoff = 6;
+	const sint8 default_xoffs[8] = {1,-1,0,1,-1,1,0,-1};
+	const sint8 default_yoffs[8] = {1,1,1,0,-1,-1,-1,0};
+	for(uint8 d_idx = 0; d_idx < 8; d_idx++) {
+		char buf[64];
+		sprintf(buf, "driveleft_base_offset_%s", directions[d_idx]);
+		vector_tpl<int> temp_offset = contents.get_ints(buf);
+		if (temp_offset.get_count()>=2) {
+			for(uint8 i=0; i<2; i++) {
+				env_t::driveleft_base_offsets[d_idx][i] = temp_offset[i];
+			}
+		} else {
+			env_t::driveleft_base_offsets[d_idx][0] = default_xoff*default_xoffs[d_idx];
+			env_t::driveleft_base_offsets[d_idx][1] = default_yoff*default_yoffs[d_idx];
+		}
+	}
+	for(uint8 d_idx = 0; d_idx < 8; d_idx++) {
+		char buf[64];
+		sprintf(buf, "overtaking_base_offset_%s", directions[d_idx]);
+		vector_tpl<int> temp_offset = contents.get_ints(buf);
+		if (temp_offset.get_count()>=2) {
+			for(uint8 i=0; i<2; i++) {
+				env_t::overtaking_base_offsets[d_idx][i] = temp_offset[i];
+			}
+		} else {
+			// if not defined, it should be same as driveleft base offset.
+			for(uint8 i=0; i<2; i++) {
+				env_t::overtaking_base_offsets[d_idx][i] = env_t::driveleft_base_offsets[d_idx][i];
+			}
+		}
+	}
 
 	// network stuff
 	env_t::server_frames_ahead              = contents.get_int_clamped( "server_frames_ahead",             env_t::server_frames_ahead,              0, INT_MAX );

--- a/vehicle/simroadtraffic.cc
+++ b/vehicle/simroadtraffic.cc
@@ -1407,8 +1407,8 @@ void private_car_t::get_screen_offset( int &xoff, int &yoff, const sint16 raster
 
 	if(  welt->get_settings().is_drive_left()  ) {
 		const int drive_left_dir = ribi_t::get_dir(get_direction());
-		xoff += tile_raster_scale_x( driveleft_base_offsets[drive_left_dir][0], raster_width );
-		yoff += tile_raster_scale_y( driveleft_base_offsets[drive_left_dir][1], raster_width );
+		xoff += tile_raster_scale_x( env_t::driveleft_base_offsets[drive_left_dir][0], raster_width );
+		yoff += tile_raster_scale_y( env_t::driveleft_base_offsets[drive_left_dir][1], raster_width );
 	}
 
 	// eventually shift position to take care of overtaking

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -105,46 +105,18 @@ bool vehicle_base_t::need_realignment() const
 }
 
 // [0]=xoff [1]=yoff
-sint8 vehicle_base_t::driveleft_base_offsets[8][2] =
-{
-	{  12,  6 },
-	{ -12,  6 },
-	{   0,  6 },
-	{  12,  0 },
-	{ -12, -6 },
-	{  12, -6 },
-	{   0, -6 },
-	{ -12,  0 }
-};
-
-// [0]=xoff [1]=yoff
 sint8 vehicle_base_t::overtaking_base_offsets[8][2];
 
 // recalc offsets for overtaking
 void vehicle_base_t::set_overtaking_offsets( bool driving_on_the_left )
 {
 	sint8 sign = driving_on_the_left ? -1 : 1;
-	// a tile has the internal size of
-	const sint8 XOFF=12;
-	const sint8 YOFF=6;
-
-	overtaking_base_offsets[0][0] = sign * XOFF;
-	overtaking_base_offsets[1][0] = -sign * XOFF;
-	overtaking_base_offsets[2][0] = 0;
-	overtaking_base_offsets[3][0] = sign * XOFF;
-	overtaking_base_offsets[4][0] = -sign * XOFF;
-	overtaking_base_offsets[5][0] = sign * XOFF;
-	overtaking_base_offsets[6][0] = 0;
-	overtaking_base_offsets[7][0] = -sign * XOFF;
-
-	overtaking_base_offsets[0][1] = sign * YOFF;
-	overtaking_base_offsets[1][1] = sign * YOFF;
-	overtaking_base_offsets[2][1] = sign * YOFF;
-	overtaking_base_offsets[3][1] = 0;
-	overtaking_base_offsets[4][1] = -sign * YOFF;
-	overtaking_base_offsets[5][1] = -sign * YOFF;
-	overtaking_base_offsets[6][1] = -sign * YOFF;
-	overtaking_base_offsets[7][1] = 0;
+	
+	for(uint8 d_idx=0; d_idx<8; d_idx++) {
+		for(uint8 i=0; i<2; i++) {
+			overtaking_base_offsets[d_idx][i]=sign*env_t::overtaking_base_offsets[d_idx][i];
+		}
+	}
 }
 
 
@@ -2314,8 +2286,8 @@ void road_vehicle_t::get_screen_offset( int &xoff, int &yoff, const sint16 raste
 
 	if(  welt->get_settings().is_drive_left()  ) {
 		const int drive_left_dir = ribi_t::get_dir(get_direction());
-		xoff += tile_raster_scale_x( driveleft_base_offsets[drive_left_dir][0], raster_width );
-		yoff += tile_raster_scale_y( driveleft_base_offsets[drive_left_dir][1], raster_width );
+		xoff += tile_raster_scale_x( env_t::driveleft_base_offsets[drive_left_dir][0], raster_width );
+		yoff += tile_raster_scale_y( env_t::driveleft_base_offsets[drive_left_dir][1], raster_width );
 	}
 
 	// eventually shift position to take care of overtaking

--- a/vehicle/simvehicle.h
+++ b/vehicle/simvehicle.h
@@ -46,7 +46,6 @@ protected:
 	static uint16 diagonal_multiplier;
 
 	// [0]=xoff [1]=yoff
-	static sint8 driveleft_base_offsets[8][2];
 	static sint8 overtaking_base_offsets[8][2];
 
 	/**


### PR DESCRIPTION
`driveleft_base_offset`および`overtaking_base_offset`を`env_t`に移動し、`simuconf.tab`で設定可能にしました