### PR TITLE
set margin of the stop length of choosing

### DIFF
--- a/dataobj/route.cc
+++ b/dataobj/route.cc
@@ -115,7 +115,7 @@ bool route_t::node_in_use=false;
 /**
  * find the route to an unknown location
  */
-bool route_t::find_route(karte_t *welt, const koord3d start, test_driver_t *tdriver, const uint32 max_khm, uint8 start_dir, uint32 max_depth, bool need_electric, bool coupling )
+bool route_t::find_route(karte_t *welt, const koord3d start, test_driver_t *tdriver, const uint32 max_khm, uint8 start_dir, uint32 max_depth, bool need_electric, bool coupling, const uint8 choose_margin )
 {
 	bool ok = false;
 
@@ -198,7 +198,7 @@ bool route_t::find_route(karte_t *welt, const koord3d start, test_driver_t *tdri
 			already_there = tdriver->is_coupling_target( gr, tmp->parent==NULL ? NULL : tmp->parent->gr);
 		} else {
 			// normal routine.
-			already_there = tdriver->is_target( gr, tmp->parent==NULL ? NULL : tmp->parent->gr, need_electric );
+			already_there = tdriver->is_target( gr, tmp->parent==NULL ? NULL : tmp->parent->gr, need_electric, choose_margin );
 		}
 		if(  already_there  ) {
 			// we added a target to the closed list: check for length

--- a/dataobj/route.h
+++ b/dataobj/route.h
@@ -136,7 +136,7 @@ public:
 	 * Finds route to a location, where @p tdriver->is_target becomes true.
 	 * @param max_depth is the maximum length of a route
 	 */
-	bool find_route(karte_t *w, const koord3d start, test_driver_t *tdriver, const uint32 max_khm, uint8 start_dir, uint32 max_depth, const bool need_electric, bool coupling = false);
+	bool find_route(karte_t *w, const koord3d start, test_driver_t *tdriver, const uint32 max_khm, uint8 start_dir, uint32 max_depth, const bool need_electric, bool coupling = false, const uint8 choose_margin=0 );
 
 	/**
 	 * Calculates the route from @p start to @p target

--- a/gui/signal_info.cc
+++ b/gui/signal_info.cc
@@ -33,6 +33,23 @@ signal(s)
 		add_component(&bt_choose_signal);
 	}
 
+	add_table(2,0);
+	{
+		lb_tiles_margin.set_text("Margin");
+		lb_tiles_margin.set_tooltip("tiles length of the margin to stop when choosing. Set this margin to the stop side(advance to end->end side)");
+		numinp_tiles_margin.set_width(50);
+		numinp_tiles_margin.set_height(5);
+		numinp_tiles_margin.set_limits(0,200);
+		numinp_tiles_margin.set_increment_mode(1);
+		numinp_tiles_margin.disable();
+		numinp_tiles_margin.add_listener(this);
+		if(signal->get_desc()->is_choose_sign()  &&  !welt->get_settings().get_advance_to_end()) {
+			add_component(&lb_tiles_margin);
+			add_component(&numinp_tiles_margin);
+		}
+	}
+	end_table();
+
 	bt_remove_signal.init( button_t::roundbox, translator::translate("remove signal"));
 	bt_remove_signal.enable( !signal->is_deletable( welt->get_active_player() ) );
 	bt_remove_signal.add_listener(this);
@@ -40,9 +57,10 @@ signal(s)
 	
 	reset_min_windowsize();
 	set_windowsize(get_min_windowsize() );
+	update_data();
 }
 
-bool signal_info_t::action_triggered( gui_action_creator_t* comp, value_t /* */)
+bool signal_info_t::action_triggered( gui_action_creator_t* comp, value_t p)
 {
 	if(  comp==&bt_remove_signal  ) {
 		bool suspended_execution=false;
@@ -79,6 +97,13 @@ bool signal_info_t::action_triggered( gui_action_creator_t* comp, value_t /* */)
 		welt->set_tool( tool_t::simple_tool[TOOL_CHANGE_ROADSIGN], welt->get_active_player() );
 		return true;
 	}
+	if(  comp==&numinp_tiles_margin  ) {
+		char param[256];
+		sprintf( param, "%s,%i,m,", signal->get_pos().get_str(), (uint8)p.i );
+		tool_t::simple_tool[TOOL_CHANGE_ROADSIGN]->set_default_param( param );
+		welt->set_tool( tool_t::simple_tool[TOOL_CHANGE_ROADSIGN], welt->get_active_player() );
+		return true;
+	}
 	return false;
 }
 
@@ -91,8 +116,11 @@ void signal_info_t::update_data()
 	bt_choose_signal.pressed = signal->is_choose_signal();
 	if(  signal->is_choose_signal()  ) {
 		bt_advance_to_end.enable();
+		numinp_tiles_margin.enable();
+		numinp_tiles_margin.set_value(signal->get_margin_length());
 	} else {
 		bt_advance_to_end.disable();
+		numinp_tiles_margin.disable();
 	}
 	bt_remove_signal.enable( !signal->is_deletable( welt->get_active_player() ) );
 }

--- a/gui/signal_info.h
+++ b/gui/signal_info.h
@@ -5,6 +5,8 @@
 #include "components/action_listener.h"
 #include "components/gui_button.h"
 #include "components/gui_container.h"
+#include "components/gui_numberinput.h"
+#include "components/gui_label.h"
 
 class signal_t;
 
@@ -16,6 +18,8 @@ class signal_info_t : public obj_infowin_t, public action_listener_t
 	private:
 		signal_t* signal;
 		button_t bt_require_parent, bt_remove_signal, bt_advance_to_end, bt_choose_signal;
+		gui_numberinput_t numinp_tiles_margin;	
+		gui_label_t lb_tiles_margin;
 
 	public:
 		signal_info_t(signal_t*);

--- a/ifc/simtestdriver.h
+++ b/ifc/simtestdriver.h
@@ -47,7 +47,7 @@ public:
 	// returns true for the way search to an unknown target.
 	// first is current ground, second is starting ground
 	virtual bool is_target(const grund_t *,const grund_t *) const = 0;
-	virtual bool is_target(const grund_t *gr, const grund_t *prev_gr, const bool need_electric) const {return is_target(gr, prev_gr);}
+	virtual bool is_target(const grund_t *gr, const grund_t *prev_gr, const bool need_electric, const uint8 choose_margin) const {return is_target(gr, prev_gr);}
 	
 	virtual bool is_coupling_target(const grund_t *, const grund_t *) const { return 0; }
 

--- a/obj/roadsign.cc
+++ b/obj/roadsign.cc
@@ -93,6 +93,7 @@ roadsign_t::roadsign_t(player_t *player, koord3d pos, ribi_t::ribi dir, const ro
 		set_end_of_choose(true);
 		set_end_of_guide(true);
 	}
+	choose_signal_margin_length=0;
 	ticks_yellow_ns = ticks_yellow_ow = 2;
 	set_owner( player );
 	if(  desc->is_private_way()  ) {
@@ -688,6 +689,11 @@ void roadsign_t::rdwr(loadsave_t *file)
 		set_advance_to_end(true);
 		set_end_of_choose(true);
 		set_end_of_guide(true);
+	}
+	if(file->get_OTRP_version()>=51) {
+		file->rdwr_byte(choose_signal_margin_length);
+	} else {
+		choose_signal_margin_length = 0;
 	}
 
 	if(file->is_saving()) {

--- a/obj/roadsign.h
+++ b/obj/roadsign.h
@@ -50,6 +50,8 @@ protected:
 		end_of_guide   = 1U<<4 // end of guide signal (for searching coupling target)
 	};
 
+	uint8 choose_signal_margin_length;
+
 	sint8 after_yoffset, after_xoffset;
 
 	// 0 = not fixed, 1 = only fix left lane, 2 = only fix right lane, 3 = fix both lane, 4 = not applied
@@ -178,6 +180,8 @@ public:
 	bool is_flag_end_of_guide() const { return (choose_sign_flag&end_of_guide)>0; }
 	void set_end_of_guide(bool tf) { tf? choose_sign_flag|=end_of_guide:choose_sign_flag&=~end_of_guide; }
 	uint8 const get_choose_sign_flag() {return choose_sign_flag;}
+	uint8 const get_margin_length() {return choose_signal_margin_length;}
+	void set_margin_length(uint8 i) {choose_signal_margin_length=i;}
 	/**
 	* draw the part overlapping the vehicles
 	* (needed to get the right offset even on hills)

--- a/simtool.cc
+++ b/simtool.cc
@@ -9368,6 +9368,7 @@ bool tool_change_traffic_light_t::init( player_t *player )
  * a:set advance to end state for signal
  * c:set end of choose signal
  * g:set end of guide signal
+ * m:set margin of the stoplength of choose signal
  * 
  */
 bool tool_change_roadsign_t::init( player_t* )
@@ -9450,6 +9451,20 @@ bool tool_change_roadsign_t::init( player_t* )
 			if( roadsign_t *rs = gr->find<roadsign_t>()  ) {
 				if(  rs->get_waytype()!=road_wt && rs->get_waytype()!=water_wt && rs->get_waytype()!=air_wt  ) {
 					rs->set_end_of_guide(inst);
+					end_of_choose_info_t* signal_info_win = (end_of_choose_info_t*)win_get_magic((ptrdiff_t)rs);
+					if(  signal_info_win  ) {
+						signal_info_win->update_data();
+					}
+				}
+			}
+		}
+		break;
+
+		case 'm':
+		if(  grund_t *gr = welt->lookup(pos)  ) {
+			if( roadsign_t *rs = gr->find<signal_t>()  ) {
+				if(  rs->get_waytype()!=road_wt && rs->get_waytype()!=water_wt && rs->get_waytype()!=air_wt  ) {
+					rs->set_margin_length((uint8)inst);
 					end_of_choose_info_t* signal_info_win = (end_of_choose_info_t*)win_get_magic((ptrdiff_t)rs);
 					if(  signal_info_win  ) {
 						signal_info_win->update_data();

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -3486,7 +3486,7 @@ int rail_vehicle_t::get_cost(const grund_t *gr, const weg_t *w, const sint32 max
 
 
 // this routine is called by find_route, to determined if we reached a destination
-bool rail_vehicle_t::is_target(const grund_t *gr,const grund_t *prev_gr, const bool need_electric) const
+bool rail_vehicle_t::is_target(const grund_t *gr,const grund_t *prev_gr, const bool need_electric, const uint8 choose_margin) const
 {
 	const schiene_t * sch1 = (const schiene_t *) gr->get_weg(get_waytype());
 	// first check blocks, if we can go there
@@ -3524,7 +3524,7 @@ bool rail_vehicle_t::is_target(const grund_t *gr,const grund_t *prev_gr, const b
 	}
 	// end of stop: Is it long enough?
 	const uint32 available_halt_length = cnv->calc_available_halt_length_in_vehicle_steps(gr->get_pos(), ribi); // 256 units per a straight tile
-	return available_halt_length >= ((uint32)cnv->get_entire_convoy_length()) << 4;
+	return available_halt_length >= (((uint32)cnv->get_entire_convoy_length()) << 4)+(uint32)choose_margin*VEHICLE_STEPS_PER_TILE;
 }
 
 // this routine is called by find_route, to determined if we reached a coupling point
@@ -3856,11 +3856,22 @@ skip_choose:
 			if(  !try_coupling  &&  !welt->get_settings().get_advance_to_end()  &&  target_rt.get_count()>2  &&  !sig->is_advance_to_end()  ) {
 				uint32 stop_length = convoi_t::calc_available_halt_length_in_vehicle_steps(target_rt.at(target_rt.get_count()-1),ribi_type(target_rt.at(target_rt.get_count()-1)-target_rt.at(target_rt.get_count()-2)),get_waytype());
 				stop_length -= ribi_t::is_bend(welt->lookup(target_rt.at(target_rt.get_count()-1))->get_weg(get_waytype())->get_ribi_unmasked())? diagonal_vehicle_steps_per_tile/2: VEHICLE_STEPS_PER_TILE;
-				while(  stop_length>=cnv->get_entire_convoy_length()*VEHICLE_STEPS_PER_CARUNIT  ) {
+				while(  stop_length>=cnv->get_entire_convoy_length()*VEHICLE_STEPS_PER_CARUNIT+sig->get_margin_length()*VEHICLE_STEPS_PER_TILE  ) {
 					target_rt.remove_koord_from(max(0,target_rt.get_count()-2));
 					stop_length -= ribi_t::is_bend(welt->lookup(target_rt.at(target_rt.get_count()-1))->get_weg(get_waytype())->get_ribi_unmasked())? diagonal_vehicle_steps_per_tile: VEHICLE_STEPS_PER_TILE;
 				}
 			} 
+			else if(  !try_coupling  &&  !welt->get_settings().get_advance_to_end()  &&  target_rt.get_count()>2  &&  sig->get_margin_length()>0  ) {
+				// advance to end but with margin.
+				uint32 margin_length=sig->get_margin_length()*VEHICLE_STEPS_PER_TILE;
+				// this calculation is with margin length>0, so remove end tile first.
+				target_rt.remove_koord_from(max(0,target_rt.get_count()-2));
+				margin_length -= ribi_t::is_bend(welt->lookup(target_rt.at(target_rt.get_count()-1))->get_weg(get_waytype())->get_ribi_unmasked())? diagonal_vehicle_steps_per_tile/2: VEHICLE_STEPS_PER_TILE;
+				while(  margin_length>0  ) {
+					target_rt.remove_koord_from(max(0,target_rt.get_count()-2));
+					margin_length -= ribi_t::is_bend(welt->lookup(target_rt.at(target_rt.get_count()-1))->get_weg(get_waytype())->get_ribi_unmasked())? diagonal_vehicle_steps_per_tile: VEHICLE_STEPS_PER_TILE;
+				}
+			}
 			// broadcast new route
 			convoihandle_t c = cnv->self;
 			while(  c.is_bound()  ) {

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -3824,20 +3824,21 @@ skip_choose:
 		const int richtung = ribi_type(cnv->get_route()->at(start_block),cnv->get_route()->at(start_block<cnv->get_route()->get_count()-1?start_block+1:start_block));	// to avoid confusion at diagonals
 		if(  try_coupling  ) {
 			// search for coupling point.
-			route_found = target_rt.find_route( welt, cnv->get_route()->at(start_block), this, speed_to_kmh(cnv->get_min_top_speed()), richtung, welt->get_settings().get_max_choose_route_steps(), cnv->is_electrification(), true );
+			route_found = target_rt.find_route( welt, cnv->get_route()->at(start_block), this, speed_to_kmh(cnv->get_min_top_speed()), richtung, welt->get_settings().get_max_choose_route_steps(), cnv->is_electrification(), true, 0 );
 			cnv->set_use_electric(cnv->is_electrification());
 			if (  !route_found  ) {
-				route_found = target_rt.find_route( welt, cnv->get_route()->at(start_block), this, speed_to_kmh(cnv->get_min_top_speed()), richtung, welt->get_settings().get_max_choose_route_steps(), cnv->needs_electrification(), true );
+				route_found = target_rt.find_route( welt, cnv->get_route()->at(start_block), this, speed_to_kmh(cnv->get_min_top_speed()), richtung, welt->get_settings().get_max_choose_route_steps(), cnv->needs_electrification(), true, 0 );
 				if(  route_found  ) {
 					cnv->set_use_electric(false);
 				}
 			}
 		}
 		if(  !route_found  &&  (!sig->is_guide_signal()  ||  !try_coupling)  ) {
-			route_found = target_rt.find_route( welt, cnv->get_route()->at(start_block), this, speed_to_kmh(cnv->get_min_top_speed()), richtung, welt->get_settings().get_max_choose_route_steps(), cnv->is_electrification(), false );
+			const uint8 margin_length=sig->get_margin_length();
+			route_found = target_rt.find_route( welt, cnv->get_route()->at(start_block), this, speed_to_kmh(cnv->get_min_top_speed()), richtung, welt->get_settings().get_max_choose_route_steps(), cnv->is_electrification(), false, margin_length );
 			cnv->set_use_electric(cnv->is_electrification());
 			if(  !route_found  ) {
-				route_found = target_rt.find_route( welt, cnv->get_route()->at(start_block), this, speed_to_kmh(cnv->get_min_top_speed()), richtung, welt->get_settings().get_max_choose_route_steps(), cnv->needs_electrification(), false );
+				route_found = target_rt.find_route( welt, cnv->get_route()->at(start_block), this, speed_to_kmh(cnv->get_min_top_speed()), richtung, welt->get_settings().get_max_choose_route_steps(), cnv->needs_electrification(), false, margin_length );
 				if(  route_found  ) {
 					cnv->set_use_electric(false);
 				}
@@ -3863,13 +3864,13 @@ skip_choose:
 			} 
 			else if(  !try_coupling  &&  !welt->get_settings().get_advance_to_end()  &&  target_rt.get_count()>2  &&  sig->get_margin_length()>0  ) {
 				// advance to end but with margin.
-				uint32 margin_length=sig->get_margin_length()*VEHICLE_STEPS_PER_TILE;
+				sint32 margin_length=sig->get_margin_length()*VEHICLE_STEPS_PER_TILE;
 				// this calculation is with margin length>0, so remove end tile first.
-				target_rt.remove_koord_from(max(0,target_rt.get_count()-2));
 				margin_length -= ribi_t::is_bend(welt->lookup(target_rt.at(target_rt.get_count()-1))->get_weg(get_waytype())->get_ribi_unmasked())? diagonal_vehicle_steps_per_tile/2: VEHICLE_STEPS_PER_TILE;
+				target_rt.remove_koord_from(max(0,target_rt.get_count()-2));
 				while(  margin_length>0  ) {
-					target_rt.remove_koord_from(max(0,target_rt.get_count()-2));
 					margin_length -= ribi_t::is_bend(welt->lookup(target_rt.at(target_rt.get_count()-1))->get_weg(get_waytype())->get_ribi_unmasked())? diagonal_vehicle_steps_per_tile: VEHICLE_STEPS_PER_TILE;
+					target_rt.remove_koord_from(max(0,target_rt.get_count()-2));
 				}
 			}
 			// broadcast new route

--- a/vehicle/simvehicle.h
+++ b/vehicle/simvehicle.h
@@ -587,8 +587,8 @@ public:
 	uint32 get_cost_upslope() const OVERRIDE { return 25; }
 
 	// returns true for the way search to an unknown target.
-	bool is_target(const grund_t*, const grund_t*, const bool) const OVERRIDE;
-	bool is_target(const grund_t *gr,const grund_t *prev_gr) const OVERRIDE {return is_target(gr,prev_gr);}
+	bool is_target(const grund_t*, const grund_t*, const bool, const uint8) const OVERRIDE;
+	bool is_target(const grund_t *gr,const grund_t *prev_gr) const OVERRIDE {return is_target(gr,prev_gr,false,0);}
 	bool is_coupling_target(const grund_t *, const grund_t *) const OVERRIDE;
 
 	// handles all block stuff and route choosing ...


### PR DESCRIPTION
振分信号に置いて、詰めて停車する際に指定したタイル数分余裕をもって停車できるようにします。(Default:0tiles)
- `advance_to_end==true`の場合は終端側に余裕を空けて停車します。
- `advance_to_end==false`の場合は手前側に余裕を空けて停車します。
※`settings().advance_to_end==true`の場合は本機能は利用できません。