### PR TITLE
BUG FIX: add temp_load/unload stops to destination_halts

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -3790,7 +3790,7 @@ uint32 convoi_t::calc_available_halt_length_in_vehicle_steps(koord3d front_vehic
 // A sub routine of hat_gehalten()
 // Calculate the reachable halts from the current stop of the given convoy, considering the convoy state.
 // Results are stored in reachable_halts.
-void calc_reachable_halts(vector_tpl<haltestelle_t::reachable_halt_t>& reachable_halts, convoihandle_t cnv) {
+void calc_reachable_halts(vector_tpl<haltestelle_t::reachable_halt_t>& reachable_halts, vector_tpl<haltestelle_t::reachable_halt_t>& temp_stop_halts, convoihandle_t cnv) {
 	reachable_halts.clear();
 	const schedule_t* schedule = cnv->get_schedule();
 	const schedule_t* line_schedule = cnv->get_line().is_bound() ? cnv->get_line()->get_schedule() : schedule;
@@ -3799,6 +3799,7 @@ void calc_reachable_halts(vector_tpl<haltestelle_t::reachable_halt_t>& reachable
 		// Nothing is allowed to load here.
 		return;
 	}
+	const bool temporary_load = schedule->get_current_entry().is_temp_load();
 
 	const halthandle_t current_halt = haltestelle_t::get_stoppable_halt(schedule->get_current_entry().pos, owner, cnv->front()->get_waytype());
 	const uint8 schedule_count = schedule->get_count();
@@ -3861,6 +3862,9 @@ void calc_reachable_halts(vector_tpl<haltestelle_t::reachable_halt_t>& reachable
 		// when something irregular happens on a single convoy.
 		journey_time += line_schedule->get_median_journey_time(wrap_i, cnv->get_speedbonus_kmh());
 		reachable_halts.append(haltestelle_t::reachable_halt_t(plan_halt, (uint32)max(journey_time, 0)));
+		if(  temporary_load  ||  line_schedule->at(wrap_i).is_temp_unload()  ) {
+			temp_stop_halts.append(haltestelle_t::reachable_halt_t(plan_halt, 0));
+		}
 		if(  line_schedule->at(wrap_i).is_unload_all()  ) {
 			// passengers/cargos cannot keep boarding beyond this stop.
 			break;
@@ -3966,9 +3970,10 @@ void convoi_t::hat_gehalten(halthandle_t halt, uint32 halt_length_in_vehicle_ste
 	}
 
 	vector_tpl<haltestelle_t::reachable_halt_t> reachable_halts;
-	calc_reachable_halts(reachable_halts, self);
+	vector_tpl<haltestelle_t::reachable_halt_t> temp_stop_halts;
+	calc_reachable_halts(reachable_halts, temp_stop_halts, self);
 	inthashtable_tpl<uint8, vector_tpl<halthandle_t>> destination_halts;
-	halt->calc_destination_halt(destination_halts, reachable_halts, goods_catg_index, self);
+	halt->calc_destination_halt(destination_halts, reachable_halts, temp_stop_halts, goods_catg_index, self);
 
 	// fetch fresh cargos.
 	if(  loading_needed  ) {
@@ -5474,9 +5479,10 @@ bool convoi_t::is_users_at_next_stop() const{
 	}
 	if(  !get_schedule()->get_current_entry().is_no_load()  ) {
 		vector_tpl<haltestelle_t::reachable_halt_t> reachable_halts;
-		calc_reachable_halts(reachable_halts, self);
+		vector_tpl<haltestelle_t::reachable_halt_t> temp_stop_halts;
+		calc_reachable_halts(reachable_halts, temp_stop_halts, self);
 		inthashtable_tpl<uint8, vector_tpl<halthandle_t>> destination_halts;
-		halt->calc_destination_halt(destination_halts, reachable_halts, goods_catg_index, self);
+		halt->calc_destination_halt(destination_halts, reachable_halts, temp_stop_halts, goods_catg_index, self);
 
 		// fetch fresh cargos.
 		FOR(minivec_tpl<uint8>, category_idx, goods_catg_index) {

--- a/simhalt.cc
+++ b/simhalt.cc
@@ -4645,7 +4645,7 @@ bool unregistered_journey_time_exists(const schedule_t* schedule, player_t* play
 }
 
 
-void haltestelle_t::calc_destination_halt(inthashtable_tpl<uint8, vector_tpl<halthandle_t>> &destination_halts, const vector_tpl<reachable_halt_t> &reachable_halts, const minivec_tpl<uint8> &goods_category_indexes, convoihandle_t cnv) {
+void haltestelle_t::calc_destination_halt(inthashtable_tpl<uint8, vector_tpl<halthandle_t>> &destination_halts, const vector_tpl<reachable_halt_t> &reachable_halts, const vector_tpl<reachable_halt_t> &temp_stop_halts, const minivec_tpl<uint8> &goods_category_indexes, convoihandle_t cnv) {
 	// initialize destination_halts
 	destination_halts.clear();
 	FOR(const minivec_tpl<uint8>, const& i, goods_category_indexes) {
@@ -4666,6 +4666,10 @@ void haltestelle_t::calc_destination_halt(inthashtable_tpl<uint8, vector_tpl<hal
 		// Temporary schedule or route cost is used -> Accept all halts.
 		if(  accept_all_halts  ||  !welt->get_settings().get_time_based_routing_enabled(i)  ) {
 			FOR(const vector_tpl<reachable_halt_t>, const& rh, reachable_halts) {
+				destination_halts.access(i)->append(rh.halt);
+			}
+		} else {
+			FOR(const vector_tpl<reachable_halt_t>, const& rh, temp_stop_halts) {
 				destination_halts.access(i)->append(rh.halt);
 			}
 		}

--- a/simhalt.h
+++ b/simhalt.h
@@ -778,7 +778,7 @@ public:
 	 * @param goods_category_indexes The list of goods category indexes.
 	 * @param cnv The convoy which is requesting the destination halts.
 	 */
-	void calc_destination_halt(inthashtable_tpl<uint8, vector_tpl<halthandle_t>> &destination_halts, const vector_tpl<reachable_halt_t> &reachable_halts, const minivec_tpl<uint8> &goods_category_indexes, convoihandle_t cnv);
+	void calc_destination_halt(inthashtable_tpl<uint8, vector_tpl<halthandle_t>> &destination_halts, const vector_tpl<reachable_halt_t> &reachable_halts, const vector_tpl<reachable_halt_t> &temp_stop_halts, const minivec_tpl<uint8> &goods_category_indexes, convoihandle_t cnv);
 
 	struct loadable_fresh_goods_t {
 		ware_t::goods_amount_t amount;


### PR DESCRIPTION
臨時乗車/臨時降車駅について、`destination_halts`に無条件で追加します
これにより、所要時間ベースにおける臨時乗車駅・臨時降車駅についてはその編成が最速編成でなくても乗降が可能になります。