### PR TITLE
add terminal speed in convoi_detail_t

### DIFF
--- a/gui/convoi_detail_t.cc
+++ b/gui/convoi_detail_t.cc
@@ -183,12 +183,7 @@ void convoi_detail_t::init(convoihandle_t cnv)
 	}
 	end_table();
 
-	add_table(2,1);
-	{
-		add_component(&label_odometer);
-		add_component(&label_balance_speed_kmh);
-	}
-	end_table();
+	add_component(&label_odometer);
 
 	add_component(&label_length);
 
@@ -228,11 +223,11 @@ void convoi_detail_t::init(convoihandle_t cnv)
 	end_table();
 
 	set_table_layout(1,0);
-	add_table(3,1);
+	add_table(4,1);
 	{
 		add_component(&label_speed);
 
-		new_component<gui_fill_t>();
+		add_component(&label_balance_speed_kmh);
 
 		add_table(2,1)->set_force_equal_columns(true);
 		{

--- a/gui/convoi_detail_t.cc
+++ b/gui/convoi_detail_t.cc
@@ -183,7 +183,12 @@ void convoi_detail_t::init(convoihandle_t cnv)
 	}
 	end_table();
 
-	add_component(&label_odometer);
+	add_table(2,1);
+	{
+		add_component(&label_odometer);
+		add_component(&label_balance_speed_kmh);
+	}
+	end_table();
 
 	add_component(&label_length);
 
@@ -287,6 +292,18 @@ void convoi_detail_t::update_labels()
 	number_to_string( number, (double)cnv->get_total_distance_traveled(), 0 );
 	label_odometer.buf().printf(translator::translate("Odometer: %s km"), number );
 	label_odometer.update();
+	convoihandle_t c=cnv->get_most_parent_convoi();
+	uint64 total_power=0;
+	uint64 total_weight=0;
+	const uint32 test_balance_kmh=999;
+	while(  c.is_bound()  ) {
+		total_power+=c->get_sum_gear_and_power();
+		total_weight+=c->get_sum_gesamtweight();
+		c = c->get_coupling_convoi();
+	}
+	uint32 balance_kmh = speed_to_kmh(convoi_t::calc_max_speed(total_power,total_weight,kmh_to_speed(test_balance_kmh)));
+	label_balance_speed_kmh.buf().printf(translator::translate("%s %d km/h"), translator::translate("terminal speed:"), balance_kmh);
+	label_balance_speed_kmh.update();
 	label_power.buf().printf( translator::translate("Leistung: %d kW"), cnv->get_sum_power() );
 	label_power.update();
 	if( cnv->get_vehicle_count()>0  &&  cnv->get_vehikel( 0 )->get_desc()->get_waytype()==water_wt ) {

--- a/gui/convoi_detail_t.cc
+++ b/gui/convoi_detail_t.cc
@@ -223,7 +223,7 @@ void convoi_detail_t::init(convoihandle_t cnv)
 	end_table();
 
 	set_table_layout(1,0);
-	add_table(4,1);
+	add_table(3,1);
 	{
 		add_component(&label_speed);
 

--- a/gui/convoi_detail_t.h
+++ b/gui/convoi_detail_t.h
@@ -38,7 +38,7 @@ private:
 	gui_aligned_container_t container;
 	gui_scrollpane_t scrolly;
 
-	gui_label_buf_t label_power, label_odometer, label_resale, label_length, label_speed, label_max_speed_kmh_of_convoi;
+	gui_label_buf_t label_power, label_odometer, label_resale, label_length, label_speed, label_max_speed_kmh_of_convoi, label_balance_speed_kmh;
 
 	convoihandle_t cnv;
 	button_t sale_button;


### PR DESCRIPTION
編成詳細ウィンドウに、連結時を含む現在の状態の終端速度(平地での加速限界となる速度)を表示します。
この値は加速度の参考値になります