### PR TITLE
set offset for all vehicles

### DIFF
--- a/dataobj/environment.cc
+++ b/dataobj/environment.cc
@@ -632,6 +632,9 @@ void env_t::rdwr(loadsave_t *file)
 	// and could be different on different servers on the same computers
 }
 
+// Graphical offsets for all vehicles
+// the reading method is in setting_t, and these parameters are used in vehicle_t.
+sint8 env_t::vehicle_base_offsets[8][2][waytype_t::air_wt+1];
 // Graphical offsets for cars driving left
 // the reading method is in setting_t, and these parameters are used in vehicle_t.
 sint8 env_t::driveleft_base_offsets[8][2];

--- a/dataobj/environment.h
+++ b/dataobj/environment.h
@@ -532,6 +532,10 @@ public:
 
 	static bool send_tax_public;
 
+	// offset for all vehicles
+	// [car direction][x/y direction][waytype]
+	static sint8 vehicle_base_offsets[8][2][waytype_t::air_wt+1];
+
 	// drivelelft offset
 	static sint8 driveleft_base_offsets[8][2];
 

--- a/dataobj/settings.cc
+++ b/dataobj/settings.cc
@@ -1175,6 +1175,24 @@ void settings_t::parse_simuconf( tabfile_t& simuconf, sint16& disp_width, sint16
 			}
 		}
 	}
+	const char* waytype_list[17] = {"ignore","road","track","water","electric","monorail_track","maglev_track","tram_track","narrowgauge_track","none","none","none","none","none","none","none","air"};
+	for(uint8 wtp_idx = 0; wtp_idx < waytype_t::air_wt + 1; wtp_idx++) {
+		for(uint8 d_idx = 0; d_idx < 8; d_idx++) {
+			char buf[64];
+			sprintf(buf, "vehicle_base_offset_%s[%s]", directions[d_idx], waytype_list[wtp_idx]);
+			vector_tpl<int> temp_offset = contents.get_ints(buf);
+			if (temp_offset.get_count()>=2) {
+				for(uint8 i=0; i<2; i++) {
+					env_t::vehicle_base_offsets[d_idx][i][wtp_idx] = temp_offset[i];
+				}
+			} else {
+				// if not defined, it should be same as driveleft base offset.
+				for(uint8 i=0; i<2; i++) {
+					env_t::vehicle_base_offsets[d_idx][i][wtp_idx] = 0;
+				}
+			}
+		}
+	}	
 
 	// network stuff
 	env_t::server_frames_ahead              = contents.get_int_clamped( "server_frames_ahead",             env_t::server_frames_ahead,              0, INT_MAX );

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -1028,10 +1028,15 @@ bool vehicle_t::calc_route(koord3d start, koord3d ziel, sint32 max_speed, route_
 void vehicle_t::get_screen_offset( int &xoff, int &yoff, const sint16 raster_width ) const
 {
 	vehicle_base_t::get_screen_offset(xoff, yoff, raster_width);
-	if(  cnv==NULL  ||  cnv==(convoi_t *)1  ||  !cnv->is_reversed()  ) {
+	if(  cnv==NULL  ||  cnv==(convoi_t *)1 ) {
 		return;
 	}
 	const int dir = ribi_t::get_dir(get_direction());
+	xoff += tile_raster_scale_x( env_t::vehicle_base_offsets[dir][0][get_waytype()], raster_width );
+	yoff += tile_raster_scale_y( env_t::vehicle_base_offsets[dir][1][get_waytype()], raster_width );
+	if(  !cnv->is_reversed()  ) {
+		return;
+	}
 	// Add offset when the vehicle is reversed.
 	sint32 steps_delta;
 	steps_delta = raster_width*(VEHICLE_STEPS_PER_TILE / 2 - get_desc()->get_length_in_steps() + env_t::reverse_base_offsets[dir][2]);


### PR DESCRIPTION
各waytypeについて、画像のオフセット量を`simuconf.tab`で設定可能にします。
これにより、画像上の過走を防止することができます