### PR TITLE
show only connected waytype on minimap

### DIFF
--- a/gui/minimap.cc
+++ b/gui/minimap.cc
@@ -1530,7 +1530,7 @@ void minimap_t::draw(scr_coord pos)
 			radius = number_to_radius( transfer );
 		}
 		else {
-			const int stype = station->get_station_type();
+			const int stype = station->get_connected_station_type();
 			color = color_idx_to_rgb(station->get_owner()->get_player_color1()+3);
 
 			// invalid=0, loadingbay=1, railstation = 2, dock = 4, busstop = 8, airstop = 16, monorailstop = 32, tramstop = 64, maglevstop=128, narrowgaugestop=256

--- a/simhalt.cc
+++ b/simhalt.cc
@@ -3550,6 +3550,41 @@ void haltestelle_t::recalc_station_type()
 	recalc_status();
 }
 
+haltestelle_t::stationtyp haltestelle_t::get_connected_station_type() const
+{
+	stationtyp typ = invalid;
+	for(uint32 i=registered_lines.get_count(); i-->0;) {
+		waytype_t wt = registered_lines[i]->get_schedule()->get_waytype();
+		switch (wt)
+		{
+			case road_wt:	 	 typ |= busstop; 		 break;
+			case water_wt:       typ |= dock;            break;
+			case air_wt:         typ |= airstop;         break;
+			case monorail_wt:    typ |= monorailstop;    break;
+			case tram_wt:
+			case track_wt:       typ |= railstation;     break;
+			case maglev_wt:      typ |= maglevstop;      break;
+			case narrowgauge_wt: typ |= narrowgaugestop; break;
+			default: ;
+		}
+	}
+	for(uint32 i=registered_convoys.get_count(); i-->0;) {
+		waytype_t wt = registered_convoys[i]->get_schedule()->get_waytype();
+		switch (wt)
+		{
+			case road_wt:	 	 typ |= busstop; 		 break;
+			case water_wt:       typ |= dock;            break;
+			case air_wt:         typ |= airstop;         break;
+			case monorail_wt:    typ |= monorailstop;    break;
+			case tram_wt:
+			case track_wt:       typ |= railstation;     break;
+			case maglev_wt:      typ |= maglevstop;      break;
+			case narrowgauge_wt: typ |= narrowgaugestop; break;
+			default: ;
+		}		
+	}
+	return typ&station_type;
+}
 
 
 int haltestelle_t::generate_pedestrians(koord3d pos, int count)

--- a/simhalt.h
+++ b/simhalt.h
@@ -853,6 +853,7 @@ public:
 	 */
 	stationtyp get_station_type() const { return station_type; }
 	void recalc_station_type();
+	stationtyp get_connected_station_type() const;
 
 	/**
 	 * fragt den namen der Haltestelle ab.


### PR DESCRIPTION
地図に置いて、空港・港マークは実際に飛行機・船を運行している駅にのみ表示します。