### PR TITLE
BUG FIX: calculate balance speed

### DIFF
--- a/gui/convoi_detail_t.cc
+++ b/gui/convoi_detail_t.cc
@@ -289,11 +289,10 @@ void convoi_detail_t::update_labels()
 	label_odometer.update();
 	convoihandle_t c=cnv->get_most_parent_convoi();
 	uint64 total_power=0;
-	uint64 total_weight=0;
+	uint64 total_weight=c->get_sum_gesamtweight();
 	const uint32 test_balance_kmh=999;
 	while(  c.is_bound()  ) {
 		total_power+=c->get_sum_gear_and_power();
-		total_weight+=c->get_sum_gesamtweight();
 		c = c->get_coupling_convoi();
 	}
 	uint32 balance_kmh = speed_to_kmh(convoi_t::calc_max_speed(total_power,total_weight,kmh_to_speed(test_balance_kmh)));


### PR DESCRIPTION
平衡速度(終端速度)の計算のための重量計算が誤っていたため修正しました