### PR TITLE
reset next_stop_index and next_coupling_index in vorfahren()

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -2538,6 +2538,9 @@ void convoi_t::vorfahren()
 		c->uncouple_done = false;
 		c->reverse_coupling_done = false;
 		c->reversing_coupling_needed = false;
+		// reset next stop index and coupling index
+		c->next_stop_index = 65535;
+		c->next_coupling_index = route_t::INVALID_INDEX;
 		c = c->get_coupling_convoi();
 	}
 	c = self;


### PR DESCRIPTION
`convoi_t::next_stop_index`および`convoi_t::next_coupling_index`を毎回駅発車時等に初期値にリセットすることにしました。これにより一部信号冒進等が防がれる可能性があります