### PR TITLE
show loading level with convoy tooltip

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -4331,6 +4331,15 @@ void convoi_t::calc_loading()
 	recalc_data=true;
 }
 
+sint32 convoi_t::get_max_loading() const
+{
+	sint32 max_loading = 0;
+	for(unsigned i=0; i<anz_vehikel; i++) {
+		const vehicle_t* v = fahr[i];
+		max_loading += v->get_cargo_max();
+	}
+	return max_loading;
+}
 
 void convoi_t::calc_speedbonus_kmh()
 {

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -908,6 +908,7 @@ public:
 	*/
 	const sint32 &get_loading_level() const { return loading_level; }
 	sint32 get_capacity_left() const;
+	sint32 get_max_loading() const;
 
 	/**
 	* At which loading level is the train allowed to start? 0 during driving.

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -2058,17 +2058,20 @@ void vehicle_t::display_after(int xpos, int ypos, bool is_global) const
 		xpos += tile_raster_scale_x(get_xoff(), raster_width);
 		ypos += tile_raster_scale_y(get_yoff(), raster_width)+14;
 		if(ypos>LINESPACE+32  &&  ypos+LINESPACE<display_get_clip_wh().yy) {
-			if(  cnv->get_max_loading()>0  &&  (state==env_t::LINE_NAME_TOOLTIPS || state==env_t::LINE_NAME_AND_STATES_TOOLTIPS)  ) {
-				// show loading level only for loadable convoy(not for locomotive, etc.)
-				// show loading capacity as gray background
-				display_fillbox_wh_clip_rgb( xpos, ypos+14, 100, D_WAITINGBAR_WIDTH, color_idx_to_rgb(COL_GREY4), dirty );
-				// show loading level as green(if level<=100%), or orange(overloading).
-				display_fillbox_wh_clip_rgb( xpos, ypos+14, cnv->get_loading_level()>100?100:cnv->get_loading_level(), D_WAITINGBAR_WIDTH, color_idx_to_rgb(cnv->get_loading_level()>100?COL_RED:COL_LIGHT_GREEN), dirty );
-			}
 			display_ddd_proportional_clip( xpos, ypos, color, color_idx_to_rgb(COL_BLACK), tooltip_text, true );
-			if( lh.is_bound() && ( state == env_t::LINE_NAME_TOOLTIPS || state == env_t::LINE_NAME_AND_STATES_TOOLTIPS ) ) {
-				uint8 tooltip_width = proportional_string_width(tooltip_text);
-				display_fillbox_wh_clip_rgb( xpos, ypos-D_WAITINGBAR_WIDTH, tooltip_width+4, D_WAITINGBAR_WIDTH, color_idx_to_rgb(lh->get_colour()), dirty );
+			if(  state==env_t::LINE_NAME_TOOLTIPS  ||  state==env_t::LINE_NAME_AND_STATES_TOOLTIPS  ) {
+				if(  cnv->get_max_loading()>0  ) {
+					// show loading level only for loadable convoy(not for locomotive, etc.)
+					// show loading capacity as gray background
+					display_fillbox_wh_clip_rgb( xpos, ypos+14, 100, D_WAITINGBAR_WIDTH, color_idx_to_rgb(COL_GREY4), dirty );
+					// show loading level as green(if level<=100%), or orange(overloading).
+					display_fillbox_wh_clip_rgb( xpos, ypos+14, cnv->get_loading_level()>100?100:cnv->get_loading_level(), D_WAITINGBAR_WIDTH, color_idx_to_rgb(cnv->get_loading_level()>100?COL_RED:COL_LIGHT_GREEN), dirty );
+				}
+				if(  lh.is_bound()  ) {
+					// show line colour
+					uint8 tooltip_width = proportional_string_width(tooltip_text);
+					display_fillbox_wh_clip_rgb( xpos, ypos-D_WAITINGBAR_WIDTH, tooltip_width+4, D_WAITINGBAR_WIDTH, color_idx_to_rgb(lh->get_colour()), dirty );
+				}
 			}
 		}
 	}

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -2058,7 +2058,7 @@ void vehicle_t::display_after(int xpos, int ypos, bool is_global) const
 		xpos += tile_raster_scale_x(get_xoff(), raster_width);
 		ypos += tile_raster_scale_y(get_yoff(), raster_width)+14;
 		if(ypos>LINESPACE+32  &&  ypos+LINESPACE<display_get_clip_wh().yy) {
-			if(  cnv->get_max_loading()>0  ) {
+			if(  cnv->get_max_loading()>0  &&  (state==env_t::LINE_NAME_TOOLTIPS || state==env_t::LINE_NAME_AND_STATES_TOOLTIPS)  ) {
 				// show loading level only for loadable convoy(not for locomotive, etc.)
 				// show loading capacity as gray background
 				display_fillbox_wh_clip_rgb( xpos, ypos+14, 100, D_WAITINGBAR_WIDTH, color_idx_to_rgb(COL_GREY4), dirty );

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -2058,6 +2058,13 @@ void vehicle_t::display_after(int xpos, int ypos, bool is_global) const
 		xpos += tile_raster_scale_x(get_xoff(), raster_width);
 		ypos += tile_raster_scale_y(get_yoff(), raster_width)+14;
 		if(ypos>LINESPACE+32  &&  ypos+LINESPACE<display_get_clip_wh().yy) {
+			if(  cnv->get_max_loading()>0  ) {
+				// show loading level only for loadable convoy(not for locomotive, etc.)
+				// show loading capacity as gray background
+				display_fillbox_wh_clip_rgb( xpos, ypos+14, 100, D_WAITINGBAR_WIDTH, color_idx_to_rgb(COL_GREY4), dirty );
+				// show loading level as green(if level<=100%), or orange(overloading).
+				display_fillbox_wh_clip_rgb( xpos, ypos+14, cnv->get_loading_level()>100?100:cnv->get_loading_level(), D_WAITINGBAR_WIDTH, color_idx_to_rgb(cnv->get_loading_level()>100?COL_RED:COL_LIGHT_GREEN), dirty );
+			}
 			display_ddd_proportional_clip( xpos, ypos, color, color_idx_to_rgb(COL_BLACK), tooltip_text, true );
 		}
 	}


### PR DESCRIPTION
路線名・編成名・状態表示のツールチップに乗車率を示すバーを追加しました
・全積載量をグレーのバーで可視化
・乗車率100%以下なら緑で相対的な乗車率を可視化、乗車率100%以上ならオレンジで状態表示（バーは伸びません）