### PR TITLE
BUG FIX: screenshot with ctrl pressed

### DIFF
--- a/display/simgraph16.cc
+++ b/display/simgraph16.cc
@@ -5514,11 +5514,11 @@ bool display_snapshot( const scr_rect &area )
 
 	raw_image_t img(clipped_area.w, clipped_area.h, raw_image_t::FMT_RGB888);
 
-	for (scr_coord_val y = clipped_area.y; y < clipped_area.y + clipped_area.h; ++y) {
+	for (scr_coord_val y = 0; y < clipped_area.h; ++y) {
 		uint8 *dst = img.access_pixel(0, y);
-		const PIXVAL *row = textur + 0 + y*disp_width;
+		const PIXVAL *row = textur + (clipped_area.x + 0) + (clipped_area.y + y) * disp_width;
 
-		for (scr_coord_val x = clipped_area.x; x < clipped_area.x + clipped_area.w; ++x) {
+		for (scr_coord_val x = 0; x < clipped_area.w; ++x) {
 			const PIXVAL pixel = *row++;
 
 #ifdef RGB555


### PR DESCRIPTION
`ctrl`キーを押した状態でスクリーンショットを撮影した場合にクラッシュする不具合を修正しました。
本解消により、simutrans内のアクティブなウィンドウのみを`ctrl`キーを押しながらスクリーンショットツールを使用することで撮影することができます。