### PR TITLE
ci: enable Windows build on pull requests

### DIFF
--- a/.github/workflows/otrp-windows-64.yml
+++ b/.github/workflows/otrp-windows-64.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - v*
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   wingdi32:


### PR DESCRIPTION
Add pull_request trigger to Windows 64-bit build workflow to match Ubuntu build behavior.
This allows Windows builds to be generated automatically when PRs are opened, synchronized, or reopened.

https://claude.ai/code/session_01VWaNfw7AAcjjvoU588FbPA