### PR TITLE
add up and down button for schedule_entry_t

### DIFF
--- a/dataobj/schedule.cc
+++ b/dataobj/schedule.cc
@@ -189,6 +189,63 @@ bool schedule_t::remove()
 }
 
 
+void schedule_t::move_entry_forward( uint8 cur )
+{
+	if( entries.get_count() <= 1 ) {
+		return;
+	}
+	// allow only not last entry
+	if( cur >= (next_line.is_bound()? entries.get_count()-2 : entries.get_count()-1) ) {
+		return;
+	}
+	// just append everything
+	entries.insert_at( cur+2, entries[ cur ] );
+	entries.remove_at( cur );
+
+	// if cur was not at end of list then cur and other changed places
+	uint8 other = (cur + entries.get_count() + 1 ) % entries.get_count();
+
+	if (cur == entries.get_count()-1) {
+		// all entries moved down one index
+		current_stop = (current_stop + 1 + entries.get_count()) % entries.get_count();
+	}
+	else if (current_stop == other) {
+		current_stop = cur;
+	}
+	else if (current_stop == cur) {
+		current_stop = other;
+	}
+}
+
+
+
+void schedule_t::move_entry_backward( uint8 cur )
+{
+	if( entries.get_count() <= 1 ) {
+		return;
+	}
+	// allow only non-zero or not next line's entry
+	if( cur==0 || (next_line.is_bound()&&cur==entries.get_count()-1) ) {
+		return;
+	}
+	entries.insert_at( cur-1, entries[ cur ] );
+	entries.remove_at( cur+1 );
+	// if cur was not at start of list then cur and other changed places
+	uint8 other = (cur + entries.get_count() - 1 ) % entries.get_count();
+
+	if (cur == 0) {
+		// all entries moved up one index
+		current_stop = (current_stop - 1 + entries.get_count()) % entries.get_count();
+	}
+	else if (current_stop == other) {
+		current_stop = cur;
+	}
+	else if (current_stop == cur) {
+		current_stop = other;
+	}
+}
+
+
 
 void schedule_t::rdwr(loadsave_t *file)
 {

--- a/dataobj/schedule.h
+++ b/dataobj/schedule.h
@@ -214,6 +214,9 @@ public:
 	 */
 	void remove_all() { entries.clear(); }
 
+	void move_entry_forward(uint8);
+	void move_entry_backward(uint8);
+
 	void rdwr(loadsave_t *file);
 
 	void rotate90( sint16 y_size );

--- a/gui/components/gui_aligned_container.h
+++ b/gui/components/gui_aligned_container.h
@@ -124,6 +124,8 @@ public:
 	C* new_component(const A1& a1, const A2& a2, const A3& a3, const A4& a4) { C* comp = new C(a1, a2, a3, a4); take_component(comp); return comp; }
 	template<class C, class A1, class A2, class A3, class A4, class A5>
 	C* new_component(const A1& a1, const A2& a2, const A3& a3, const A4& a4, const A5& a5) { C* comp = new C(a1, a2, a3, a4, a5); take_component(comp); return comp; }
+	template<class C, class A1, class A2, class A3, class A4, class A5, class A6>
+	C* new_component(const A1& a1, const A2& a2, const A3& a3, const A4& a4, const A5& a5, const A6& a6) { C* comp = new C(a1, a2, a3, a4, a5, a6); take_component(comp); return comp; }
 
 	/**
 	 * Creates and appends new component, takes ownership of pointer

--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -39,6 +39,8 @@
 #include "minimap.h"
 
 static karte_ptr_t welt;
+#define UP_FLAG (0x4000)
+#define DOWN_FLAG (0x2000)
 
 /**
  * One entry in the list of schedule entries.
@@ -51,21 +53,33 @@ class gui_schedule_entry_t : public gui_aligned_container_t, public gui_action_c
 	player_t* player;
 	waytype_t waytype;
 	gui_image_t arrow;
+	gui_image_t up_arrow;
+	gui_image_t down_arrow;
 	gui_label_buf_t stop;
+	bool is_allow_up;// allow up? (not 0 nor last (when next line is bound))
+	bool is_allow_down;// allow down? (not last nor last-1 (when next line is bound))
 
 public:
-	gui_schedule_entry_t(player_t* pl, schedule_entry_t e, uint n, waytype_t const wt)
+	gui_schedule_entry_t(player_t* pl, schedule_entry_t e, uint n, waytype_t const wt, const bool can_up, const bool can_down)
 	{
 		player = pl;
 		entry  = e;
 		number = n;
 		waytype = wt;
 		is_current = false;
-		set_table_layout(2,1);
+		is_allow_up = can_up;
+		is_allow_down = can_down;
+		set_table_layout(4,1);
 
+		// up & down arrow
+		add_component(&up_arrow);
+		up_arrow.set_image(gui_theme_t::arrow_button_up_img[0], true);
+		add_component(&down_arrow);
+		down_arrow.set_image(gui_theme_t::arrow_button_down_img[0], true);
+		// jump to this stop
 		add_component(&arrow);
 		arrow.set_image(gui_theme_t::pos_button_img[0], true);
-
+		// stop name and flags info
 		add_component(&stop);
 		update_label();
 	}
@@ -76,6 +90,8 @@ public:
 		schedule_t::gimme_stop_name(stop.buf(), welt, player, entry, -1, waytype);
 		stop.set_color(is_current ? SYSCOL_TEXT_HIGHLIGHT : SYSCOL_TEXT);
 		stop.update();
+		up_arrow.set_image(gui_theme_t::arrow_button_up_img[(player==welt->get_active_player()&&is_allow_up)?0:2], true);
+		down_arrow.set_image(gui_theme_t::arrow_button_down_img[(player==welt->get_active_player()&&is_allow_down)?0:2], true);
 	}
 
 	void draw(scr_coord offset) OVERRIDE
@@ -96,12 +112,30 @@ public:
 	bool infowin_event(const event_t *ev) OVERRIDE
 	{
 		if( ev->ev_class == EVENT_CLICK ) {
-			if(  IS_RIGHTCLICK(ev)  ||  ev->mx < stop.get_pos().x) {
+			if(  IS_RIGHTCLICK(ev)  ||  (  ev->mx < stop.get_pos().x  &&  ev->mx >= arrow.get_pos().x  )  ) {
 				// just center on it
 				welt->get_viewport()->change_world_position( entry.pos );
 			} else if( ev->ev_code == MOUSE_WHEELUP || ev->ev_code == MOUSE_WHEELDOWN ) {
 				return false;
-			} 
+			}
+			else if(  player!=welt->get_active_player()  ) {
+				// avoid change by other player
+				call_listeners(number);
+			}
+			else if(  ev->mx < down_arrow.get_pos().x  ) {
+				// up arrow, actioon triggered
+				if(  is_allow_up  ) {
+					call_listeners( UP_FLAG | number );
+					return false;
+				}
+			}
+			else if(  ev->mx < arrow.get_pos().x  ) {
+				// down arrow, actioon triggered
+				if(  is_allow_down  ) {
+					call_listeners( DOWN_FLAG | number );
+					return false;
+				}
+			}
 			else {
 				call_listeners(number);
 			}
@@ -202,8 +236,10 @@ void schedule_gui_stats_t::update_schedule()
 			new_component<gui_textarea_t>(&buf);
 		}
 		else {
-			for(uint i=0; i<schedule->get_count(); i++) {
-				entries.append( new_component<gui_schedule_entry_t>(player, schedule->at(i), i, schedule->get_waytype()));
+			for(uint8 i=0; i<schedule->get_count(); i++) {
+				const bool is_allow_up = (i!=0 && (!schedule->get_next_line().is_bound()||i!=schedule->get_count()-1));
+				const bool is_allow_down = (i!=schedule->get_count()-1 && (!schedule->get_next_line().is_bound()||i!=schedule->get_count()-2));
+				entries.append( new_component<gui_schedule_entry_t>(player, schedule->at(i), i, schedule->get_waytype(), is_allow_up, is_allow_down) );
 				entries.back()->add_listener( this );
 			}
 			entries[ schedule->get_current_stop() ]->set_active(true);
@@ -215,6 +251,7 @@ void schedule_gui_stats_t::update_schedule()
 			last_schedule = schedule->copy();
 		}
 		set_size(get_min_size());
+		call_listeners( schedule->get_current_stop() );
 	}
 	highlight_schedule(true);
 }
@@ -229,7 +266,21 @@ void schedule_gui_stats_t::draw(scr_coord offset)
 bool schedule_gui_stats_t::action_triggered(gui_action_creator_t *, value_t v)
 {
 	// has to be one of the entries
-	call_listeners(v);
+	if( v.i & UP_FLAG ) {
+		dbg->message("schedule_gui_stats_t::action_triggered()","up button pressed!");
+		uint8 up_stop = v.i & 0x00FF;
+		schedule->move_entry_backward(  up_stop  );
+		call_listeners( schedule->get_current_stop() );
+	}
+	else if( v.i & DOWN_FLAG ) {
+		dbg->message("schedule_gui_stats_t::action_triggered()","down button pressed!");
+		uint8 down_stop = v.i & 0x00FF;
+		schedule->move_entry_forward( down_stop );
+		call_listeners( schedule->get_current_stop() );
+	}
+	else {
+		call_listeners(v);
+	}
 	return true;
 }
 
@@ -260,6 +311,7 @@ schedule_gui_t::schedule_gui_t(schedule_t* schedule_, player_t* player_, convoih
 	if (schedule_) {
 		init(schedule_, player_, cnv_, cnv_line_name);
 	}
+	stats->add_listener(this);
 }
 
 schedule_gui_t::~schedule_gui_t()
@@ -711,7 +763,7 @@ void schedule_gui_t::init(schedule_t* schedule_, player_t* player, convoihandle_
 	extract_driving_settings(false);
 
 
-	add_table(2,1);
+	add_table(6,1);
 	{
 		bt_revert.init(button_t::roundbox, "Revert schedule");
 		bt_revert.set_tooltip("Revert to original schedule");
@@ -729,6 +781,17 @@ void schedule_gui_t::init(schedule_t* schedule_, player_t* player, convoihandle_
 		else {
 			new_component<gui_fill_t>();
 		}
+
+		bt_up.init(button_t::arrowup, "up");
+		bt_up.set_tooltip("up this entry");
+		bt_up.add_listener(this);
+		add_component(&bt_up);
+		new_component<gui_label_t>("up");
+		bt_down.init(button_t::arrowdown, "down");
+		bt_down.set_tooltip("down this entry");
+		bt_down.add_listener(this);
+		add_component(&bt_down);
+		new_component<gui_label_t>("down");
 	}
 	end_table();
 
@@ -832,6 +895,8 @@ void schedule_gui_t::update_selection()
 	bt_temp_unload.disable();
 	bt_temp_unload_all.disable();
 	bt_pass_stop.disable();
+	bt_up.disable();
+	bt_down.disable();
 
 
 	if(  !schedule->empty()  ) {
@@ -846,6 +911,13 @@ void schedule_gui_t::update_selection()
     
 		bt_no_overtake.enable();
 		bt_no_overtake.pressed = schedule->at(current_stop).is_no_overtake();
+
+		if(  current_stop!=0  &&  (!schedule->get_next_line().is_bound()  ||  current_stop!=schedule->get_count()-1)  ) {
+			bt_up.enable();
+		}
+		if(  current_stop!=schedule->get_count()-1  &&  (!schedule->get_next_line().is_bound()  ||  current_stop!=schedule->get_count()-2)  ) {
+			bt_down.enable();
+		}
 
 		bt_max_speed_kmh_of_convoi.enable();
 		bt_max_speed_kmh_of_convoi.pressed = schedule->at(current_stop).is_overwrite_max_speed_kmh_of_convoi();
@@ -1023,7 +1095,11 @@ bool schedule_gui_t::infowin_event(const event_t *ev)
 bool schedule_gui_t::action_triggered( gui_action_creator_t *comp, value_t p)
 {
 dbg->message("schedule_gui_t::action_triggered()","comp=%p combo=%p",comp,&line_selector);
-	// Always call update_tool for any actions to prevent an unexpected state
+	// Always call update_tool for any actions to prevent an unexpected stat
+	if(  player!=welt->get_active_player()  ) {
+		// different player! no action!
+		return true;
+	}
 	bool should_set_schedule_tool = true;
 	if(comp == &bt_add) {
 		mode = adding;
@@ -1043,6 +1119,16 @@ dbg->message("schedule_gui_t::action_triggered()","comp=%p combo=%p",comp,&line_
 		bt_insert.pressed = false;
 		bt_remove.pressed = true;
 		should_set_schedule_tool = false;
+	}
+	else if(comp == &bt_up) {
+		if(!schedule->empty()) {
+			schedule->move_entry_backward(schedule->get_current_stop());
+		}
+	}
+	else if(comp == &bt_down) {
+		if(!schedule->empty()) {
+			schedule->move_entry_forward(schedule->get_current_stop());
+		}
 	}
 	else if(comp == &bt_find_parent) {
 		if(!schedule->empty()) {

--- a/gui/schedule_gui.h
+++ b/gui/schedule_gui.h
@@ -73,6 +73,7 @@ class schedule_gui_t : public gui_frame_t, public action_listener_t
 		bt_load_before_departure, bt_reverse_convoy, bt_reverse_coupling, bt_wait_coupling_done, bt_uncouple_child, bt_max_speed_kmh_of_convoi, bt_no_overtake, bt_max_load_all_stops, bt_pass_stop,
 		bt_temp_load, bt_temp_unload, bt_temp_unload_all;
 	button_t bt_reverse_default;
+	button_t bt_up, bt_down;
 
 	gui_numberinput_t numimp_spacing, numimp_spacing_shift, 
 		numimp_delay_tolerance, numimp_max_speed, numimp_max_speed_kmh_of_convoi , numimp_tbgr_waiting_time, numimp_length_coupling_done;
@@ -155,7 +156,7 @@ public:
 /**
  * List of displayed schedule entries.
  */
-class schedule_gui_stats_t : public gui_aligned_container_t, action_listener_t, public gui_action_creator_t
+class schedule_gui_stats_t : public gui_aligned_container_t, public action_listener_t, public gui_action_creator_t
 {
 	static cbuffer_t buf;
 


### PR DESCRIPTION
スケジュールの各エントリ、及びスケジュール詳細にup/downボタンを設け、スケジュールエントリを削除→挿入することなく順番を変更可能にしました