### PR TITLE
BUG FIX: layout=1 depot for water

### DIFF
--- a/simtool.cc
+++ b/simtool.cc
@@ -6147,7 +6147,10 @@ const char *tool_build_depot_t::tool_depot_aux(player_t *player, koord3d pos, co
 				return NOTICE_DEPOT_BAD_POS;
 			}
 			layout = ribi_t::is_straight_ew(ribi);
-		} else {
+		} else if(desc->get_all_layouts() == 1) {
+			layout = 0;
+		}
+		else {
 			return NOTICE_DEPOT_BAD_POS;
 		}
 

--- a/simtool.cc
+++ b/simtool.cc
@@ -6148,6 +6148,10 @@ const char *tool_build_depot_t::tool_depot_aux(player_t *player, koord3d pos, co
 			}
 			layout = ribi_t::is_straight_ew(ribi);
 		} else if(desc->get_all_layouts() == 1) {
+			if(!ribi_t::is_straight(ribi)) {
+				return NOTICE_DEPOT_BAD_POS;
+			}
+			// water depot can be layout=1.
 			layout = 0;
 		}
 		else {


### PR DESCRIPTION
船の車庫について、`dims=1,1,1`の車庫アドオンが存在しました。本アドオンはv51_1では設置不可能になっていたため例外処理を行います