### PR TITLE
BUG FIX: do not remove all stop!

### DIFF
--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -251,7 +251,6 @@ void schedule_gui_stats_t::update_schedule()
 			last_schedule = schedule->copy();
 		}
 		set_size(get_min_size());
-		call_listeners( schedule->get_current_stop() );
 	}
 	highlight_schedule(true);
 }

--- a/gui/schedule_gui.h
+++ b/gui/schedule_gui.h
@@ -156,7 +156,7 @@ public:
 /**
  * List of displayed schedule entries.
  */
-class schedule_gui_stats_t : public gui_aligned_container_t, public action_listener_t, public gui_action_creator_t
+class schedule_gui_stats_t : public gui_aligned_container_t, action_listener_t, public gui_action_creator_t
 {
 	static cbuffer_t buf;
 


### PR DESCRIPTION
スケジュールウィンドウで削除するとすべてのエントリが削除される不具合を修正しました