### PR TITLE
set endhalt by route-search_frame_t (not search it)

### DIFF
--- a/gui/route_search_frame.cc
+++ b/gui/route_search_frame.cc
@@ -252,9 +252,10 @@ void route_search_frame_t::search_route() {
         return;
     }
     ware_t dummy_ware = ware_t();
-    dummy_ware.menge = 100;
+    dummy_ware.menge = 0;
     dummy_ware.index = search_ware_index;
     dummy_ware.set_zielpos(dest_halt->get_init_pos());
+    dummy_ware.set_ziel(dest_halt);
     halthandle_t start_halt_array[1] = {from_halt};
     haltestelle_t::search_route(start_halt_array, 1, false, dummy_ware);
 

--- a/simhalt.cc
+++ b/simhalt.cc
@@ -2080,6 +2080,7 @@ int haltestelle_t::search_route( const halthandle_t *const start_halts, const ui
 	}
 	else {
 		// we already set getoff stop (because this goods is dummy!)
+		// e.g. called by route_search_frame_t
 		halthandle_t halt = ware.get_ziel();
 				end_halts.append(halt);
 

--- a/simhalt.cc
+++ b/simhalt.cc
@@ -2044,6 +2044,7 @@ int haltestelle_t::search_route( const halthandle_t *const start_halts, const ui
 	bool end_conn_comp_undefined = false;
 
 	if(  ware.menge>0  ||  !ware.get_ziel().is_bound()  ) {
+		// usual searching of target halt
 		for( uint32 h=0;  h<plan->get_haltlist_count();  ++h ) {
 			halthandle_t halt = halt_list[h];
 			if(  halt.is_bound()  &&  halt->is_enabled(ware_catg_idx)  ) {

--- a/simhalt.cc
+++ b/simhalt.cc
@@ -2079,6 +2079,7 @@ int haltestelle_t::search_route( const halthandle_t *const start_halts, const ui
 		}
 	}
 	else {
+		// goods menge==0 and target halt is already set.
 		// we already set getoff stop (because this goods is dummy!)
 		// e.g. called by route_search_frame_t
 		halthandle_t halt = ware.get_ziel();

--- a/simhalt.cc
+++ b/simhalt.cc
@@ -2043,35 +2043,55 @@ int haltestelle_t::search_route( const halthandle_t *const start_halts, const ui
 	// if one target halt is undefined, we have to start search from all halts
 	bool end_conn_comp_undefined = false;
 
-	for( uint32 h=0;  h<plan->get_haltlist_count();  ++h ) {
-		halthandle_t halt = halt_list[h];
-		if(  halt.is_bound()  &&  halt->is_enabled(ware_catg_idx)  ) {
-			// check if this is present in the list of start halts
-			for(  uint16 s=0;  s<start_halt_count;  ++s  ) {
-				if(  halt==start_halts[s]  ) {
-					// destination halt is also a start halt -> within walking distance
-					ware.set_ziel( start_halts[s] );
-					ware.clear_transit_halts();
-					if(  return_ware  ) {
-						return_ware->set_ziel( start_halts[s] );
+	if(  ware.menge>0  ||  !ware.get_ziel().is_bound()  ) {
+		for( uint32 h=0;  h<plan->get_haltlist_count();  ++h ) {
+			halthandle_t halt = halt_list[h];
+			if(  halt.is_bound()  &&  halt->is_enabled(ware_catg_idx)  ) {
+				// check if this is present in the list of start halts
+				for(  uint16 s=0;  s<start_halt_count;  ++s  ) {
+					if(  halt==start_halts[s]  ) {
+						// destination halt is also a start halt -> within walking distance
+						ware.set_ziel( start_halts[s] );
 						ware.clear_transit_halts();
+						if(  return_ware  ) {
+							return_ware->set_ziel( start_halts[s] );
+							ware.clear_transit_halts();
+						}
+						return ROUTE_WALK;
 					}
-					return ROUTE_WALK;
 				}
-			}
-			end_halts.append(halt);
+				end_halts.append(halt);
 
-			// check connected component of target halt
-			uint16 endhalt_conn_comp = halt->all_links[ware_catg_idx].catg_connected_component;
-			if (endhalt_conn_comp == UNDECIDED_CONNECTED_COMPONENT) {
-				// undefined: all start halts are probably connected to this target
-				end_conn_comp_undefined = true;
-			}
-			else {
-				// store connected component
-				if (!end_conn_comp_undefined) {
-					end_conn_comp.append_unique( endhalt_conn_comp );
+				// check connected component of target halt
+				uint16 endhalt_conn_comp = halt->all_links[ware_catg_idx].catg_connected_component;
+				if (endhalt_conn_comp == UNDECIDED_CONNECTED_COMPONENT) {
+					// undefined: all start halts are probably connected to this target
+					end_conn_comp_undefined = true;
 				}
+				else {
+					// store connected component
+					if (!end_conn_comp_undefined) {
+						end_conn_comp.append_unique( endhalt_conn_comp );
+					}
+				}
+			}
+		}
+	}
+	else {
+		// we already set getoff stop (because this goods is dummy!)
+		halthandle_t halt = ware.get_ziel();
+				end_halts.append(halt);
+
+		// check connected component of target halt
+		uint16 endhalt_conn_comp = halt->all_links[ware_catg_idx].catg_connected_component;
+		if (endhalt_conn_comp == UNDECIDED_CONNECTED_COMPONENT) {
+			// undefined: all start halts are probably connected to this target
+			end_conn_comp_undefined = true;
+		}
+		else {
+			// store connected component
+			if (!end_conn_comp_undefined) {
+				end_conn_comp.append_unique( endhalt_conn_comp );
 			}
 		}
 	}

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -2059,6 +2059,10 @@ void vehicle_t::display_after(int xpos, int ypos, bool is_global) const
 		ypos += tile_raster_scale_y(get_yoff(), raster_width)+14;
 		if(ypos>LINESPACE+32  &&  ypos+LINESPACE<display_get_clip_wh().yy) {
 			display_ddd_proportional_clip( xpos, ypos, color, color_idx_to_rgb(COL_BLACK), tooltip_text, true );
+			if(cnv->get_line().is_bound()) {
+				uint8 tooltip_width = proportional_string_width(tooltip_text);
+				display_fillbox_wh_clip_rgb( xpos, ypos-4, tooltip_width, D_WAITINGBAR_WIDTH, color_idx_to_rgb(cnv->get_line()->get_colour()), dirty );
+			}
 		}
 	}
 }

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -2061,7 +2061,7 @@ void vehicle_t::display_after(int xpos, int ypos, bool is_global) const
 			display_ddd_proportional_clip( xpos, ypos, color, color_idx_to_rgb(COL_BLACK), tooltip_text, true );
 			if(cnv->get_line().is_bound()) {
 				uint8 tooltip_width = proportional_string_width(tooltip_text);
-				display_fillbox_wh_clip_rgb( xpos, ypos-4, tooltip_width, D_WAITINGBAR_WIDTH, color_idx_to_rgb(cnv->get_line()->get_colour()), dirty );
+				display_fillbox_wh_clip_rgb( xpos, ypos-D_WAITINGBAR_WIDTH, tooltip_width+4, D_WAITINGBAR_WIDTH, color_idx_to_rgb(cnv->get_line()->get_colour()), dirty );
 			}
 		}
 	}


### PR DESCRIPTION
`route_search_frame_t`による経路計算時に、目的地駅を事前に渡すことで付近の別の駅を目的地として計算しないようにしました
`ware.menge==0`かつ`ware.ziel.is_bound()`のときのみ目的地駅を事前に渡した駅に設定します