### PR TITLE
check electrification when reverse at waypoint

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -1283,6 +1283,7 @@ bool convoi_t::drive_to()
 					get_most_parent_convoi()->reversing_coupling_needed=reverse_here;
 					get_most_parent_convoi()->state=ROUTING_1;
 					get_most_parent_convoi()->alte_richtung=get_most_parent_convoi()->front()->get_direction();
+					get_most_parent_convoi()->check_electrification();
 					return false;
 				}
 			}


### PR DESCRIPTION
中継点において連結反転を行った際に、電化設定が不正確な場合があったため修正しました