### PR TITLE
Add world.get_label_list API

### DIFF
--- a/script/api/api_world.cc
+++ b/script/api/api_world.cc
@@ -15,6 +15,8 @@
 #include "../../simversion.h"
 #include "../../player/simplay.h"
 #include "../../obj/gebaeude.h"
+#include "../../obj/label.h"
+#include "../../boden/grund.h"
 #include "../../descriptor/ground_desc.h"
 
 using namespace script_api;
@@ -99,6 +101,40 @@ gebaeude_t* world_attraction_list_get(attraction_list_t, uint32 index)
 SQInteger world_get_attraction_list(HSQUIRRELVM vm)
 {
 	return push_instance(vm, "attraction_list_x");
+}
+
+
+// label list
+namespace script_api {
+	declare_fake_param(label_list_t, "label_list_x");
+}
+
+SQInteger world_label_list_next(HSQUIRRELVM vm)
+{
+	return generic_get_next(vm, welt->get_label_list().get_count());
+}
+
+label_t* world_label_list_get(label_list_t, uint32 index)
+{
+	const slist_tpl<koord>& labels = welt->get_label_list();
+	if (index < labels.get_count()) {
+		koord pos = labels.at(index);
+		grund_t *gr = welt->lookup_kartenboden(pos);
+		if (gr) {
+			return gr->find<label_t>();
+		}
+	}
+	return NULL;
+}
+
+SQInteger world_get_label_list(HSQUIRRELVM vm)
+{
+	return push_instance(vm, "label_list_x");
+}
+
+SQInteger world_get_label_count(HSQUIRRELVM vm)
+{
+	return param<uint32>::push(vm, welt->get_label_list().get_count());
 }
 
 SQInteger world_get_attraction_count(HSQUIRRELVM vm)
@@ -334,6 +370,12 @@ void export_world(HSQUIRRELVM vm, bool scenario)
 	 */
 	STATIC register_function(vm, world_get_convoy_list, "get_convoy_list", 1, ".");
 	/**
+	 * Returns iterator through the list of labels on the map.
+	 * @returns iterator class.
+	 * @typemask label_list_x()
+	 */
+	STATIC register_function(vm, world_get_label_list, "get_label_list", 1, ".");
+	/**
 	 * Returns size of the map.
 	 * @typemask coord()
 	 */
@@ -371,6 +413,34 @@ void export_world(HSQUIRRELVM vm, bool scenario)
 	 * @typemask integer()
 	 */
 	register_function(vm, world_get_attraction_count, "get_count",  1, "x");
+
+	end_class(vm);
+
+	/**
+	 * Implements iterator to iterate through the list of all labels on the map.
+	 *
+	 * Usage:
+	 * @code
+	 * local list = world.get_label_list()
+	 * foreach(label in list) {
+	 *     ... // label is an instance of the label_x class
+	 * }
+	 * @endcode
+	 */
+	create_class(vm, "label_list_x");
+	/**
+	 * Meta-method to be used in foreach loops to loop over all labels on the map. Do not call it directly.
+	 */
+	register_function(vm, world_label_list_next,  "_nexti",  2, ". o|i");
+	/**
+	 * Meta-method to be used in foreach loops to loop over all labels on the map. Do not call it directly.
+	 */
+	register_method(vm,   world_label_list_get,   "_get", true);
+	/**
+	 * Returns number of labels in the list.
+	 * @typemask integer()
+	 */
+	register_function(vm, world_get_label_count, "get_count",  1, "x");
 
 	end_class(vm);
 

--- a/script/api/squirrel_types_ai.awk
+++ b/script/api/squirrel_types_ai.awk
@@ -388,6 +388,7 @@ BEGIN {
 	export_types_ai["world::get_year_transported_goods"] = "array<integer>()"
 	export_types_ai["world::use_timeline"] = "bool()"
 	export_types_ai["attraction_list_x::_get"] = "building_x(integer)"
+	export_types_ai["label_list_x::_get"] = "label_x(integer)"
 	export_types_ai["::get_pakset_name"] = "string()"
 	export_types_ai["::get_version_number"] = "string()"
 	export_types_ai["simple_heap_x::clear"] = "void()"

--- a/script/api/squirrel_types_scenario.awk
+++ b/script/api/squirrel_types_scenario.awk
@@ -406,6 +406,7 @@ BEGIN {
 	export_types_scenario["world::get_year_transported_goods"] = "array<integer>()"
 	export_types_scenario["world::use_timeline"] = "bool()"
 	export_types_scenario["attraction_list_x::_get"] = "building_x(integer)"
+	export_types_scenario["label_list_x::_get"] = "label_x(integer)"
 	export_types_scenario["::get_pakset_name"] = "string()"
 	export_types_scenario["::get_version_number"] = "string()"
 	export_types_scenario["simple_heap_x::clear"] = "void()"

--- a/tests/automated-tests/all_tests.nut
+++ b/tests/automated-tests/all_tests.nut
@@ -70,7 +70,8 @@ all_tests <- [
 	test_good_is_interchangeable,
 	test_good_speed_bonus,
 	test_slope_to_dir,
-	test_way_road_has_double_slopes
+	test_way_road_has_double_slopes,
+	test_label
 ]
 
 
@@ -137,7 +138,6 @@ failing_tests <- [
 	test_halt_make_public_underground,
 	test_halt_move_stop_invalid_param,
 	test_headquarters_build_flat,
-	test_label,
 	test_player_cash,
 	test_player_isactive,
 	test_player_headquarters,

--- a/tests/run-automated-tests.sh
+++ b/tests/run-automated-tests.sh
@@ -63,6 +63,15 @@ while [ $elapsed -lt $timeout ]; do
 		break
 	fi
 
+	# Check for test failures (assertions failed but test runner completed)
+	if grep -q 'Failed tests:' "$TEMP_LOG" 2>/dev/null; then
+		echo ""
+		echo "✗ Test execution failed (test assertion failure detected)"
+		kill $pid 2>/dev/null || true
+		result=1
+		break
+	fi
+
 	# Check for errors
 	if grep -q 'error \[Call function failed\] calling' "$TEMP_LOG" 2>/dev/null || \
 	   grep -q 'error \[Reading / compiling script failed\] calling' "$TEMP_LOG" 2>/dev/null || \


### PR DESCRIPTION
## 概要
- `world::get_label_list` Squirrel APIを実装（既存の `attraction_list` と同じイテレータパターンを使用）し、このAPIが未実装のため失敗していた `test_label` を有効化
- `run-automated-tests.sh` でテストのアサーション失敗を検出してsimutransを即座に終了するように修正（従来は5分のタイムアウトまで待っていた）

## テスト計画
- [x] 新しい `get_label_list` APIで `test_label` がパスすることを確認
- [x] `run-automated-tests.sh` がアサーション失敗を検出することを確認（既知の失敗テストを一時的に追加してテスト）し、simutransプロセスが即座にkillされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)