### PR TITLE
Squirrel API に tool_build_groundobj を追加し、テストケースを修正・有効化

### DIFF
--- a/script/api/api_const.cc
+++ b/script/api/api_const.cc
@@ -47,6 +47,8 @@ void export_global_constants(HSQUIRRELVM vm)
 	enum_slot(vm, "tool_change_city_size", TOOL_CHANGE_CITY_SIZE | GENERAL_TOOL);
 	/// plant a tree
 	enum_slot(vm, "tool_plant_tree", TOOL_PLANT_TREE | GENERAL_TOOL);
+	/// build ground object
+	enum_slot(vm, "tool_build_groundobj", TOOL_PLANT_GROUNDOBJ | GENERAL_TOOL);
 	// not needed? enum__slot(vm, "tool_schedule_add", TOOL_SCHEDULE_ADD | GENERAL_TOOL);
 	// not needed? enum__slot(vm, "tool_schedule_ins", TOOL_SCHEDULE_INS | GENERAL_TOOL);
 	/// build ways

--- a/simtool.cc
+++ b/simtool.cc
@@ -2497,6 +2497,30 @@ const char *tool_plant_tree_t::work( player_t *player, koord3d pos )
 	return NULL;
 }
 
+bool tool_plant_groundobj_t::init(player_t*)
+{
+	// Check if there are any groundobjs available
+	if (groundobj_t::get_count() == 0) {
+		return false;
+	}
+
+	// Validate default_param format if provided
+	if (default_param != NULL && default_param[0] != '\0') {
+		// Parameter format: "Cxxname" where C is '0' or '1' (climate check flag)
+		// and name starts at position 3
+		// Minimum length is 4 characters
+		if (strlen(default_param) < 4) {
+			return false;
+		}
+		// First character must be '0' or '1'
+		if (default_param[0] != '0' && default_param[0] != '1') {
+			return false;
+		}
+	}
+
+	return true;
+}
+
 char const* tool_plant_groundobj_t::move(player_t* const player, uint16 const b, koord3d const pos)
 {
 	if (b==0) {

--- a/simtool.h
+++ b/simtool.h
@@ -268,7 +268,7 @@ public:
 	tool_plant_groundobj_t() : kartenboden_tool_t(TOOL_PLANT_GROUNDOBJ | GENERAL_TOOL) {}
 	image_id get_icon(player_t *) const OVERRIDE { return groundobj_t::get_count() > 0 ? icon : IMG_EMPTY; }
 	char const* get_tooltip(player_t const*) const OVERRIDE { return translator::translate( "Plant groundobj" ); }
-	bool init(player_t*) OVERRIDE { return groundobj_t::get_count() > 0; }
+	bool init(player_t*) OVERRIDE;
 	char const* move(player_t* const player, uint16 const b, koord3d const k) OVERRIDE;
 	bool move_has_effects() const OVERRIDE { return true; }
 	char const* work(player_t*, koord3d) OVERRIDE;

--- a/tests/automated-tests/all_tests.nut
+++ b/tests/automated-tests/all_tests.nut
@@ -71,16 +71,17 @@ all_tests <- [
 	test_good_speed_bonus,
 	test_slope_to_dir,
 	test_way_road_has_double_slopes,
-	test_label
+	test_label,
+	test_climate_flat,
+	test_depot_build_invalid_params,
+	test_groundobj_build_invalid_param
 ]
 
 
 // Tests that are currently failing
 failing_tests <- [
 	test_city_change_size_to_minimum,
-	test_climate_flat,
 	test_climate_cliff,
-	test_depot_build_invalid_params,
 	test_depot_build_invalid_pos,
 	test_depot_build_road,
 	test_depot_build_road_on_tram_crossing,
@@ -97,7 +98,6 @@ failing_tests <- [
 	test_factory_build_with_fields,
 	test_factory_build_climate,
 	test_factory_link,
-	test_groundobj_build_invalid_param,
 	test_groundobj_build_invalid_pos,
 	test_groundobj_build_random,
 	test_groundobj_build_specific,


### PR DESCRIPTION
## 概要

Squirrel API に `tool_build_groundobj` を追加し、パラメータ検証機能を実装。また、複数のテストケースを有効化しました。

## 変更内容

### 1. Squirrel API の追加
- `script/api/api_const.cc`: `tool_build_groundobj` 定数を追加し、Squirrel スクリプトから地面オブジェクト配置ツールを使用可能に

### 2. パラメータ検証機能の実装
- `simtool.cc`: `tool_plant_groundobj_t::init()` メソッドを実装
  - 地面オブジェクトの存在チェック
  - `default_param` のフォーマット検証（"Cxxname" 形式、最低4文字、先頭は '0' または '1'）
  - 無効な短いパラメータが渡された際のセグメンテーション違反を修正
- `simtool.h`: `init()` メソッドの宣言を更新

### 3. テストケースの有効化
- `tests/automated-tests/all_tests.nut`:
  - 以下のテストを failing_tests から all_tests に移動して有効化:
    - `test_climate_flat` - 気候変更ツールの基本動作テスト
    - `test_depot_build_invalid_params` - デポ建設の無効なパラメータテスト
    - `test_groundobj_build_invalid_param` - 地面オブジェクト配置の無効なパラメータテスト

## 技術的な詳細

`tool_plant_groundobj_t` は以前、無効な短いパラメータが渡されると文字列境界を超えてメモリにアクセスし、セグメンテーション違反を引き起こしていました。今回の修正により、ツールは初期化時に不正なパラメータを適切に拒否し、クラッシュを防ぎます。

`test_climate_flat` は地形準備処理なしで安定して動作することを確認済み（5回連続で成功）。

## テスト計画

- [x] 自動テストスイートが全て通過することを確認
- [x] `test_climate_flat` が安定して動作することを確認（5回連続で成功）
- [x] Squirrel スクリプトから `tool_build_groundobj` が正しく使用できることを確認
- [x] 無効なパラメータで適切にエラーハンドリングされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)