### PR TITLE
FIX: network modeで保存したデータがnon network modeで読み込めない

### DIFF
--- a/simworld.cc
+++ b/simworld.cc
@@ -5760,7 +5760,9 @@ void karte_t::rdwr_gamestate(loadsave_t *file, loadingscreen_t *ls)
 	file->rdwr_long(ticks);
 	file->rdwr_long(last_month);
 	file->rdwr_long(last_year);
-	if(file->get_OTRP_version()>=51) {
+
+	const uint8 otrp_version = file->get_OTRP_version();
+	if((otrp_version==51  &&  env_t::networkmode)  ||  otrp_version>=52) {
 		file->rdwr_long(time_multiplier);
 		file->rdwr_bool(fix_game_speed);
 	}

--- a/simworld.cc
+++ b/simworld.cc
@@ -5760,8 +5760,7 @@ void karte_t::rdwr_gamestate(loadsave_t *file, loadingscreen_t *ls)
 	file->rdwr_long(ticks);
 	file->rdwr_long(last_month);
 	file->rdwr_long(last_year);
-	if(file->get_OTRP_version()>=51&&env_t::networkmode) {
-		// game speed (only network mode)
+	if(file->get_OTRP_version()>=51) {
 		file->rdwr_long(time_multiplier);
 		file->rdwr_bool(fix_game_speed);
 	}


### PR DESCRIPTION
## 概要

- `karte_t::rdwr_gamestate()` において、`time_multiplier` と `fix_game_speed` の読み書きが `env_t::networkmode` というランタイム条件に依存していた非対称性を修正

## 問題の詳細

`simworld.cc` の `rdwr_gamestate()` に以下のコードがありました:

```cpp
if(file->get_OTRP_version()>=51 && env_t::networkmode) {
    file->rdwr_long(time_multiplier);
    file->rdwr_bool(fix_game_speed);
}
```

`env_t::networkmode` はセーブファイルの属性ではなく、現在のゲームの実行モードです。rdwr の条件はファイルバージョンのみに依存すべきであり、ランタイム条件に依存すると以下のシナリオでセーブデータが破損します:

1. **ネットワークモードでセーブ → 非ネットワークモードでロード**: 書き込まれた5バイト（long + bool）が読み飛ばされ、以降のデータの読み取り位置がずれる
2. **非ネットワークモードでセーブ → ネットワークモードでロード**: 書き込まれていないデータを読もうとし、後続データを誤って解釈する

## 修正内容

`env_t::networkmode` 条件を除去し、OTRP バージョンのみで分岐するように変更:

```cpp
if(file->get_OTRP_version()>=51) {
    file->rdwr_long(time_multiplier);
    file->rdwr_bool(fix_game_speed);
}
```

## テスト計画

- [ ] 非ネットワークモードでセーブ・ロードが正常に動作すること
- [ ] ネットワークモードでセーブ・ロードが正常に動作すること
- [x] ネットワークモードで保存したデータを非ネットワークモードでロードできること

🤖 Generated with [Claude Code](https://claude.com/claude-code)