### PR TITLE
Add debug.set_game_speed() Squirrel API

### DIFF
--- a/script/api/api_control.cc
+++ b/script/api/api_control.cc
@@ -12,6 +12,7 @@
 #include "../script.h"
 #include "../../squirrel/sq_extensions.h"
 #include "../../simtool.h"
+#include "../../simworld.h"
 
 namespace script_api {
 
@@ -28,6 +29,15 @@ namespace script_api {
 	{
 		tool_pause_t t;
 		return t.is_selected();
+	}
+
+	// Sets the game speed multiplier (1 = normal, 5 = 5x speed).
+	// Internally the time_multiplier is speed*16.
+	void_t set_game_speed(sint32 speed)
+	{
+		sint32 new_multiplier = speed * 16;
+		welt->change_time_multiplier(new_multiplier - welt->get_time_multiplier());
+		return void_t();
 	}
 };
 
@@ -95,6 +105,13 @@ void export_control(HSQUIRRELVM vm)
 	 * @param p true if script should make the game pause in case of error
 	 */
 	STATIC register_function<void_t(*)(bool)>(vm, set_pause_on_error, "set_pause_on_error", true);
+
+	/**
+	 * Sets game speed multiplier. 1 = normal speed, 5 = 5x speed.
+	 * Does not work in network games. Use with care.
+	 * @param speed integer speed multiplier (1 = normal, 5 = five times normal speed)
+	 */
+	STATIC register_method(vm, &set_game_speed, "set_game_speed", false, true);
 
 	end_class(vm);
 }

--- a/tests/automated-tests/tests/test_sign.nut
+++ b/tests/automated-tests/tests/test_sign.nut
@@ -1146,6 +1146,9 @@ function test_sign_signal_turns_red_on_leading_vehicle()
 	ASSERT_TRUE(sig != null)
 	ASSERT_EQUAL(sig.get_state(), state_red)
 
+	// Speed up the game to 5x to make the test run faster.
+	debug.set_game_speed(5)
+
 	// Wait for the convoy to approach and pass the signal.
 	// When the head passes the signal, it should immediately turn red.
 	local head_passed_signal = false


### PR DESCRIPTION
## Summary

- `script/api/api_control.cc` に `debug.set_game_speed(speed)` を追加
  - `speed` は整数の倍率（1 = 通常、5 = 5倍速）
  - 内部的に `time_multiplier = speed * 16` になるよう `change_time_multiplier()` を呼び出す
- `test_sign_signal_turns_red_on_leading_vehicle` でループ前に `debug.set_game_speed(5)` を呼び出し、テストの実行時間を短縮

## Test plan

- [x] `test_sign_signal_turns_red_on_leading_vehicle` 単独でPASS確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)