### PR TITLE
set allow other player connection when merge other's stop or change owner of halts

### DIFF
--- a/simhalt.cc
+++ b/simhalt.cc
@@ -3278,6 +3278,12 @@ void haltestelle_t::merge_halt( halthandle_t halt_merged )
 		return;
 	}
 
+	if(  owner!=halt_merged->get_owner()  ) {
+		// we merge different owner's stop
+		// we set allow other player access because other convoy can connect here!
+		flags|=HS_ALLOW_OTHER_PLAYER_CONNECTION;
+	}
+
 	halt_merged->change_owner( owner, false );
 
 	// add statistics
@@ -3373,6 +3379,10 @@ void haltestelle_t::make_private_and_join( player_t *player, bool public_underta
 			}
 		}
 	}
+
+	// set allow other player access.
+	// because this stop could be access other player before change owner.
+	flags |= HS_ALLOW_OTHER_PLAYER_CONNECTION;
 
 	// transfer ownership
 	owner = player;


### PR DESCRIPTION
公共駅・他社駅を自社化した際、および所有者の異なる駅同士を統合した際に他社乗り入れを自動で許可します。これにより、従来乗り入れていた他社の路線が一時的に接続不可になることを防止できます。