### PR TITLE
Add automated test cases for schedule entry stop flags (NO_LOAD, NO_UNLOAD, UNLOAD_ALL, TRANSFER_INTERVAL)

### DIFF
--- a/.github/workflows/otrp-automated-tests.yml
+++ b/.github/workflows/otrp-automated-tests.yml
@@ -127,6 +127,10 @@ jobs:
       run: |
         unzip tests/simutrans-test-base.zip -d $HOME
 
+    - name: Copy script files to test base
+      run: |
+        cp -r simutrans/script/. $HOME/simutrans-test-base/script/
+
     - name: Run test batch
       run: |
         set +e  # Don't exit on first failure

--- a/script/api/api_schedule.cc
+++ b/script/api/api_schedule.cc
@@ -74,9 +74,12 @@ void append_entry(HSQUIRRELVM vm, SQInteger index, schedule_t* sched)
 	uint16 waiting_time_shift = 0;
 	get_slot(vm, "wait", waiting_time_shift, index);
 
+	uint32 stop_flags = 0;
+	get_slot(vm, "flags", stop_flags, index);
+
 	grund_t *gr = welt->lookup(pos);
 	if (gr) {
-		sched->append(gr, minimum_loading, waiting_time_shift);
+		sched->append(gr, minimum_loading, waiting_time_shift, stop_flags);
 	}
 }
 
@@ -151,7 +154,13 @@ void export_schedule(HSQUIRRELVM vm)
 	 * Waiting time setting.
 	 */
 	integer wait;
+	/**
+	 * Stop flags bitmask (NO_LOAD=4, NO_UNLOAD=8, etc.).
+	 */
+	integer flags;
 #endif
+
+	create_slot(vm, "flags", 0);
 
 	/**
 	 * Returns halt at this entry position.

--- a/script/api_param.cc
+++ b/script/api_param.cc
@@ -577,6 +577,7 @@ namespace script_api {
 
 		set_slot(vm, "load", (sint32)v.minimum_loading);
 		set_slot(vm, "wait", (sint32)v.waiting_time_shift);
+		set_slot(vm, "flags", v.get_stop_flags());
 
     return 1;
 	}

--- a/simutrans/script/script_base.nut
+++ b/simutrans/script/script_base.nut
@@ -460,14 +460,17 @@ class schedule_entry_x {
 	load = 0
 	/// waiting
 	wait = 0
+	/// stop flags (NO_LOAD=4, NO_UNLOAD=8, etc.)
+	flags = 0
 
-	constructor(pos, l, w)
+	constructor(pos, l, w, f = 0)
 	{
 		x = pos.x
 		y = pos.y
 		z = pos.z
 		load = l
 		wait = w
+		flags = f
 	}
 }
 

--- a/tests/automated-tests/all_tests.nut
+++ b/tests/automated-tests/all_tests.nut
@@ -200,6 +200,8 @@ all_tests <- [
 	test_transport_freight_valid_route,
 	test_transport_pax_no_load,
 	test_transport_pax_no_unload,
+	test_transport_pax_unload_all,
+	test_transport_pax_transfer_interval,
 	test_trees_plant_single_invalid_param,
 	test_way_tunnel_build_straight
 ]

--- a/tests/automated-tests/all_tests.nut
+++ b/tests/automated-tests/all_tests.nut
@@ -198,6 +198,8 @@ all_tests <- [
 	test_transport_pax_valid_route,
 	test_transport_mail_valid_route,
 	test_transport_freight_valid_route,
+	test_transport_pax_no_load,
+	test_transport_pax_no_unload,
 	test_trees_plant_single_invalid_param,
 	test_way_tunnel_build_straight
 ]

--- a/tests/automated-tests/tests/test_transport.nut
+++ b/tests/automated-tests/tests/test_transport.nut
@@ -506,3 +506,196 @@ function test_transport_pax_no_unload()
 	ASSERT_EQUAL(command_x(tool_remove_way).work(pl, coord3d(4, 2, 0), coord3d(4, 9, 0), "" + wt_road), null)
 	RESET_ALL_PLAYER_FUNDS()
 }
+
+
+function test_transport_pax_unload_all()
+{
+	local pl = player_x(0)
+	local UNLOAD_ALL = 32
+
+	// Speed up simulation
+	debug.set_game_speed(5)
+
+	// Build road A(4,3) -- B(4,8) -- C(4,13) -- depot(4,14)
+	// Passenger source at coord(3,2), destination at coord(3,14)
+	// Stops are spaced 5 tiles apart so catchment areas do not overlap.
+	ASSERT_EQUAL(command_x(tool_build_way).work(pl, coord3d(4, 2, 0), coord3d(4, 14, 0), "cobblestone_road"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4,  3, 0), "BusStop"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4,  8, 0), "BusStop"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 13, 0), "BusStop"), null)
+	ASSERT_EQUAL(command_x.build_depot(pl, coord3d(4, 14, 0), building_desc_x("CarDepot")), null)
+
+	local depot  = depot_x(4, 14, 0)
+	local halt_a = halt_x.get_halt(coord3d(4,  3, 0), pl)
+	local halt_b = halt_x.get_halt(coord3d(4,  8, 0), pl)
+	local halt_c = halt_x.get_halt(coord3d(4, 13, 0), pl)
+
+	// Create schedule: A -> B(UNLOAD_ALL) -> C
+	local sched = schedule_x(wt_road, [
+		schedule_entry_x(coord3d(4,  3, 0), 0, 0),              // A: normal
+		schedule_entry_x(coord3d(4,  8, 0), 0, 0, UNLOAD_ALL),  // B: unload all (transfer point)
+		schedule_entry_x(coord3d(4, 13, 0), 0, 0)               // C: normal
+	])
+
+	// Create and start bus
+	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("Buessig"))
+	local cnv = depot.get_convoy_list()[0]
+	cnv.change_schedule(pl, sched)
+	depot.start_all_convoys(pl)
+
+	// Wait for halt graph update
+	sleep()
+	sleep()
+
+	// A->C via B(UNLOAD_ALL): B is zwischenziel (transfer point), so route exists
+	ASSERT_EQUAL(world.generate_goods(coord(3, 2), coord(3, 14), good_desc_x.passenger, 30), 1)
+	ASSERT_EQUAL(halt_a.waiting[0], 30)
+	// Passengers board with zwischenziel=B (UNLOAD_ALL makes B a transfer halt)
+	ASSERT_EQUAL(halt_a.get_freight_to_halt(good_desc_x.passenger, halt_b), 30)
+
+	// No direct route to C from A (UNLOAD_ALL cuts the connection graph at B)
+	ASSERT_EQUAL(halt_a.get_freight_to_halt(good_desc_x.passenger, halt_c), 0)
+
+	// Wait for convoy to visit A and load
+	while (halt_a.convoys[0] == 0) {
+		sleep()
+	}
+	while (halt_a.waiting[0] > 0) {
+		sleep()
+	}
+
+	ASSERT_EQUAL(halt_a.departed[0], 30)
+
+	// Bus arrives at B, unloads everyone (UNLOAD_ALL), then they re-board for C
+	while (halt_b.arrived[0] < 30) {
+		sleep()
+	}
+	ASSERT_EQUAL(halt_b.arrived[0], 30)
+
+	// Wait for re-boarding and departure from B
+	while (halt_b.departed[0] < 30) {
+		sleep()
+	}
+	ASSERT_EQUAL(halt_b.departed[0], 30)
+
+	// All passengers should arrive at C
+	while (halt_c.arrived[0] < 30) {
+		sleep()
+	}
+	ASSERT_EQUAL(halt_c.arrived[0], 30)
+
+	// clean up
+	debug.set_game_speed(1)
+	cnv.destroy(pl)
+	sleep()
+	sleep()
+	ASSERT_EQUAL(command_x(tool_remover).work(pl, coord3d(4,  3, 0)), null)
+	ASSERT_EQUAL(command_x(tool_remover).work(pl, coord3d(4,  8, 0)), null)
+	ASSERT_EQUAL(command_x(tool_remover).work(pl, coord3d(4, 13, 0)), null)
+	ASSERT_EQUAL(command_x(tool_remover).work(pl, coord3d(4, 14, 0)), null)
+	ASSERT_EQUAL(command_x(tool_remove_way).work(pl, coord3d(4, 2, 0), coord3d(4, 14, 0), "" + wt_road), null)
+	RESET_ALL_PLAYER_FUNDS()
+}
+
+
+function test_transport_pax_transfer_interval()
+{
+	local pl = player_x(0)
+	local TRANSFER_INTERVAL = 128
+
+	// Speed up simulation
+	debug.set_game_speed(5)
+
+	// L-shaped route: A(3,13) -- B(3,8) -- C(3,3) -- [corner(3,2)] -- D(10,3) -- E(10,8) -- depot(10,9)
+	// C is at (3,3) and D at (10,3) rather than the L-corner tiles (3,2) and (10,2),
+	// because Simutrans cannot build bus stops on road bend/junction tiles.
+	// Stops are well-separated so catchment areas do not overlap.
+	ASSERT_EQUAL(command_x(tool_build_way).work(pl, coord3d(3,  2, 0), coord3d(3, 13, 0), "cobblestone_road"), null)
+	ASSERT_EQUAL(command_x(tool_build_way).work(pl, coord3d(3,  2, 0), coord3d(10,  2, 0), "cobblestone_road"), null)
+	ASSERT_EQUAL(command_x(tool_build_way).work(pl, coord3d(10, 2, 0), coord3d(10,  9, 0), "cobblestone_road"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(3, 13, 0), "BusStop"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(3,  8, 0), "BusStop"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(3,  3, 0), "BusStop"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(10, 3, 0), "BusStop"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(10, 8, 0), "BusStop"), null)
+	ASSERT_EQUAL(command_x.build_depot(pl, coord3d(10, 9, 0), building_desc_x("CarDepot")), null)
+
+	local depot  = depot_x(10, 9, 0)
+	local halt_a = halt_x.get_halt(coord3d(3, 13, 0), pl)
+	local halt_c = halt_x.get_halt(coord3d(3,  3, 0), pl)
+	local halt_d = halt_x.get_halt(coord3d(10, 3, 0), pl)
+	local halt_e = halt_x.get_halt(coord3d(10, 8, 0), pl)
+
+	// Create schedule: A -> B(TI) -> C -> D(TI) -> E
+	// TI divides the route into sections: section1=[A..D], section2=[D..E].
+	// From A, routing can reach at most D (the 2nd TI marker) but not E.
+	// D is NOT a transfer halt (unlike UNLOAD_ALL), so the route search cannot
+	// explore D's connections to find E.
+	// From C (within section2 from C's perspective), routing can reach E directly.
+	local sched = schedule_x(wt_road, [
+		schedule_entry_x(coord3d(3, 13, 0), 0, 0),                     // A: normal
+		schedule_entry_x(coord3d(3,  8, 0), 0, 0, TRANSFER_INTERVAL),  // B: 1st TI marker
+		schedule_entry_x(coord3d(3,  3, 0), 0, 0),                     // C: normal
+		schedule_entry_x(coord3d(10, 3, 0), 0, 0, TRANSFER_INTERVAL),  // D: 2nd TI marker
+		schedule_entry_x(coord3d(10, 8, 0), 0, 0)                      // E: normal
+	])
+
+	// Create and start bus
+	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("Buessig"))
+	local cnv = depot.get_convoy_list()[0]
+	cnv.change_schedule(pl, sched)
+	depot.start_all_convoys(pl)
+
+	// Wait for halt graph update
+	sleep()
+	sleep()
+
+	// A->E: no route (the 2nd TI marker D blocks routing from A to E)
+	ASSERT_EQUAL(world.generate_goods(coord(2, 14), coord(11, 9), good_desc_x.passenger, 20), 0)
+
+	// A->D: route exists (D is within A's section, directly reachable)
+	ASSERT_EQUAL(world.generate_goods(coord(2, 14), coord(11, 3), good_desc_x.passenger, 15), 1)
+	ASSERT_EQUAL(halt_a.waiting[0], 15)
+
+	// C->E: route exists (E is within C's section, past the 2nd TI marker)
+	ASSERT_EQUAL(world.generate_goods(coord(2, 3), coord(11, 9), good_desc_x.passenger, 15), 1)
+	ASSERT_EQUAL(halt_c.waiting[0], 15)
+
+	// Wait for convoy to visit A and load the A->D passengers
+	while (halt_a.convoys[0] == 0) {
+		sleep()
+	}
+	while (halt_a.waiting[0] > 0) {
+		sleep()
+	}
+
+	ASSERT_EQUAL(halt_a.departed[0], 15)
+
+	// A->D passengers unload at D (their destination)
+	while (halt_d.arrived[0] < 15) {
+		sleep()
+	}
+	ASSERT_EQUAL(halt_d.arrived[0], 15)
+
+	// C->E passengers unload at E (their destination)
+	while (halt_e.arrived[0] < 15) {
+		sleep()
+	}
+	ASSERT_EQUAL(halt_e.arrived[0], 15)
+
+	// clean up
+	debug.set_game_speed(1)
+	cnv.destroy(pl)
+	sleep()
+	sleep()
+	ASSERT_EQUAL(command_x(tool_remover).work(pl, coord3d(3, 13, 0)), null)
+	ASSERT_EQUAL(command_x(tool_remover).work(pl, coord3d(3,  8, 0)), null)
+	ASSERT_EQUAL(command_x(tool_remover).work(pl, coord3d(3,  3, 0)), null)
+	ASSERT_EQUAL(command_x(tool_remover).work(pl, coord3d(10, 3, 0)), null)
+	ASSERT_EQUAL(command_x(tool_remover).work(pl, coord3d(10, 8, 0)), null)
+	ASSERT_EQUAL(command_x(tool_remover).work(pl, coord3d(10, 9, 0)), null)
+	ASSERT_EQUAL(command_x(tool_remove_way).work(pl, coord3d(3,  2, 0), coord3d(3, 13, 0), "" + wt_road), null)
+	ASSERT_EQUAL(command_x(tool_remove_way).work(pl, coord3d(3,  2, 0), coord3d(10, 2, 0), "" + wt_road), null)
+	ASSERT_EQUAL(command_x(tool_remove_way).work(pl, coord3d(10, 2, 0), coord3d(10, 9, 0), "" + wt_road), null)
+	RESET_ALL_PLAYER_FUNDS()
+}

--- a/tests/automated-tests/tests/test_transport.nut
+++ b/tests/automated-tests/tests/test_transport.nut
@@ -352,3 +352,157 @@ function test_transport_freight_valid_route()
 	ASSERT_EQUAL(command_x(tool_remove_way).work(player_x(0), coord3d(5, 7, 0), coord3d(4, 7, 0), "" + wt_road), null)
 	RESET_ALL_PLAYER_FUNDS()
 }
+
+
+function test_transport_pax_no_load()
+{
+	local pl = player_x(0)
+	local NO_LOAD = 4
+
+	// Speed up simulation
+	debug.set_game_speed(5)
+
+	// Build road A(4,2) -- B(4,5) -- C(4,8) -- depot(4,9)
+	ASSERT_EQUAL(command_x(tool_build_way).work(pl, coord3d(4, 2, 0), coord3d(4, 9, 0), "cobblestone_road"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 2, 0), "BusStop"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 5, 0), "BusStop"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 8, 0), "BusStop"), null)
+	ASSERT_EQUAL(command_x.build_depot(pl, coord3d(4, 9, 0), building_desc_x("CarDepot")), null)
+
+	local depot  = depot_x(4, 9, 0)
+	local halt_a = halt_x.get_halt(coord3d(4, 2, 0), pl)
+	local halt_b = halt_x.get_halt(coord3d(4, 5, 0), pl)
+	local halt_c = halt_x.get_halt(coord3d(4, 8, 0), pl)
+
+	// Create schedule: A -> B(NO_LOAD) -> C
+	local sched = schedule_x(wt_road, [
+		schedule_entry_x(coord3d(4, 2, 0), 0, 0),           // A: normal
+		schedule_entry_x(coord3d(4, 5, 0), 0, 0, NO_LOAD),  // B: no loading
+		schedule_entry_x(coord3d(4, 8, 0), 0, 0)            // C: normal
+	])
+
+	// Create and start bus
+	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("Buessig"))
+	local cnv = depot.get_convoy_list()[0]
+	cnv.change_schedule(pl, sched)
+	depot.start_all_convoys(pl)
+
+	// Wait for halt graph update
+	sleep()
+	sleep()
+
+	// Generate passengers A -> C: should succeed (route exists via A)
+	ASSERT_EQUAL(world.generate_goods(coord(3, 2), coord(3, 8), good_desc_x.passenger, 30), 1)
+	ASSERT_EQUAL(halt_a.waiting[0], 30)
+
+	// Generate passengers B -> C: should fail (no route, B has NO_LOAD)
+	ASSERT_EQUAL(world.generate_goods(coord(3, 5), coord(3, 8), good_desc_x.passenger, 20), 0)
+
+	// Wait for convoy to visit A and load
+	while (halt_a.convoys[0] == 0) {
+		sleep()
+	}
+	while (halt_a.waiting[0] > 0) {
+		sleep()
+	}
+
+	ASSERT_EQUAL(halt_a.departed[0], 30)
+
+	// Wait for convoy to arrive at C and unload
+	while (halt_c.arrived[0] < 30) {
+		sleep()
+	}
+
+	ASSERT_EQUAL(halt_c.arrived[0], 30)
+	// B should have had no departures (nothing loaded there)
+	ASSERT_EQUAL(halt_b.departed[0], 0)
+
+	// clean up
+	debug.set_game_speed(1)
+	cnv.destroy(pl)
+	sleep()
+	sleep()
+	ASSERT_EQUAL(command_x(tool_remover).work(pl, coord3d(4, 2, 0)), null)
+	ASSERT_EQUAL(command_x(tool_remover).work(pl, coord3d(4, 5, 0)), null)
+	ASSERT_EQUAL(command_x(tool_remover).work(pl, coord3d(4, 8, 0)), null)
+	ASSERT_EQUAL(command_x(tool_remover).work(pl, coord3d(4, 9, 0)), null)
+	ASSERT_EQUAL(command_x(tool_remove_way).work(pl, coord3d(4, 2, 0), coord3d(4, 9, 0), "" + wt_road), null)
+	RESET_ALL_PLAYER_FUNDS()
+}
+
+
+function test_transport_pax_no_unload()
+{
+	local pl = player_x(0)
+	local NO_UNLOAD = 8
+
+	// Speed up simulation
+	debug.set_game_speed(5)
+
+	// Build road A(4,2) -- B(4,5) -- C(4,8) -- depot(4,9)
+	ASSERT_EQUAL(command_x(tool_build_way).work(pl, coord3d(4, 2, 0), coord3d(4, 9, 0), "cobblestone_road"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 2, 0), "BusStop"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 5, 0), "BusStop"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 8, 0), "BusStop"), null)
+	ASSERT_EQUAL(command_x.build_depot(pl, coord3d(4, 9, 0), building_desc_x("CarDepot")), null)
+
+	local depot  = depot_x(4, 9, 0)
+	local halt_a = halt_x.get_halt(coord3d(4, 2, 0), pl)
+	local halt_b = halt_x.get_halt(coord3d(4, 5, 0), pl)
+	local halt_c = halt_x.get_halt(coord3d(4, 8, 0), pl)
+
+	// Create schedule: A -> B(NO_UNLOAD) -> C
+	local sched = schedule_x(wt_road, [
+		schedule_entry_x(coord3d(4, 2, 0), 0, 0),             // A: normal
+		schedule_entry_x(coord3d(4, 5, 0), 0, 0, NO_UNLOAD),  // B: no unloading
+		schedule_entry_x(coord3d(4, 8, 0), 0, 0)              // C: normal
+	])
+
+	// Create and start bus
+	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("Buessig"))
+	local cnv = depot.get_convoy_list()[0]
+	cnv.change_schedule(pl, sched)
+	depot.start_all_convoys(pl)
+
+	// Wait for halt graph update
+	sleep()
+	sleep()
+
+	// Passengers A -> B: should fail (no route, B has NO_UNLOAD)
+	ASSERT_EQUAL(world.generate_goods(coord(3, 2), coord(3, 5), good_desc_x.passenger, 20), 0)
+
+	// Passengers A -> C: should succeed (C is normal, route exists)
+	ASSERT_EQUAL(world.generate_goods(coord(3, 2), coord(3, 8), good_desc_x.passenger, 30), 1)
+	ASSERT_EQUAL(halt_a.waiting[0], 30)
+
+	// Wait for convoy to visit A, load, then reach C
+	while (halt_a.convoys[0] == 0) {
+		sleep()
+	}
+	while (halt_a.waiting[0] > 0) {
+		sleep()
+	}
+
+	ASSERT_EQUAL(halt_a.departed[0], 30)
+
+	// Wait for arrival at C
+	while (halt_c.arrived[0] < 30) {
+		sleep()
+	}
+
+	ASSERT_EQUAL(halt_c.arrived[0], 30)
+	// B should have no arrivals (nothing was unloaded there)
+	ASSERT_EQUAL(halt_b.arrived[0], 0)
+
+	// clean up
+	debug.set_game_speed(1)
+	cnv.destroy(pl)
+	sleep()
+	sleep()
+	ASSERT_EQUAL(command_x(tool_remover).work(pl, coord3d(4, 2, 0)), null)
+	ASSERT_EQUAL(command_x(tool_remover).work(pl, coord3d(4, 5, 0)), null)
+	ASSERT_EQUAL(command_x(tool_remover).work(pl, coord3d(4, 8, 0)), null)
+	ASSERT_EQUAL(command_x(tool_remover).work(pl, coord3d(4, 9, 0)), null)
+	ASSERT_EQUAL(command_x(tool_remove_way).work(pl, coord3d(4, 2, 0), coord3d(4, 9, 0), "" + wt_road), null)
+	RESET_ALL_PLAYER_FUNDS()
+}


### PR DESCRIPTION
## 概要

OTRPのスケジュールエントリ `stop_flags` に関する自動テストケースを追加します。

### スクリプトAPI拡張 (`schedule_entry_x`)

- `schedule_entry_x` に4番目の引数 `flags`（デフォルト値0）を追加し、`stop_flags` を設定できるようにしました
- `append_entry()` 経由でフラグがゲームロジックに正しく渡されるよう `api_schedule.cc` および `api_param.cc` を修正しました

### 追加テスト一覧

| テスト名 | 検証内容 |
|---------|---------|
| `test_transport_pax_no_load` | `NO_LOAD`(=4) 設定停留所からの乗車が不可となること |
| `test_transport_pax_no_unload` | `NO_UNLOAD`(=8) 設定停留所への降車が不可となること |
| `test_transport_pax_unload_all` | `UNLOAD_ALL`(=32) 設定停留所が乗換ノードとなり、全旅客が強制降車・即再乗車してCまで到達できること |
| `test_transport_pax_transfer_interval` | `TRANSFER_INTERVAL`(=128) により区間が分割され、AからEへの直通経路が存在しない一方、A→D・C→Eの区間内経路は正常に機能すること |

### UNLOAD_ALL と TRANSFER_INTERVAL の挙動の違い

- **UNLOAD_ALL**: `force_transfer_search` フラグが立つため停留所が transfer halt になり、経路探索アルゴリズムがその先の接続を探索できる（A→B→C の乗換経路が成立）
- **TRANSFER_INTERVAL**: transfer halt にはならず区間境界として機能するため、区間をまたぐ直通経路（A→E）は存在しない。区間内の経路（A→D、C→E）は正常に機能する

🤖 Generated with [Claude Code](https://claude.com/claude-code)