### PR TITLE
BUG FIX: convoys proliferate when replace them

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -1791,6 +1791,7 @@ void convoi_t::betrete_depot(depot_t *dep, bool is_loading)
 	// remove vehicles from world data structure
 	convoihandle_t c = self;
 	convoihandle_t child = c->get_coupling_convoi();
+	const bool coupling_arrived_depot = child.is_bound();
 	while(c.is_bound()) {
 		c->uncouple_convoi();
 		if( c->reversed ) {
@@ -1818,7 +1819,7 @@ void convoi_t::betrete_depot(depot_t *dep, bool is_loading)
 
 		c->maxspeed_average_count = 0;
 		c->state = INITIAL;
-		dep->convoi_arrived(c, !is_loading  &&  get_schedule());
+		dep->convoi_arrived(c, !is_loading  &&  get_schedule(), coupling_arrived_depot);
 		if(child.is_bound()) {
 			c->coupling_convoi = child;
 			child = child->get_coupling_convoi();

--- a/simdepot.cc
+++ b/simdepot.cc
@@ -158,8 +158,6 @@ void replace_cars(convoihandle_t cnv, depot_t* depot) {
 			}
 		}
 	}
-	// Finally, start the replaced convoy
-	cnv->set_state(convoi_t::states::WAITING_FOR_LEAVING_DEPOT);
 }
 
 
@@ -221,6 +219,7 @@ void depot_t::convoi_arrived(convoihandle_t acnv, bool schedule_adjust)
 	if(  schedule_adjust  &&  replacement_seed.is_bound()  &&  replacement_seed!=acnv  ) {
 		// replace cars of the arrived convoy, then start it immediately.
 		replace_cars(acnv, this);
+		start_convoi(acnv, false);
 	}
 }
 

--- a/simdepot.cc
+++ b/simdepot.cc
@@ -165,7 +165,7 @@ void replace_cars(convoihandle_t cnv, depot_t* depot) {
  * first a convoy reaches the depot during its journey
  * second during loading a convoi is stored in a depot => only store it again
  */
-void depot_t::convoi_arrived(convoihandle_t acnv, bool schedule_adjust)
+void depot_t::convoi_arrived(convoihandle_t acnv, bool schedule_adjust, const bool coupled)
 {
 	for( uint32 i=0; i<convois.get_count(); i++ ) {
 		if (acnv==convois.at(i)) {
@@ -216,7 +216,7 @@ void depot_t::convoi_arrived(convoihandle_t acnv, bool schedule_adjust)
 		}
 	}
 	
-	if(  schedule_adjust  &&  replacement_seed.is_bound()  &&  replacement_seed!=acnv  ) {
+	if(  schedule_adjust  &&  replacement_seed.is_bound()  &&  replacement_seed!=acnv  &&  !coupled  ) {
 		// replace cars of the arrived convoy, then start it immediately.
 		replace_cars(acnv, this);
 		start_convoi(acnv, false);

--- a/simdepot.cc
+++ b/simdepot.cc
@@ -476,6 +476,7 @@ bool depot_t::start_convoi(convoihandle_t cnv, bool local_execution)
 		buf.clear();
 		buf.printf( translator::translate("Vehicle %s is coupled convoy, so it cannot depart alone!"), cnv->get_name() );
 		create_win( new news_img(buf), w_time_delete, magic_none);
+		return false;
 	}
 	// Check the start condition
 	if(  !can_start_convoi(cnv, local_execution)  ) {

--- a/simdepot.h
+++ b/simdepot.h
@@ -166,7 +166,7 @@ public:
 	 * A convoi arrived at the depot and is added to the convoi list.
 	 * If schedule_adjust is true, the current depot is removed from schedule.
 	 */
-	void convoi_arrived(convoihandle_t cnv, bool schedule_adjust);
+	void convoi_arrived(convoihandle_t cnv, bool schedule_adjust, const bool coupled=false);
 
 	/**
 	 * Parameters to determine layout and behaviour of the depot_frame_t.


### PR DESCRIPTION
車庫において、編成置き換えを行った際に編成が増殖しクラッシュを招くバグを修正しました