### PR TITLE
BUG FIX: layout overflow with pipette_tool

### DIFF
--- a/simtool.cc
+++ b/simtool.cc
@@ -8066,7 +8066,7 @@ const char *tool_pipette_t::work(player_t *pl, koord3d pos)
 				t.cursor = tool_t::general_tool[TOOL_BUILD_HOUSE]->cursor;
 				param_str.clear();
 				param_str.printf("%d,%s",
-					gb->get_tile()->get_layout(), /*rotation*/
+					gb->get_tile()->get_layout()&8, /*rotation*/
 					gb->get_tile()->get_desc()->get_name());
 				t.set_default_param(param_str);
 				welt->set_tool(&t, pl);

--- a/simtool.cc
+++ b/simtool.cc
@@ -8065,8 +8065,8 @@ const char *tool_pipette_t::work(player_t *pl, koord3d pos)
 				static tool_build_house_t t = tool_build_house_t();
 				t.cursor = tool_t::general_tool[TOOL_BUILD_HOUSE]->cursor;
 				param_str.clear();
-				param_str.printf("%d,%s",
-					gb->get_tile()->get_layout()&8, /*rotation*/
+				param_str.printf("0%d%s",
+					gb->get_tile()->get_layout(), /*rotation*/
 					gb->get_tile()->get_desc()->get_name());
 				t.set_default_param(param_str);
 				welt->set_tool(&t, pl);


### PR DESCRIPTION
ピペットツールで市内建築物等を抽出した際、レイアウト数が不適切な値となりクラッシュするケースがあったため対応しました