### PR TITLE
fix: correct inappropriate log levels

### DIFF
--- a/network/network.cc
+++ b/network/network.cc
@@ -547,7 +547,7 @@ network_command_t* network_check_activity(karte_t *, int timeout)
 			network_command_t *nwc = socket_list_t::get_client(client_id).receive_nwc();
 			if (nwc) {
 				received_command_queue.append(nwc);
-				dbg->warning( "network_check_activity()", "received cmd %s (id %d) from socket[%d]", nwc->get_name(), nwc->get_id(), sender );
+				dbg->message( "network_check_activity()", "received cmd %s (id %d) from socket[%d]", nwc->get_name(), nwc->get_id(), sender );
 			}
 			// errors are caught and treated in socket_info_t::receive_nwc
 		}

--- a/simworld.cc
+++ b/simworld.cc
@@ -7324,7 +7324,7 @@ void karte_t::process_network_commands(sint32 *ms_difference)
 			const sint32 time_to_next = (sint32)next_step_time - (sint32)timems; // +'ve - still waiting for next,  -'ve - lagging
 			const sint64 frame_timediff = ((sint64)server_sync_step - sync_steps - settings.get_server_frames_ahead() - env_t::additional_client_frames_behind) * fix_ratio_frame_time; // +'ve - server is ahead,  -'ve - client is ahead
 			const sint64 timediff = time_to_next + frame_timediff;
-			dbg->warning("NWC_CHECK", "time difference to server %lli", frame_timediff );
+			dbg->debug("NWC_CHECK", "time difference to server %lli", frame_timediff );
 
 			if(  frame_timediff < (0 - (sint64)settings.get_server_frames_ahead() - (sint64)env_t::additional_client_frames_behind) * (sint64)fix_ratio_frame_time / 2  ) {
 				// running way ahead - more than half margin, simply set next_step_time ahead to where it should be
@@ -7431,9 +7431,9 @@ void karte_t::do_network_world_command(network_world_command_t *nwc)
 		char buf[256];
 		const int offset = server_checklist.print(buf, "server");
 		LCHKLST(server_sync_step).print(buf + offset, "client");
-		dbg->warning("karte_t:::do_network_world_command", "sync_step=%u  %s", server_sync_step, buf);
+		dbg->message("karte_t:::do_network_world_command", "sync_step=%u  %s", server_sync_step, buf);
 		if(  LCHKLST(server_sync_step)!=server_checklist  ) {
-			dbg->warning("karte_t:::do_network_world_command", "disconnecting due to checklist mismatch" );
+			dbg->error("karte_t:::do_network_world_command", "disconnecting due to checklist mismatch. sync_step=%u  %s", server_sync_step, buf);
 			network_disconnect();
 		}
 	}


### PR DESCRIPTION
## 概要

ネットワーク関連コードで不適切なログレベルが使用されていた箇所を修正しました。

## 変更内容

| ファイル | 変更前 | 変更後 | 理由 |
|---|---|---|---|
| `network/network.cc` | `warning` | `message` | コマンド受信は正常動作であり、警告レベルは不適切 |
| `simworld.cc` | `warning` | `debug` | サーバーとの時刻差分ログは頻繁に出力される通常情報のため |
| `simworld.cc` | `warning` | `message` | チェックリスト一致時のログは正常動作のため |
| `simworld.cc` | `warning` | `error` | チェックリスト不一致による切断は実際のエラーのため。あわせてメッセージに `sync_step` 情報を追加 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)