### PR TITLE
BUG FIX: departure slot group combobox does not wheel down with drag

### DIFF
--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -1072,9 +1072,6 @@ bool schedule_gui_t::infowin_event(const event_t *ev)
 		if(  !line_selector.getroffen(ev->cx, ev->cy-D_TITLEBAR_HEIGHT)  ) {
 			line_selector.close_box();
 		}
-		if(  !departure_slot_group_selector.getroffen(ev->cx, ev->cy-D_TITLEBAR_HEIGHT)  ) {
-			departure_slot_group_selector.close_box();
-		}
 	}
 	else if(  ev->ev_class == INFOWIN  &&  ev->ev_code == WIN_CLOSE  &&  schedule!=NULL  ) {
 


### PR DESCRIPTION
`schedule_gui_t`の`departure_slot_group`の`combobox`が、ドラッグによるスクロールに対応していませんでした