### PR TITLE
show unused addon list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -482,6 +482,7 @@ SOURCES += gui/station_building_select.cc
 SOURCES += gui/themeselector.cc
 SOURCES += gui/tool_selector.cc
 SOURCES += gui/trafficlight_info.cc
+SOURCES += gui/unused_addons_frame.cc
 SOURCES += gui/vehiclelist_frame.cc
 SOURCES += gui/welt.cc
 SOURCES += gui/simple_number_input.cc

--- a/bauer/brueckenbauer.cc
+++ b/bauer/brueckenbauer.cc
@@ -70,6 +70,12 @@ const bridge_desc_t *bridge_builder_t::get_desc(const char *name)
 }
 
 
+const stringhashtable_tpl<const bridge_desc_t *>& bridge_builder_t::get_desc_table()
+{
+	return desc_table;
+}
+
+
 const bridge_desc_t *bridge_builder_t::find_bridge(const waytype_t wtyp, const sint32 min_speed, const uint16 time)
 {
 	const bridge_desc_t *find_desc=NULL;

--- a/bauer/brueckenbauer.h
+++ b/bauer/brueckenbauer.h
@@ -10,6 +10,7 @@
 #include "../simtypes.h"
 #include "../dataobj/koord.h"
 #include "../dataobj/koord3d.h"
+#include "../tpl/stringhashtable_tpl.h"
 
 class bridge_desc_t;
 class grund_t;
@@ -113,6 +114,9 @@ public:
 	 * @return bridge descriptor or NULL if not found
 	 */
 	static const bridge_desc_t *get_desc(const char *name);
+
+	/// @returns the full descriptor table (for iterating all registered bridges)
+	static const stringhashtable_tpl<const bridge_desc_t *>& get_desc_table();
 
 	/**
 	 * Builds the bridge and performs all checks.

--- a/bauer/hausbauer.cc
+++ b/bauer/hausbauer.cc
@@ -901,6 +901,12 @@ const building_desc_t* hausbauer_t::get_desc(const char *name)
 }
 
 
+const stringhashtable_tpl<const building_desc_t *>& hausbauer_t::get_desc_table()
+{
+	return desc_table;
+}
+
+
 const building_desc_t* hausbauer_t::get_random_station(const building_desc_t::btype type, const waytype_t wt, const uint16 time, const uint8 enables)
 {
 	weighted_vector_tpl<const building_desc_t*> stops;

--- a/bauer/hausbauer.h
+++ b/bauer/hausbauer.h
@@ -12,6 +12,7 @@
 #include "../halthandle_t.h"
 #include "../simtypes.h"
 #include "../tpl/vector_tpl.h"
+#include "../tpl/stringhashtable_tpl.h"
 
 class gebaeude_t;
 class karte_ptr_t;
@@ -65,6 +66,9 @@ public:
 
 	/// @returns the house description with name @p name
 	static const building_desc_t* get_desc(const char *name);
+
+	/// @returns the full descriptor table (for iterating all registered buildings)
+	static const stringhashtable_tpl<const building_desc_t *>& get_desc_table();
 
 	/**
 	 * Registers the house description so the house can be built in-game.

--- a/bauer/tunnelbauer.cc
+++ b/bauer/tunnelbauer.cc
@@ -67,6 +67,12 @@ const tunnel_desc_t *tunnel_builder_t::get_desc(const char *name)
 }
 
 
+const stringhashtable_tpl<tunnel_desc_t *>& tunnel_builder_t::get_desc_table()
+{
+	return tunnel_by_name;
+}
+
+
 /**
  * Find a matching tunnel
  */

--- a/bauer/tunnelbauer.h
+++ b/bauer/tunnelbauer.h
@@ -10,6 +10,7 @@
 #include "../simtypes.h"
 #include "../dataobj/koord.h"
 #include "../dataobj/koord3d.h"
+#include "../tpl/stringhashtable_tpl.h"
 
 class karte_ptr_t;
 class player_t;
@@ -38,6 +39,9 @@ public:
 	static void register_desc(tunnel_desc_t *desc);
 
 	static const tunnel_desc_t *get_desc(const char *);
+
+	/// @returns the full descriptor table (for iterating all registered tunnels)
+	static const stringhashtable_tpl<tunnel_desc_t *>& get_desc_table();
 
 	static const tunnel_desc_t *get_tunnel_desc(const waytype_t wtyp, const sint32 min_speed,const uint16 time);
 

--- a/bauer/vehikelbauer.cc
+++ b/bauer/vehikelbauer.cc
@@ -383,6 +383,12 @@ const vehicle_desc_t *vehicle_builder_t::get_info(const char *name)
 }
 
 
+const stringhashtable_tpl<const vehicle_desc_t *>& vehicle_builder_t::get_desc_table()
+{
+	return name_fahrzeuge;
+}
+
+
 slist_tpl<vehicle_desc_t const*> const & vehicle_builder_t::get_info(waytype_t const typ, uint8 sortkey)
 {
 	return typ_fahrzeuge[sortkey][GET_WAYTYPE_INDEX(typ)];

--- a/bauer/vehikelbauer.h
+++ b/bauer/vehikelbauer.h
@@ -9,6 +9,7 @@
 
 #include "../dataobj/koord3d.h"
 #include "../simtypes.h"
+#include "../tpl/stringhashtable_tpl.h"
 #include <string>
 
 class vehicle_t;
@@ -59,6 +60,9 @@ public:
 
 	static const vehicle_desc_t * get_info(const char *name);
 	static slist_tpl<vehicle_desc_t const*> const& get_info(waytype_t, uint8 sortkey = vehicle_builder_t::sb_name);
+
+	/// @returns the full descriptor table (for iterating all registered vehicles)
+	static const stringhashtable_tpl<const vehicle_desc_t *>& get_desc_table();
 
 	/** extended search for vehicles for AI
 	*/

--- a/bauer/wegbauer.cc
+++ b/bauer/wegbauer.cc
@@ -246,6 +246,12 @@ const way_desc_t * way_builder_t::get_desc(const char * way_name, const uint16 t
 
 
 
+const stringhashtable_tpl<const way_desc_t *>& way_builder_t::get_desc_table()
+{
+	return desc_table;
+}
+
+
 // generates timeline message
 void way_builder_t::new_month()
 {

--- a/bauer/wegbauer.h
+++ b/bauer/wegbauer.h
@@ -10,6 +10,7 @@
 #include "../simtypes.h"
 #include "../dataobj/koord3d.h"
 #include "../tpl/vector_tpl.h"
+#include "../tpl/stringhashtable_tpl.h"
 
 
 class way_desc_t;
@@ -51,6 +52,9 @@ public:
 	static bool waytype_available( const waytype_t wtyp, uint16 time );
 
 	static const vector_tpl<const way_desc_t *>&  get_way_list(waytype_t, systemtype_t system_type);
+
+	/// @returns the full descriptor table (for iterating all registered ways)
+	static const stringhashtable_tpl<const way_desc_t *>& get_desc_table();
 
 
 	/**

--- a/gui/loadsave_frame.cc
+++ b/gui/loadsave_frame.cc
@@ -8,6 +8,8 @@
 #include <sys/stat.h>
 
 #include "loadsave_frame.h"
+#include "unused_addons_frame.h"
+#include "simwin.h"
 
 #include "../sys/simsys.h"
 #include "../simworld.h"
@@ -71,8 +73,13 @@ bool loadsave_frame_t::item_action(const char *filename)
 		if(  !welt->load(filename)  ) {
 			welt->switch_server( false, true );
 		}
-		else if(  env_t::server  ) {
-			welt->announce_server(karte_t::SERVER_ANNOUNCE_HELLO);
+		else {
+			if(  env_t::server  ) {
+				welt->announce_server(karte_t::SERVER_ANNOUNCE_HELLO);
+			}
+			if(  show_unused_addons.pressed  ) {
+				create_win( new unused_addons_frame_t(), w_info, magic_none );
+			}
 		}
 		DBG_MESSAGE( "loadsave_frame_t::item_action", "load world %li ms", dr_time() - start_load );
 	}
@@ -127,6 +134,8 @@ loadsave_frame_t::loadsave_frame_t(bool do_load) : savegame_frame_t(".sve",false
 		bottom_left_frame.add_component(&easy_server);
 		previous_OTRP.init( button_t::square_automatic, "This is a data of OTRP v12 or v13.");
 		bottom_left_frame.add_component(&previous_OTRP);
+		show_unused_addons.init( button_t::square_automatic, "Show unused addons list");
+		bottom_left_frame.add_component(&show_unused_addons);
 	}
 	else {
 		save_as_standard.init( button_t::square_automatic, "Readable by standard.");
@@ -238,6 +247,7 @@ const char *loadsave_frame_t::get_info(const char *fname)
 	date[lengthof(date)-1] = 0;
 	return date;
 }
+
 
 
 loadsave_frame_t::~loadsave_frame_t()

--- a/gui/loadsave_frame.h
+++ b/gui/loadsave_frame.h
@@ -35,6 +35,7 @@ private:
 	button_t easy_server; // only active on loading savegames
 	button_t previous_OTRP; // only active on loading savegames
 	button_t save_as_standard; // only active on saving savegames
+	button_t show_unused_addons; // show unused pak descriptors in current map
 
 	static stringhashtable_tpl<sve_info_t *> cached_info;
 

--- a/gui/unused_addons_frame.cc
+++ b/gui/unused_addons_frame.cc
@@ -1,0 +1,238 @@
+/*
+ * This file is part of the Simutrans project under the Artistic License.
+ * (see LICENSE.txt)
+ */
+
+#include "unused_addons_frame.h"
+
+#include "../simworld.h"
+#include "../simplan.h"
+#include "../simconvoi.h"
+#include "../simfab.h"
+#include "../boden/grund.h"
+#include "../boden/wege/weg.h"
+#include "../obj/gebaeude.h"
+#include "../obj/bruecke.h"
+#include "../obj/tunnel.h"
+#include "../obj/wayobj.h"
+#include "../obj/roadsign.h"
+#include "../vehicle/simvehicle.h"
+#include "../descriptor/vehicle_desc.h"
+#include "../descriptor/tunnel_desc.h"
+#include "../bauer/hausbauer.h"
+#include "../bauer/vehikelbauer.h"
+#include "../bauer/wegbauer.h"
+#include "../bauer/brueckenbauer.h"
+#include "../bauer/tunnelbauer.h"
+#include "../bauer/fabrikbauer.h"
+#include "../dataobj/translator.h"
+#include "../tpl/stringhashtable_tpl.h"
+#include "../utils/cbuffer_t.h"
+#include "../sys/simsys.h"
+
+#include "components/gui_divider.h"
+
+
+unused_addons_frame_t::unused_addons_frame_t() :
+	gui_frame_t(translator::translate("Unused addons")),
+	scrollpane(&list_container)
+{
+	build_list();
+
+	set_table_layout(1, 0);
+
+	count_label.buf().printf(translator::translate("%d unused addons found"), (int)entries.get_count());
+	count_label.update();
+	add_component(&count_label);
+
+	new_component<gui_divider_t>();
+
+	// populate list container before adding to scrollpane
+	list_container.set_table_layout(2, 0);
+	list_container.set_margin(scr_size(D_H_SPACE, D_V_SPACE), scr_size(D_H_SPACE, D_V_SPACE));
+	list_container.set_spacing(scr_size(D_H_SPACE, 1));
+	for (uint32 i = 0; i < entries.get_count(); i++) {
+		list_container.new_component<gui_label_t>(entries[i].name.c_str());
+		list_container.new_component<gui_label_t>(entries[i].type);
+	}
+
+	scrollpane.set_scroll_amount_y(D_BUTTON_HEIGHT);
+	add_component(&scrollpane);
+
+	new_component<gui_divider_t>();
+
+	copy_btn.init(button_t::roundbox | button_t::flexible, "Copy as CSV");
+	copy_btn.add_listener(this);
+	add_component(&copy_btn);
+
+	set_resizemode(diagonal_resize);
+	reset_min_windowsize();
+	set_windowsize(scr_size(D_DEFAULT_WIDTH, D_DEFAULT_HEIGHT));
+	resize(scr_coord(0, 0));
+}
+
+
+void unused_addons_frame_t::build_list()
+{
+	karte_t *welt = world();
+
+	// --- Step 1: collect all descriptor names used on the current map ---
+	stringhashtable_tpl<bool> used;
+
+	// Scan all tiles
+	for (sint16 y = 0; y < welt->get_size().y; y++) {
+		for (sint16 x = 0; x < welt->get_size().x; x++) {
+			const planquadrat_t *plan = welt->access(x, y);
+			if (!plan) continue;
+			for (uint8 b = 0; b < plan->get_boden_count(); b++) {
+				const grund_t *gr = plan->get_boden_bei(b);
+
+				// Ways (up to 2 per tile)
+				for (uint8 wi = 0; wi < 2; wi++) {
+					if (const weg_t *w = gr->get_weg_nr(wi)) {
+						used.put(w->get_desc()->get_name(), true);
+					}
+				}
+
+				// Buildings
+				if (const gebaeude_t *gb = gr->find<gebaeude_t>()) {
+					used.put(gb->get_tile()->get_desc()->get_name(), true);
+				}
+
+				// Bridges
+				if (const bruecke_t *brk = gr->find<bruecke_t>()) {
+					used.put(brk->get_desc()->get_name(), true);
+				}
+
+				// Tunnels
+				if (const tunnel_t *tun = gr->find<tunnel_t>()) {
+					used.put(tun->get_desc()->get_name(), true);
+				}
+
+				// Way objects (catenary etc.)
+				if (const wayobj_t *wo = gr->find<wayobj_t>()) {
+					used.put(wo->get_desc()->get_name(), true);
+				}
+
+				// Road signs / signals
+				if (const roadsign_t *rs = gr->find<roadsign_t>()) {
+					used.put(rs->get_desc()->get_name(), true);
+				}
+			}
+		}
+	}
+
+	// Convoys -> vehicles
+	for (uint32 i = 0; i < welt->convoys().get_count(); i++) {
+		const convoihandle_t c = welt->convoys()[i];
+		for (uint8 vi = 0; vi < c->get_vehicle_count(); vi++) {
+			used.put(c->get_vehikel(vi)->get_desc()->get_name(), true);
+		}
+	}
+
+	// Factories
+	FOR(slist_tpl<fabrik_t*>, const fab, welt->get_fab_list()) {
+		used.put(fab->get_desc()->get_name(), true);
+	}
+
+	// --- Step 2: collect all registered descriptors and find unused ones ---
+
+	// Buildings
+	FOR(stringhashtable_tpl<building_desc_t const*>, const& i, hausbauer_t::get_desc_table()) {
+		if (!used.get(i.value->get_name())) {
+			entry_t e;
+			e.name = i.value->get_name();
+			e.type = "Building";
+			entries.append(e);
+		}
+	}
+
+	// Vehicles
+	FOR(stringhashtable_tpl<vehicle_desc_t const*>, const& i, vehicle_builder_t::get_desc_table()) {
+		if (!used.get(i.value->get_name())) {
+			entry_t e;
+			e.name = i.value->get_name();
+			e.type = "Vehicle";
+			entries.append(e);
+		}
+	}
+
+	// Ways
+	FOR(stringhashtable_tpl<way_desc_t const*>, const& i, way_builder_t::get_desc_table()) {
+		if (!used.get(i.value->get_name())) {
+			entry_t e;
+			e.name = i.value->get_name();
+			e.type = "Way";
+			entries.append(e);
+		}
+	}
+
+	// Bridges
+	FOR(stringhashtable_tpl<bridge_desc_t const*>, const& i, bridge_builder_t::get_desc_table()) {
+		if (!used.get(i.value->get_name())) {
+			entry_t e;
+			e.name = i.value->get_name();
+			e.type = "Bridge";
+			entries.append(e);
+		}
+	}
+
+	// Tunnels
+	FOR(stringhashtable_tpl<tunnel_desc_t*>, const& i, tunnel_builder_t::get_desc_table()) {
+		if (!used.get(i.value->get_name())) {
+			entry_t e;
+			e.name = i.value->get_name();
+			e.type = "Tunnel";
+			entries.append(e);
+		}
+	}
+
+	// Way objects
+	FOR(stringhashtable_tpl<way_obj_desc_t const*>, const& i, wayobj_t::get_list()) {
+		if (!used.get(i.value->get_name())) {
+			entry_t e;
+			e.name = i.value->get_name();
+			e.type = "Wayobj";
+			entries.append(e);
+		}
+	}
+
+	// Road signs
+	FOR(stringhashtable_tpl<roadsign_desc_t const*>, const& i, roadsign_t::get_desc_table()) {
+		if (!used.get(i.value->get_name())) {
+			entry_t e;
+			e.name = i.value->get_name();
+			e.type = "Roadsign";
+			entries.append(e);
+		}
+	}
+
+	// Factories
+	FOR(stringhashtable_tpl<factory_desc_t const*>, const& i, factory_builder_t::get_factory_table()) {
+		if (!used.get(i.value->get_name())) {
+			entry_t e;
+			e.name = i.value->get_name();
+			e.type = "Factory";
+			entries.append(e);
+		}
+	}
+}
+
+
+bool unused_addons_frame_t::action_triggered(gui_action_creator_t *comp, value_t)
+{
+	if (comp == &copy_btn) {
+		cbuffer_t buf;
+		buf.append("name,type\n");
+		for (uint32 i = 0; i < entries.get_count(); i++) {
+			buf.append(entries[i].name.c_str());
+			buf.append(",");
+			buf.append(entries[i].type);
+			buf.append("\n");
+		}
+		if (buf.len() > 0) {
+			dr_copy(buf, buf.len());
+		}
+	}
+	return true;
+}

--- a/gui/unused_addons_frame.h
+++ b/gui/unused_addons_frame.h
@@ -1,0 +1,44 @@
+/*
+ * This file is part of the Simutrans project under the Artistic License.
+ * (see LICENSE.txt)
+ */
+
+#ifndef GUI_UNUSED_ADDONS_FRAME_H
+#define GUI_UNUSED_ADDONS_FRAME_H
+
+#include "gui_frame.h"
+#include "components/gui_button.h"
+#include "components/gui_scrollpane.h"
+#include "components/gui_aligned_container.h"
+#include "components/gui_label.h"
+#include "../tpl/vector_tpl.h"
+#include <string>
+
+/**
+ * Dialog that lists all pak descriptors not used in the current map.
+ * Provides a "Copy as CSV" button for exporting the list.
+ */
+class unused_addons_frame_t : public gui_frame_t, public action_listener_t
+{
+	struct entry_t {
+		std::string name;
+		const char *type; // static string, no ownership
+	};
+
+	vector_tpl<entry_t> entries;
+	gui_aligned_container_t list_container;
+	gui_scrollpane_t scrollpane;
+	gui_label_buf_t count_label;
+	button_t copy_btn;
+
+	void build_list();
+
+public:
+	unused_addons_frame_t();
+
+	const char *get_help_filename() const OVERRIDE { return NULL; }
+
+	bool action_triggered(gui_action_creator_t *comp, value_t v) OVERRIDE;
+};
+
+#endif

--- a/obj/roadsign.h
+++ b/obj/roadsign.h
@@ -224,6 +224,8 @@ public:
 
 	static const roadsign_desc_t *find_desc(const char *name) { return table.get(name); }
 
+	static const stringhashtable_tpl<const roadsign_desc_t *>& get_desc_table() { return table; }
+
 	static const vector_tpl<const roadsign_desc_t*>& get_available_signs(const waytype_t wt);
 };
 


### PR DESCRIPTION
マップロード時に、未使用のアドオンのリストを表示可能にしました
- 未使用アドオンリスト表示ボタンを追加
- 未使用アドオンリストはロード完了時に表示
- 未使用アドオンリストはcsvにコピー可能：コピーするとアドオン名＋属性のリストを取得できる