### PR TITLE
add reverse convoy coupling button in convoi_info_t

### DIFF
--- a/gui/convoi_info_t.cc
+++ b/gui/convoi_info_t.cc
@@ -384,9 +384,9 @@ void convoi_info_t::draw(scr_coord pos, scr_size size)
 			button.set_text("release back");
 			button.enable();
 		} else if(  cnv->is_coupled()  ) {
-			button.set_tooltip("Please decouple the other convoy to edit the schedule.");
-			button.set_text("Fahrplan");
-			button.disable();
+			button.set_tooltip("Reverse coupling order");
+			button.set_text("Reverse coupling");
+			button.enable();
 		} else {
 			button.set_tooltip("Alters a schedule.");
 			button.set_text("Fahrplan");
@@ -591,9 +591,13 @@ bool convoi_info_t::action_triggered( gui_action_creator_t *comp,value_t /* */)
 				cnv->call_convoi_tool('r', NULL);
 				return true;
 			}
+			else if(  cnv->is_coupled()  ) {
+				cnv->call_convoi_tool('c', NULL);
+				return true;
+			}
 			else {
-			cnv->call_convoi_tool( 'f', NULL );
-			return true;
+				cnv->call_convoi_tool( 'f', NULL );
+				return true;
 			}
 		}
 

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -6038,6 +6038,19 @@ bool convoi_t::couple_convoi_during_running(convoihandle_t coupled) {
 	return true;
 }
 
+void convoi_t::reverse_convoy_coupling_by_user_request()
+{
+	// reverse convoy coupling by user request
+	// this must be most parent convoy!
+	if(  is_coupled()  ) {
+		return;
+	}
+	// firse we release the reservation
+	unreserve_route();
+	// then reverse convoy coupling
+	reverse_convoy_coupling();
+}
+
 uint16 convoi_t::get_length_coupling_done() const {
 	convoihandle_t c = self;
 	if( c->is_coupled() ) {

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -1156,6 +1156,9 @@ public:
 	// if this bool value is true, reversing done, this convoy is no longer the leading (most parent) convoy.
 	bool reverse_convoy_coupling_at_waypoint();
 
+	// Reverse convoy coupling by user request
+	void reverse_convoy_coupling_by_user_request();
+
 	// coupling during running.
 	// Only for during leaving a depot
 	bool couple_convoi_during_running(convoihandle_t coupled);

--- a/simtool.cc
+++ b/simtool.cc
@@ -8645,6 +8645,7 @@ bool scenario_check_convoy(karte_t *welt, player_t *player, convoihandle_t cnv, 
  * 'e' : toggle delay recovery
  * 't' : go to next stop
  * 'v' : reversing convoi direction
+ * 'c' : reversing coupling convoys
  * 'm' : apply max speed of convoy
  * 'b' : apply balance speed (limit power)
  */
@@ -8847,6 +8848,12 @@ bool tool_change_convoi_t::init( player_t *player )
 		case 'v':
 		{
 			cnv->reverse_vehicles_on_user_request();
+		}
+		break;
+
+		case 'c':
+		{
+			cnv->get_most_parent_convoi()->reverse_convoy_coupling_by_user_request();
 		}
 		break;
 


### PR DESCRIPTION
編成同士の連結順序反転を行うボタンを追加しました
・最後尾の編成の「スケジュール」ボタンに相当するボタンを連結順序反転用に使用します