### PR TITLE
resolve digit insufficiency

### DIFF
--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -2110,7 +2110,7 @@ void vehicle_t::display_after(int xpos, int ypos, bool is_global) const
 				}
 				if(  env_t::show_line_colors && lh.is_bound()  ) {
 					// show line colour
-					uint8 tooltip_width = proportional_string_width(tooltip_text);
+					sint32 tooltip_width = proportional_string_width(tooltip_text);
 					display_fillbox_wh_clip_rgb( xpos, ypos-D_WAITINGBAR_WIDTH, tooltip_width+4, D_WAITINGBAR_WIDTH, color_idx_to_rgb(lh->get_colour()), dirty );
 				}
 			}


### PR DESCRIPTION
路線カラーの表示tooltipの帯の幅が`uint8`だったため長い路線名に対して桁落ちしていました。修正しました