### PR TITLE
do not add running cost when drive without leader

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -735,6 +735,11 @@ uint32 convoi_t::get_entire_convoy_length() const
  */
 void convoi_t::add_running_cost( const weg_t *weg )
 {
+	if(!get_most_parent_convoi()->front()->is_leading()) {
+		// if the most parent convoy's front vehicle is not leading, do not consider running cost
+		// e.g. start from station (reset vehicles)
+		return;
+	}
 	jahresgewinn += base_sum_running_costs;
 
 	if(  weg  &&  weg->get_owner()!=get_owner()  &&  weg->get_owner()!=NULL  ) {


### PR DESCRIPTION
先頭車両が`is_leading()`ではない場合、編成の運行費を加算しません
これにより、駅発車時の車両再配置時、折り返し時等に運行費等が不正に加算されていた現象が解消されます