### PR TITLE
delete up and down arrow in gui_schedule_entry_t

### DIFF
--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -307,14 +307,21 @@ void schedule_gui_t::init(schedule_t* schedule_, player_t* player, convoihandle_
 
 	set_table_layout(1,0);
 
-	add_table(1,1);
-	if(  cnv.is_bound()  ) {
-		snprintf(lb_cnv_line_name_str,255,cnv->get_name());
-	} else {
-		snprintf(lb_cnv_line_name_str,255,cnv_line_name);
+	add_table(3,1);
+	{
+		if(  cnv.is_bound()  ) {
+			snprintf(lb_cnv_line_name_str,255,cnv->get_name());
+		} else {
+			snprintf(lb_cnv_line_name_str,255,cnv_line_name);
+		}
+		lb_cnv_line_name.set_text(lb_cnv_line_name_str);
+		add_component(&lb_cnv_line_name);
+		new_component<gui_fill_t>();
+		bt_revert.init(button_t::roundbox, "Revert schedule");
+		bt_revert.set_tooltip("Revert to original schedule");
+		bt_revert.add_listener(this);
+		add_component(&bt_revert);
 	}
-	lb_cnv_line_name.set_text(lb_cnv_line_name_str);
-	add_component(&lb_cnv_line_name);
 	end_table();
 
 
@@ -735,11 +742,6 @@ void schedule_gui_t::init(schedule_t* schedule_, player_t* player, convoihandle_
 
 	add_table(6,1);
 	{
-		bt_revert.init(button_t::roundbox, "Revert schedule");
-		bt_revert.set_tooltip("Revert to original schedule");
-		bt_revert.add_listener(this);
-		add_component(&bt_revert);
-
 		// return tickets
 		if(  !env_t::hide_rail_return_ticket  ||  schedule->get_waytype()==road_wt  ||  schedule->get_waytype()==air_wt  ||  schedule->get_waytype()==water_wt  ) {
 			//  hide the return ticket on rail stuff, where it causes much trouble
@@ -751,6 +753,7 @@ void schedule_gui_t::init(schedule_t* schedule_, player_t* player, convoihandle_
 		else {
 			new_component<gui_fill_t>();
 		}
+		new_component<gui_fill_t>();
 
 		bt_up.init(button_t::arrowup, "up");
 		bt_up.set_tooltip("up this entry");

--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -67,7 +67,7 @@ public:
 		number = n;
 		waytype = wt;
 		is_current = false;
-		set_table_layout(4,1);
+		set_table_layout(2,1);
 
 		// jump to this stop
 		add_component(&arrow);

--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -60,22 +60,15 @@ class gui_schedule_entry_t : public gui_aligned_container_t, public gui_action_c
 	bool is_allow_down;// allow down? (not last nor last-1 (when next line is bound))
 
 public:
-	gui_schedule_entry_t(player_t* pl, schedule_entry_t e, uint n, waytype_t const wt, const bool can_up, const bool can_down)
+	gui_schedule_entry_t(player_t* pl, schedule_entry_t e, uint n, waytype_t const wt)
 	{
 		player = pl;
 		entry  = e;
 		number = n;
 		waytype = wt;
 		is_current = false;
-		is_allow_up = can_up;
-		is_allow_down = can_down;
 		set_table_layout(4,1);
 
-		// up & down arrow
-		add_component(&up_arrow);
-		up_arrow.set_image(gui_theme_t::arrow_button_up_img[0], true);
-		add_component(&down_arrow);
-		down_arrow.set_image(gui_theme_t::arrow_button_down_img[0], true);
 		// jump to this stop
 		add_component(&arrow);
 		arrow.set_image(gui_theme_t::pos_button_img[0], true);
@@ -90,8 +83,6 @@ public:
 		schedule_t::gimme_stop_name(stop.buf(), welt, player, entry, -1, waytype);
 		stop.set_color(is_current ? SYSCOL_TEXT_HIGHLIGHT : SYSCOL_TEXT);
 		stop.update();
-		up_arrow.set_image(gui_theme_t::arrow_button_up_img[(player==welt->get_active_player()&&is_allow_up)?0:2], true);
-		down_arrow.set_image(gui_theme_t::arrow_button_down_img[(player==welt->get_active_player()&&is_allow_down)?0:2], true);
 	}
 
 	void draw(scr_coord offset) OVERRIDE
@@ -121,20 +112,6 @@ public:
 			else if(  player!=welt->get_active_player()  ) {
 				// avoid change by other player
 				call_listeners(number);
-			}
-			else if(  ev->mx < down_arrow.get_pos().x  ) {
-				// up arrow, actioon triggered
-				if(  is_allow_up  ) {
-					call_listeners( UP_FLAG | number );
-					return false;
-				}
-			}
-			else if(  ev->mx < arrow.get_pos().x  ) {
-				// down arrow, actioon triggered
-				if(  is_allow_down  ) {
-					call_listeners( DOWN_FLAG | number );
-					return false;
-				}
 			}
 			else {
 				call_listeners(number);
@@ -237,9 +214,7 @@ void schedule_gui_stats_t::update_schedule()
 		}
 		else {
 			for(uint8 i=0; i<schedule->get_count(); i++) {
-				const bool is_allow_up = (i!=0 && (!schedule->get_next_line().is_bound()||i!=schedule->get_count()-1));
-				const bool is_allow_down = (i!=schedule->get_count()-1 && (!schedule->get_next_line().is_bound()||i!=schedule->get_count()-2));
-				entries.append( new_component<gui_schedule_entry_t>(player, schedule->at(i), i, schedule->get_waytype(), is_allow_up, is_allow_down) );
+				entries.append( new_component<gui_schedule_entry_t>(player, schedule->at(i), i, schedule->get_waytype()) );
 				entries.back()->add_listener( this );
 			}
 			entries[ schedule->get_current_stop() ]->set_active(true);

--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -39,8 +39,6 @@
 #include "minimap.h"
 
 static karte_ptr_t welt;
-#define UP_FLAG (0x4000)
-#define DOWN_FLAG (0x2000)
 
 /**
  * One entry in the list of schedule entries.
@@ -53,11 +51,7 @@ class gui_schedule_entry_t : public gui_aligned_container_t, public gui_action_c
 	player_t* player;
 	waytype_t waytype;
 	gui_image_t arrow;
-	gui_image_t up_arrow;
-	gui_image_t down_arrow;
 	gui_label_buf_t stop;
-	bool is_allow_up;// allow up? (not 0 nor last (when next line is bound))
-	bool is_allow_down;// allow down? (not last nor last-1 (when next line is bound))
 
 public:
 	gui_schedule_entry_t(player_t* pl, schedule_entry_t e, uint n, waytype_t const wt)
@@ -240,21 +234,7 @@ void schedule_gui_stats_t::draw(scr_coord offset)
 bool schedule_gui_stats_t::action_triggered(gui_action_creator_t *, value_t v)
 {
 	// has to be one of the entries
-	if( v.i & UP_FLAG ) {
-		dbg->message("schedule_gui_stats_t::action_triggered()","up button pressed!");
-		uint8 up_stop = v.i & 0x00FF;
-		schedule->move_entry_backward(  up_stop  );
-		call_listeners( schedule->get_current_stop() );
-	}
-	else if( v.i & DOWN_FLAG ) {
-		dbg->message("schedule_gui_stats_t::action_triggered()","down button pressed!");
-		uint8 down_stop = v.i & 0x00FF;
-		schedule->move_entry_forward( down_stop );
-		call_listeners( schedule->get_current_stop() );
-	}
-	else {
-		call_listeners(v);
-	}
+	call_listeners(v);
 	return true;
 }
 


### PR DESCRIPTION
スケジュールエントリのup,downの矢印が複数存在したので、エントリにあるほうを削除します（ヘッダーにあるものは維持します）