### PR TITLE
Add global route cache for convoy A* pathfinding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,6 +315,7 @@ SOURCES += dataobj/rect.cc
 SOURCES += dataobj/repositioning.cc
 SOURCES += dataobj/ribi.cc
 SOURCES += dataobj/route.cc
+SOURCES += dataobj/route_cache.cc
 SOURCES += dataobj/scenario.cc
 SOURCES += dataobj/schedule.cc
 SOURCES += dataobj/schedule_entry.cc

--- a/dataobj/route.cc
+++ b/dataobj/route.cc
@@ -775,6 +775,18 @@ route_t::route_result_t route_t::calc_route(karte_t *welt, const koord3d ziel, c
 }
 
 
+bool route_t::is_passable(karte_t *welt, test_driver_t *tdriver, bool need_electric) const
+{
+	for (uint32 i = 0; i < route.get_count(); i++) {
+		const grund_t *gr = welt->lookup(route[i]);
+		if (!gr || !tdriver->check_next_tile(gr, need_electric)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+
 void route_t::rdwr(loadsave_t *file)
 {
 	xml_tag_t r( file, "route_t" );

--- a/dataobj/route.h
+++ b/dataobj/route.h
@@ -145,6 +145,40 @@ public:
 	route_result_t calc_route(karte_t *welt, koord3d start, koord3d target, test_driver_t *tdriver, const sint32 max_speed_kmh, sint32 max_len, const bool need_electric=false );
 
 	/**
+	 * Copy constructor.
+	 */
+	route_t(const route_t& other) {
+		for (uint32 i = 0; i < other.route.get_count(); i++) {
+			route.append(other.route[i]);
+		}
+	}
+
+	/// Default constructor.
+	route_t() {}
+
+	/**
+	 * Copy assignment: copies coordinates from other route.
+	 */
+	route_t& operator=(const route_t& other) {
+		if (this != &other) {
+			route.clear();
+			route.resize(other.route.get_count());
+			for (uint32 i = 0; i < other.route.get_count(); i++) {
+				route.append(other.route[i]);
+			}
+		}
+		return *this;
+	}
+
+	/**
+	 * Returns true if every tile in the route is accessible by tdriver.
+	 * need_electric must match convoi_t::needs_electrification() to mirror
+	 * the same check performed during A* route search.
+	 * Used to validate cached routes before use.
+	 */
+	bool is_passable(karte_t *welt, test_driver_t *tdriver, bool need_electric) const;
+
+	/**
 	 * Load/Save of the route.
 	 */
 	void rdwr(loadsave_t *file);

--- a/dataobj/route_cache.cc
+++ b/dataobj/route_cache.cc
@@ -8,13 +8,13 @@
 
 
 route_t* route_cache_t::find(linehandle_t line, uint8 schedule_entry, koord3d start, koord3d ziel,
-                             sint32 max_speed_kmh, bool need_electric)
+                             sint32 max_speed_kmh, uint16 convoy_length, bool need_electric)
 {
 	line_map_t::iterator line_it = map.find(line);
 	if (line_it == map.end()) return nullptr;
 	entry_map_t::iterator entry_it = line_it->second.find(schedule_entry);
 	if (entry_it == line_it->second.end()) return nullptr;
-	route_map_t::iterator it = entry_it->second.find({start, ziel, max_speed_kmh, need_electric});
+	route_map_t::iterator it = entry_it->second.find({start, ziel, max_speed_kmh, convoy_length, need_electric});
 	if (it == entry_it->second.end()) return nullptr;
 	// Expiration check (unsigned subtraction handles wraparound)
 	karte_ptr_t welt;
@@ -27,11 +27,11 @@ route_t* route_cache_t::find(linehandle_t line, uint8 schedule_entry, koord3d st
 
 
 void route_cache_t::add(linehandle_t line, uint8 schedule_entry, koord3d start, koord3d ziel,
-                        sint32 max_speed_kmh, bool need_electric,
+                        sint32 max_speed_kmh, uint16 convoy_length, bool need_electric,
                         const route_t &r)
 {
 	karte_ptr_t welt;
-	const key_t key = {start, ziel, max_speed_kmh, need_electric};
+	const key_t key = {start, ziel, max_speed_kmh, convoy_length, need_electric};
 	route_map_t &route_map = map[line][schedule_entry];
 	route_map[key] = {r, welt->get_ticks()};
 	if (route_map.size() > MAX_ROUTES_PER_ENTRY) {
@@ -52,13 +52,13 @@ void route_cache_t::add(linehandle_t line, uint8 schedule_entry, koord3d start, 
 
 
 void route_cache_t::remove(linehandle_t line, uint8 schedule_entry, koord3d start, koord3d ziel,
-                           sint32 max_speed_kmh, bool need_electric)
+                           sint32 max_speed_kmh, uint16 convoy_length, bool need_electric)
 {
 	line_map_t::iterator line_it = map.find(line);
 	if (line_it != map.end()) {
 		entry_map_t::iterator entry_it = line_it->second.find(schedule_entry);
 		if (entry_it != line_it->second.end()) {
-			entry_it->second.erase({start, ziel, max_speed_kmh, need_electric});
+			entry_it->second.erase({start, ziel, max_speed_kmh, convoy_length, need_electric});
 		}
 	}
 }

--- a/dataobj/route_cache.cc
+++ b/dataobj/route_cache.cc
@@ -1,0 +1,49 @@
+/*
+ * This file is part of the Simutrans project under the Artistic License.
+ * (see LICENSE.txt)
+ */
+
+#include "route_cache.h"
+#include "../simworld.h"
+
+
+route_t* route_cache_t::find(linehandle_t line, koord3d start, koord3d ziel,
+                             sint32 max_speed_kmh, bool need_electric)
+{
+	auto line_it = map.find(line);
+	if (line_it == map.end()) return nullptr;
+	auto it = line_it->second.find({start, ziel, max_speed_kmh, need_electric});
+	if (it == line_it->second.end()) return nullptr;
+	// Expiration check (unsigned subtraction handles wraparound)
+	karte_ptr_t welt;
+	if (welt->get_ticks() - it->second.added_ticks > welt->ticks_per_world_month) {
+		line_it->second.erase(it);
+		return nullptr;
+	}
+	return &it->second.route;
+}
+
+
+void route_cache_t::add(linehandle_t line, koord3d start, koord3d ziel,
+                        sint32 max_speed_kmh, bool need_electric,
+                        const route_t &r)
+{
+	karte_ptr_t welt;
+	map[line][{start, ziel, max_speed_kmh, need_electric}] = {r, welt->get_ticks()};
+}
+
+
+void route_cache_t::remove(linehandle_t line, koord3d start, koord3d ziel,
+                           sint32 max_speed_kmh, bool need_electric)
+{
+	auto line_it = map.find(line);
+	if (line_it != map.end()) {
+		line_it->second.erase({start, ziel, max_speed_kmh, need_electric});
+	}
+}
+
+
+void route_cache_t::remove_line(linehandle_t line)
+{
+	map.erase(line);
+}

--- a/dataobj/route_cache.cc
+++ b/dataobj/route_cache.cc
@@ -7,38 +7,59 @@
 #include "../simworld.h"
 
 
-route_t* route_cache_t::find(linehandle_t line, koord3d start, koord3d ziel,
+route_t* route_cache_t::find(linehandle_t line, uint8 schedule_entry, koord3d start, koord3d ziel,
                              sint32 max_speed_kmh, bool need_electric)
 {
-	auto line_it = map.find(line);
+	line_map_t::iterator line_it = map.find(line);
 	if (line_it == map.end()) return nullptr;
-	auto it = line_it->second.find({start, ziel, max_speed_kmh, need_electric});
-	if (it == line_it->second.end()) return nullptr;
+	entry_map_t::iterator entry_it = line_it->second.find(schedule_entry);
+	if (entry_it == line_it->second.end()) return nullptr;
+	route_map_t::iterator it = entry_it->second.find({start, ziel, max_speed_kmh, need_electric});
+	if (it == entry_it->second.end()) return nullptr;
 	// Expiration check (unsigned subtraction handles wraparound)
 	karte_ptr_t welt;
 	if (welt->get_ticks() - it->second.added_ticks > welt->ticks_per_world_month) {
-		line_it->second.erase(it);
+		entry_it->second.erase(it);
 		return nullptr;
 	}
 	return &it->second.route;
 }
 
 
-void route_cache_t::add(linehandle_t line, koord3d start, koord3d ziel,
+void route_cache_t::add(linehandle_t line, uint8 schedule_entry, koord3d start, koord3d ziel,
                         sint32 max_speed_kmh, bool need_electric,
                         const route_t &r)
 {
 	karte_ptr_t welt;
-	map[line][{start, ziel, max_speed_kmh, need_electric}] = {r, welt->get_ticks()};
+	const key_t key = {start, ziel, max_speed_kmh, need_electric};
+	route_map_t &route_map = map[line][schedule_entry];
+	route_map[key] = {r, welt->get_ticks()};
+	if (route_map.size() > MAX_ROUTES_PER_ENTRY) {
+		// Evict the oldest entry
+		route_map_t::iterator oldest = route_map.end();
+		uint32 oldest_ticks = UINT32_MAX;
+		for (route_map_t::iterator it = route_map.begin(); it != route_map.end(); ++it) {
+			if (it->second.added_ticks < oldest_ticks) {
+				oldest_ticks = it->second.added_ticks;
+				oldest = it;
+			}
+		}
+		if (oldest != route_map.end()) {
+			route_map.erase(oldest);
+		}
+	}
 }
 
 
-void route_cache_t::remove(linehandle_t line, koord3d start, koord3d ziel,
+void route_cache_t::remove(linehandle_t line, uint8 schedule_entry, koord3d start, koord3d ziel,
                            sint32 max_speed_kmh, bool need_electric)
 {
-	auto line_it = map.find(line);
+	line_map_t::iterator line_it = map.find(line);
 	if (line_it != map.end()) {
-		line_it->second.erase({start, ziel, max_speed_kmh, need_electric});
+		entry_map_t::iterator entry_it = line_it->second.find(schedule_entry);
+		if (entry_it != line_it->second.end()) {
+			entry_it->second.erase({start, ziel, max_speed_kmh, need_electric});
+		}
 	}
 }
 

--- a/dataobj/route_cache.h
+++ b/dataobj/route_cache.h
@@ -10,14 +10,13 @@
 #include "../dataobj/koord3d.h"
 #include "../simtypes.h"
 #include "../dataobj/route.h"
+#include "../linehandle_t.h"
 
 /**
- * Global route cache keyed by (start, ziel, max_speed_kmh, need_electric).
- * need_electric is part of the key because electric vehicles can only use
- * electrified track, so a diesel route and an electric route between the
- * same endpoints may differ.
+ * Global route cache keyed by (line, start, ziel, max_speed_kmh, need_electric).
+ * Only convoys assigned to a line use this cache.
+ * Entries expire after one game month (ticks_per_world_month).
  * Memory-only: not saved/loaded with the game.
- * Shared across all convoys to avoid redundant A* searches.
  */
 struct route_cache_t {
 	struct key_t {
@@ -40,18 +39,35 @@ struct route_cache_t {
 			return h;
 		}
 	};
-	std::unordered_map<key_t, route_t, key_hash> map;
 
-	route_t* find(koord3d start, koord3d ziel, sint32 max_speed_kmh, bool need_electric) {
-		auto it = map.find({start, ziel, max_speed_kmh, need_electric});
-		return (it != map.end()) ? &it->second : nullptr;
-	}
-	void add(koord3d start, koord3d ziel, sint32 max_speed_kmh, bool need_electric, const route_t &r) {
-		map[{start, ziel, max_speed_kmh, need_electric}] = r;
-	}
-	void remove(koord3d start, koord3d ziel, sint32 max_speed_kmh, bool need_electric) {
-		map.erase({start, ziel, max_speed_kmh, need_electric});
-	}
+	struct entry_t {
+		route_t route;
+		uint32  added_ticks;
+	};
+
+	struct line_hash {
+		size_t operator()(const linehandle_t &l) const {
+			return (size_t)l.get_id();
+		}
+	};
+
+	// Outer key: linehandle_t, Inner key: route key
+	std::unordered_map<linehandle_t,
+		std::unordered_map<key_t, entry_t, key_hash>,
+		line_hash> map;
+
+	route_t* find(linehandle_t line, koord3d start, koord3d ziel,
+	              sint32 max_speed_kmh, bool need_electric);
+
+	void add(linehandle_t line, koord3d start, koord3d ziel,
+	         sint32 max_speed_kmh, bool need_electric,
+	         const route_t &r);
+
+	void remove(linehandle_t line, koord3d start, koord3d ziel,
+	            sint32 max_speed_kmh, bool need_electric);
+
+	// Erase all cache entries for a given line
+	void remove_line(linehandle_t line);
 };
 
 #endif

--- a/dataobj/route_cache.h
+++ b/dataobj/route_cache.h
@@ -1,0 +1,57 @@
+/*
+ * This file is part of the Simutrans project under the Artistic License.
+ * (see LICENSE.txt)
+ */
+
+#ifndef DATAOBJ_ROUTE_CACHE_H
+#define DATAOBJ_ROUTE_CACHE_H
+
+#include <unordered_map>
+#include "../dataobj/koord3d.h"
+#include "../simtypes.h"
+#include "../dataobj/route.h"
+
+/**
+ * Global route cache keyed by (start, ziel, max_speed_kmh, need_electric).
+ * need_electric is part of the key because electric vehicles can only use
+ * electrified track, so a diesel route and an electric route between the
+ * same endpoints may differ.
+ * Memory-only: not saved/loaded with the game.
+ * Shared across all convoys to avoid redundant A* searches.
+ */
+struct route_cache_t {
+	struct key_t {
+		koord3d start;
+		koord3d ziel;
+		sint32  max_speed_kmh;
+		bool    need_electric;
+		bool operator==(const key_t &o) const {
+			return start == o.start && ziel == o.ziel
+			    && max_speed_kmh == o.max_speed_kmh
+			    && need_electric == o.need_electric;
+		}
+	};
+	struct key_hash {
+		size_t operator()(const key_t &k) const {
+			size_t h = (size_t)(uint16)k.start.x ^ ((size_t)(uint16)k.start.y << 16) ^ ((size_t)(uint8)k.start.z << 24);
+			h ^= ((size_t)(uint16)k.ziel.x << 3) ^ ((size_t)(uint16)k.ziel.y << 19) ^ ((size_t)(uint8)k.ziel.z << 27);
+			h ^= (size_t)(uint32)k.max_speed_kmh;
+			h ^= k.need_electric ? 0x80000000u : 0u;
+			return h;
+		}
+	};
+	std::unordered_map<key_t, route_t, key_hash> map;
+
+	route_t* find(koord3d start, koord3d ziel, sint32 max_speed_kmh, bool need_electric) {
+		auto it = map.find({start, ziel, max_speed_kmh, need_electric});
+		return (it != map.end()) ? &it->second : nullptr;
+	}
+	void add(koord3d start, koord3d ziel, sint32 max_speed_kmh, bool need_electric, const route_t &r) {
+		map[{start, ziel, max_speed_kmh, need_electric}] = r;
+	}
+	void remove(koord3d start, koord3d ziel, sint32 max_speed_kmh, bool need_electric) {
+		map.erase({start, ziel, max_speed_kmh, need_electric});
+	}
+};
+
+#endif

--- a/dataobj/route_cache.h
+++ b/dataobj/route_cache.h
@@ -13,7 +13,7 @@
 #include "../linehandle_t.h"
 
 /**
- * Global route cache keyed by (line, start, ziel, max_speed_kmh, need_electric).
+ * Global route cache keyed by (line, schedule_entry, start, ziel, max_speed_kmh, convoy_length, need_electric).
  * Only convoys assigned to a line use this cache.
  * Entries expire after one game month (ticks_per_world_month).
  * Memory-only: not saved/loaded with the game.
@@ -23,10 +23,12 @@ struct route_cache_t {
 		koord3d start;
 		koord3d ziel;
 		sint32  max_speed_kmh;
+		uint16  convoy_length;
 		bool    need_electric;
 		bool operator==(const key_t &o) const {
 			return start == o.start && ziel == o.ziel
 			    && max_speed_kmh == o.max_speed_kmh
+			    && convoy_length == o.convoy_length
 			    && need_electric == o.need_electric;
 		}
 	};
@@ -35,6 +37,7 @@ struct route_cache_t {
 			size_t h = (size_t)(uint16)k.start.x ^ ((size_t)(uint16)k.start.y << 16) ^ ((size_t)(uint8)k.start.z << 24);
 			h ^= ((size_t)(uint16)k.ziel.x << 3) ^ ((size_t)(uint16)k.ziel.y << 19) ^ ((size_t)(uint8)k.ziel.z << 27);
 			h ^= (size_t)(uint32)k.max_speed_kmh;
+			h ^= (size_t)k.convoy_length << 7;
 			h ^= k.need_electric ? 0x80000000u : 0u;
 			return h;
 		}
@@ -61,14 +64,14 @@ struct route_cache_t {
 	line_map_t map;
 
 	route_t* find(linehandle_t line, uint8 schedule_entry, koord3d start, koord3d ziel,
-	              sint32 max_speed_kmh, bool need_electric);
+	              sint32 max_speed_kmh, uint16 convoy_length, bool need_electric);
 
 	void add(linehandle_t line, uint8 schedule_entry, koord3d start, koord3d ziel,
-	         sint32 max_speed_kmh, bool need_electric,
+	         sint32 max_speed_kmh, uint16 convoy_length, bool need_electric,
 	         const route_t &r);
 
 	void remove(linehandle_t line, uint8 schedule_entry, koord3d start, koord3d ziel,
-	            sint32 max_speed_kmh, bool need_electric);
+	            sint32 max_speed_kmh, uint16 convoy_length, bool need_electric);
 
 	// Erase all cache entries for a given line
 	void remove_line(linehandle_t line);

--- a/dataobj/route_cache.h
+++ b/dataobj/route_cache.h
@@ -51,19 +51,23 @@ struct route_cache_t {
 		}
 	};
 
-	// Outer key: linehandle_t, Inner key: route key
-	std::unordered_map<linehandle_t,
-		std::unordered_map<key_t, entry_t, key_hash>,
-		line_hash> map;
+	static const size_t MAX_ROUTES_PER_ENTRY = 4;
 
-	route_t* find(linehandle_t line, koord3d start, koord3d ziel,
+	typedef std::unordered_map<key_t, entry_t, key_hash> route_map_t;
+	typedef std::unordered_map<uint8, route_map_t> entry_map_t;
+	typedef std::unordered_map<linehandle_t, entry_map_t, line_hash> line_map_t;
+
+	// Outer key: linehandle_t, Middle key: schedule entry index, Inner key: route key
+	line_map_t map;
+
+	route_t* find(linehandle_t line, uint8 schedule_entry, koord3d start, koord3d ziel,
 	              sint32 max_speed_kmh, bool need_electric);
 
-	void add(linehandle_t line, koord3d start, koord3d ziel,
+	void add(linehandle_t line, uint8 schedule_entry, koord3d start, koord3d ziel,
 	         sint32 max_speed_kmh, bool need_electric,
 	         const route_t &r);
 
-	void remove(linehandle_t line, koord3d start, koord3d ziel,
+	void remove(linehandle_t line, uint8 schedule_entry, koord3d start, koord3d ziel,
 	            sint32 max_speed_kmh, bool need_electric);
 
 	// Erase all cache entries for a given line

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -42,6 +42,7 @@
 
 #include "dataobj/schedule.h"
 #include "dataobj/route.h"
+#include "dataobj/route_cache.h"
 #include "dataobj/ribi.h"
 #include "dataobj/loadsave.h"
 #include "dataobj/translator.h"
@@ -1273,6 +1274,26 @@ bool convoi_t::drive_to()
 		koord3d start = front()->get_pos();
 		koord3d ziel = schedule->get_current_entry().pos;
 
+		const sint32 max_speed_kmh = speed_to_kmh(min_top_speed);
+		const bool need_electric = needs_electrification();
+
+		// Cache-aware route calculation: tries cache first, falls back to A* on miss or passability failure.
+		auto cached_calc_route = [&](koord3d s, koord3d z, route_t* r, bool pass_stop) -> bool {
+			if (route_t *cached = welt->get_route_cache().find(s, z, max_speed_kmh, need_electric)) {
+				if (cached->is_passable(welt, fahr[0], need_electric)) {
+					*r = *cached;
+					return true;
+				} else {
+					welt->get_route_cache().remove(s, z, max_speed_kmh, need_electric);
+				}
+			}
+			const bool ok = fahr[0]->calc_route(s, z, max_speed_kmh, r, pass_stop);
+			if (ok) {
+				welt->get_route_cache().add(s, z, max_speed_kmh, need_electric, *r);
+			}
+			return ok;
+		};
+
 		// avoid stopping mid-halt
 		if(  start==ziel  ) {
 			halthandle_t halt = haltestelle_t::get_stoppable_halt(ziel,get_owner(),front()->get_waytype());
@@ -1289,7 +1310,7 @@ bool convoi_t::drive_to()
 			}
 		}
 
-		if(  !fahr[0]->calc_route( start, ziel, speed_to_kmh(min_top_speed), &route, schedule->get_current_entry().is_pass_stop() )  ) {
+		if(  !cached_calc_route( start, ziel, &route, schedule->get_current_entry().is_pass_stop() )  ) {
 			if(  state != NO_ROUTE  ) {
 				state = NO_ROUTE;
 				get_owner()->report_vehicle_problem( self, ziel );
@@ -1343,7 +1364,7 @@ bool convoi_t::drive_to()
 					}
 
 					route_t next_segment;
-					if(  !fahr[0]->calc_route( start, ziel, speed_to_kmh(min_top_speed), &next_segment, schedule->get_current_entry().is_pass_stop() )  ) {
+					if(  !cached_calc_route( start, ziel, &next_segment, schedule->get_current_entry().is_pass_stop() )  ) {
 						// do we still have a valid route to proceed => then go until there
 						if(  route.get_count()>1  ) {
 							break;

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -1282,20 +1282,22 @@ bool convoi_t::drive_to()
 		auto cached_calc_route = [&](koord3d s, koord3d z, route_t* r, bool pass_stop) -> bool {
 			if (line.is_bound()) {
 				const uint8 entry_idx = schedule->get_current_stop();
+				const uint16 cnv_len = pass_stop ? 0 : get_entire_convoy_length();
 				route_t *cached = welt->get_route_cache().find(
-						line, entry_idx, s, z, max_speed_kmh, need_electric);
+						line, entry_idx, s, z, max_speed_kmh, cnv_len, need_electric);
 				if (cached  &&  cached->is_passable(welt, fahr[0], need_electric)) {
 					*r = *cached;
 					return true;
 				}
 				if (cached) {
-					welt->get_route_cache().remove(line, entry_idx, s, z, max_speed_kmh, need_electric);
+					welt->get_route_cache().remove(line, entry_idx, s, z, max_speed_kmh, cnv_len, need_electric);
 				}
 			}
 			const bool ok = fahr[0]->calc_route(s, z, max_speed_kmh, r, pass_stop);
 			if (ok  &&  line.is_bound()) {
 				const uint8 entry_idx = schedule->get_current_stop();
-				welt->get_route_cache().add(line, entry_idx, s, z, max_speed_kmh, need_electric, *r);
+				const uint16 cnv_len = pass_stop ? 0 : get_entire_convoy_length();
+				welt->get_route_cache().add(line, entry_idx, s, z, max_speed_kmh, cnv_len, need_electric, *r);
 			}
 			return ok;
 		};

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -1281,19 +1281,21 @@ bool convoi_t::drive_to()
 		// Only convoys assigned to a line use the cache.
 		auto cached_calc_route = [&](koord3d s, koord3d z, route_t* r, bool pass_stop) -> bool {
 			if (line.is_bound()) {
+				const uint8 entry_idx = schedule->get_current_stop();
 				route_t *cached = welt->get_route_cache().find(
-						line, s, z, max_speed_kmh, need_electric);
+						line, entry_idx, s, z, max_speed_kmh, need_electric);
 				if (cached  &&  cached->is_passable(welt, fahr[0], need_electric)) {
 					*r = *cached;
 					return true;
 				}
 				if (cached) {
-					welt->get_route_cache().remove(line, s, z, max_speed_kmh, need_electric);
+					welt->get_route_cache().remove(line, entry_idx, s, z, max_speed_kmh, need_electric);
 				}
 			}
 			const bool ok = fahr[0]->calc_route(s, z, max_speed_kmh, r, pass_stop);
 			if (ok  &&  line.is_bound()) {
-				welt->get_route_cache().add(line, s, z, max_speed_kmh, need_electric, *r);
+				const uint8 entry_idx = schedule->get_current_stop();
+				welt->get_route_cache().add(line, entry_idx, s, z, max_speed_kmh, need_electric, *r);
 			}
 			return ok;
 		};

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -1278,9 +1278,11 @@ bool convoi_t::drive_to()
 		const bool need_electric = needs_electrification();
 
 		// Cache-aware route calculation: tries cache first, falls back to A* on miss or passability failure.
-		// Only convoys assigned to a line use the cache.
+		// Only convoys assigned to a line use the cache, and only when the convoy's schedule
+		// exactly matches the line's schedule (no extra depot entries).
+		const bool use_route_cache = line.is_bound()  &&  schedule->get_count() == line->get_schedule()->get_count();
 		auto cached_calc_route = [&](koord3d s, koord3d z, route_t* r, bool pass_stop) -> bool {
-			if (line.is_bound()) {
+			if (use_route_cache) {
 				const uint8 entry_idx = schedule->get_current_stop();
 				const uint16 cnv_len = pass_stop ? 0 : get_entire_convoy_length();
 				route_t *cached = welt->get_route_cache().find(
@@ -1294,7 +1296,7 @@ bool convoi_t::drive_to()
 				}
 			}
 			const bool ok = fahr[0]->calc_route(s, z, max_speed_kmh, r, pass_stop);
-			if (ok  &&  line.is_bound()) {
+			if (ok  &&  use_route_cache) {
 				const uint8 entry_idx = schedule->get_current_stop();
 				const uint16 cnv_len = pass_stop ? 0 : get_entire_convoy_length();
 				welt->get_route_cache().add(line, entry_idx, s, z, max_speed_kmh, cnv_len, need_electric, *r);

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -1278,18 +1278,22 @@ bool convoi_t::drive_to()
 		const bool need_electric = needs_electrification();
 
 		// Cache-aware route calculation: tries cache first, falls back to A* on miss or passability failure.
+		// Only convoys assigned to a line use the cache.
 		auto cached_calc_route = [&](koord3d s, koord3d z, route_t* r, bool pass_stop) -> bool {
-			if (route_t *cached = welt->get_route_cache().find(s, z, max_speed_kmh, need_electric)) {
-				if (cached->is_passable(welt, fahr[0], need_electric)) {
+			if (line.is_bound()) {
+				route_t *cached = welt->get_route_cache().find(
+						line, s, z, max_speed_kmh, need_electric);
+				if (cached  &&  cached->is_passable(welt, fahr[0], need_electric)) {
 					*r = *cached;
 					return true;
-				} else {
-					welt->get_route_cache().remove(s, z, max_speed_kmh, need_electric);
+				}
+				if (cached) {
+					welt->get_route_cache().remove(line, s, z, max_speed_kmh, need_electric);
 				}
 			}
 			const bool ok = fahr[0]->calc_route(s, z, max_speed_kmh, r, pass_stop);
-			if (ok) {
-				welt->get_route_cache().add(s, z, max_speed_kmh, need_electric, *r);
+			if (ok  &&  line.is_bound()) {
+				welt->get_route_cache().add(line, s, z, max_speed_kmh, need_electric, *r);
 			}
 			return ok;
 		};

--- a/simlinemgmt.cc
+++ b/simlinemgmt.cc
@@ -14,6 +14,7 @@
 
 #include "dataobj/schedule.h"
 #include "dataobj/loadsave.h"
+#include "dataobj/route_cache.h"
 
 #include "gui/schedule_list.h"
 
@@ -53,6 +54,8 @@ void simlinemgmt_t::delete_line(linehandle_t line)
 
 void simlinemgmt_t::update_line(linehandle_t line)
 {
+	// invalidate cached routes for this line since the schedule changed
+	world()->get_route_cache().remove_line(line);
 	// when a line is updated, all managed convoys must get the new schedule!
 	const int count = line->count_convoys();
 	for(  int i = 0;  i<count;  i++  ) {

--- a/simworld.h
+++ b/simworld.h
@@ -22,6 +22,7 @@
 #include "dataobj/settings.h"
 #include "dataobj/loadsave.h"
 #include "dataobj/rect.h"
+#include "dataobj/route_cache.h"
 
 #include "utils/checklist.h"
 #include "utils/sha1_hash.h"
@@ -124,6 +125,9 @@ public:
 	};
 
 private:
+	/// Route cache: maps (start, ziel, max_speed_kmh, need_electric) to a cached route_t.
+	route_cache_t route_cache;
+
 	/**
 	 * @name Map properties
 	 * Basic map properties are stored in this variables.
@@ -1166,6 +1170,8 @@ public:
 
 	void set_copy_convoi(convoihandle_t cnv) { copy_convoi = cnv; };
 	convoihandle_t get_copy_convoi() { return copy_convoi; }
+
+	route_cache_t& get_route_cache() { return route_cache; }
 
 private:
 	/**

--- a/tests/automated-tests/all_tests.nut
+++ b/tests/automated-tests/all_tests.nut
@@ -206,6 +206,9 @@ all_tests <- [
 	test_transport_pax_temp_unload_all,
 	test_transport_pax_transfer_interval,
 	test_transport_route_cache_convoy_length,
+	test_transport_route_cache_invalidation,
+	test_transport_route_cache_need_electric,
+	test_transport_two_convoys_on_same_line,
 	test_trees_plant_single_invalid_param,
 	test_way_tunnel_build_straight
 ]

--- a/tests/automated-tests/tests/test_transport.nut
+++ b/tests/automated-tests/tests/test_transport.nut
@@ -1035,81 +1035,206 @@ function test_transport_pax_transfer_interval()
 }
 
 
-function test_transport_route_cache_convoy_length()
+function test_transport_route_cache_invalidation()
 {
 	local pl = player_x(0)
 
 	// Layout:
-	//   halt_a: (4,2)-(4,3) [2 tiles], halt_b: (4,7)-(4,8) [2 tiles]
-	//   depot: (4,10)
-	//   Rail: (4,2)-(4,3)-(4,4)-(4,5)-(4,6)-(4,7)-(4,8)-(4,9)-(4,10)
+	//   (4,2) branch point (no stop), (4,3)=halt_a, (4,7)=halt_b, (4,8) branch point, (4,9)=depot
 	//
-	// Schedule: halt_b (4,7) -> halt_a (4,3).
-	// Convoy departs depot, goes to halt_b first (near depot), then to halt_a.
-	// We assert positions at halt_a (the 2nd schedule entry) so it is cache-aware.
-	// With advance_to_end=false:
-	//   cnv_short (1 loco, 1 tile): head stops at (4,3) — fits in 1 tile.
-	//   cnv_long (1 loco + 3 wagons, 2+ tiles): head advances to (4,2) to fit.
-	// Verifies that the route cache differentiates by convoy length.
+	//   Short road (direct):   (4,2)-(4,3)-...-(4,7)-(4,8)-(4,9)
+	//   Detour road (U-shape): (4,2)-(7,2)-(7,8)-(4,8)
+	//
+	// Stops at (4,3) and (4,7) — through-road tiles, NOT at intersection tiles (4,2)/(4,8).
+	// Convoy 1 caches the short route halt_a->halt_b.
+	// After convoy 1 reaches halt_b, the middle (4,4)-(4,6) is severed.
+	// Convoy 2 must detect the cached route is now impassable and find the detour.
 
 	debug.set_game_speed(5)
-	settings.set_advance_to_end(false)
 
-	local rail = way_desc_x.get_available_ways(wt_rail, st_flat)[0]
-	ASSERT_TRUE(rail != null)
+	// Build short road and detour
+	ASSERT_EQUAL(command_x(tool_build_way).work(pl, coord3d(4, 2, 0), coord3d(4, 9, 0), "cobblestone_road"), null)
+	ASSERT_EQUAL(command_x(tool_build_way).work(pl, coord3d(4, 2, 0), coord3d(7, 2, 0), "cobblestone_road"), null)
+	ASSERT_EQUAL(command_x(tool_build_way).work(pl, coord3d(7, 2, 0), coord3d(7, 8, 0), "cobblestone_road"), null)
+	ASSERT_EQUAL(command_x(tool_build_way).work(pl, coord3d(7, 8, 0), coord3d(4, 8, 0), "cobblestone_road"), null)
 
-	// Build track, 2-tile stops, and depot
-	ASSERT_EQUAL(command_x.build_way(pl, coord3d(4, 2, 0), coord3d(4, 10, 0), rail, false), null)
-	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 2, 0), "TrainStop"), null)
-	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 3, 0), "TrainStop"), null)
-	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 7, 0), "TrainStop"), null)
-	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 8, 0), "TrainStop"), null)
-	ASSERT_EQUAL(command_x.build_depot(pl, coord3d(4, 10, 0), building_desc_x("TrainDepot")), null)
+	// Stops at through-road tiles (not at intersection branch points)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 3, 0), "BusStop"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 7, 0), "BusStop"), null)
+	ASSERT_EQUAL(command_x.build_depot(pl, coord3d(4, 9, 0), building_desc_x("CarDepot")), null)
 
 	local halt_a = halt_x.get_halt(coord3d(4, 3, 0), pl)
 	local halt_b = halt_x.get_halt(coord3d(4, 7, 0), pl)
-	local sched  = create_simple_schedule(wt_rail, [ coord3d(4, 7, 0), coord3d(4, 3, 0) ])
-	local depot  = depot_x(4, 10, 0)
+	local sched  = create_simple_schedule(wt_road, [ coord3d(4, 3, 0), coord3d(4, 7, 0) ])
+	local depot  = depot_x(4, 9, 0)
 
-	// Create line and assign schedule
-	ASSERT_EQUAL(pl.create_line(wt_rail), true)
-	local line_list = pl.get_line_list()
-	local line = line_list[line_list.get_count() - 1]
-	line.change_schedule(pl, sched)
-
-	// Short convoy: 1 diesel loco only (1 tile)
-	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("1Diesellokomotive"))
-	local cnv_short = depot.get_convoy_list()[0]
-	cnv_short.set_line(pl, line)
+	// Convoy 1: routes halt_a->halt_b via short road (populates cache)
+	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("Buessig"))
+	local cnv1 = depot.get_convoy_list()[0]
+	cnv1.change_schedule(pl, sched)
 	depot.start_all_convoys(pl)
 
-	// Wait for short convoy to reach halt_a, check head position,
-	// then sell it so it does not block the single-track line.
-	while (halt_a.convoys[0] < 1) {
+	// Wait until convoy 1 has arrived at halt_b (short route is now cached)
+	while (halt_b.convoys[0] < 1) {
 		sleep()
 	}
-	// Short convoy (1 tile) stops with head at schedule pos (4,3)
-	ASSERT_EQUAL(cnv_short.get_pos().tostring(), coord3d(4, 3, 0).tostring())
-	cnv_short.destroy(pl)
+
+	// Remove convoy 1 to prevent it from visiting halt_b again and skewing the count
+	cnv1.destroy(pl)
 	sleep()
 	sleep()
 
-	// Long convoy: 1 diesel loco + 3 passenger wagons (2+ tiles)
-	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("1Diesellokomotive"))
-	local cnv_long = depot.get_convoy_list()[0]
-	depot.append_vehicle(pl, cnv_long, vehicle_desc_x("AdlerPersonenwagen"))
-	depot.append_vehicle(pl, cnv_long, vehicle_desc_x("AdlerPersonenwagen"))
-	depot.append_vehicle(pl, cnv_long, vehicle_desc_x("AdlerPersonenwagen"))
-	cnv_long.set_line(pl, line)
+	// Sever the short road in the middle, invalidating the cached route
+	ASSERT_EQUAL(command_x(tool_remove_way).work(pl, coord3d(4, 4, 0), coord3d(4, 6, 0), "" + wt_road), null)
+
+	// Convoy 2: same schedule; is_passable() must reject the cached route and run A* again
+	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("Buessig"))
+	local cnv2 = depot.get_convoy_list()[0]
+	cnv2.change_schedule(pl, sched)
 	depot.start_all_convoys(pl)
 
-	// Wait for long convoy to reach halt_a
+	// Wait for convoy 2 to arrive at halt_b via the detour
+	while (halt_b.convoys[0] < 2) {
+		sleep()
+	}
+	ASSERT_TRUE(halt_b.convoys[0] >= 2)
+
+	debug.set_game_speed(1)
+}
+
+
+function test_transport_route_cache_need_electric()
+{
+	local pl = player_x(0)
+
+	// Layout:
+	//   (4,2) branch point, (4,3)=halt_a, (4,7)=halt_b, (4,8) branch point, (4,9)=depot
+	//
+	//   Direct rail:  (4,2)-(4,3)-(4,4)-(4,5)-(4,6)-(4,7)-(4,8)-(4,9)
+	//   Detour rail:  (4,2)-(7,2)-(7,8)-(4,8)   [all electrified]
+	//
+	//   Electrified:  (4,2),(4,3),(4,7),(4,8),(4,9) + full detour
+	//   NOT electrified: (4,4),(4,5),(4,6)  [middle of direct track]
+	//
+	// Diesel (need_electric=false) caches the short direct route.
+	// Electric (need_electric=true) must use the electrified detour.
+	// Verifies that the cache key differentiates electric vs non-electric routes.
+
+	debug.set_game_speed(5)
+
+	local rail     = way_desc_x.get_available_ways(wt_rail, st_flat)[0]
+	local overhead = wayobj_desc_x.get_available_wayobjs(wt_rail).filter(@(idx, w) w.is_overhead_line())[0]
+	ASSERT_TRUE(rail != null)
+	ASSERT_TRUE(overhead != null)
+
+	// Build direct track and detour
+	ASSERT_EQUAL(command_x.build_way(pl, coord3d(4, 2, 0), coord3d(4, 9, 0), rail, false), null)
+	ASSERT_EQUAL(command_x.build_way(pl, coord3d(4, 2, 0), coord3d(7, 2, 0), rail, false), null)
+	ASSERT_EQUAL(command_x.build_way(pl, coord3d(7, 2, 0), coord3d(7, 8, 0), rail, false), null)
+	ASSERT_EQUAL(command_x.build_way(pl, coord3d(7, 8, 0), coord3d(4, 8, 0), rail, false), null)
+
+	// Electrify detour + (4,2)-(4,3) and (4,7)-(4,9); leave (4,4)-(4,6) unelectrified
+	ASSERT_EQUAL(command_x.build_wayobj(pl, coord3d(4, 2, 0), coord3d(4, 3, 0), overhead), null)
+	ASSERT_EQUAL(command_x.build_wayobj(pl, coord3d(4, 7, 0), coord3d(4, 9, 0), overhead), null)
+	ASSERT_EQUAL(command_x.build_wayobj(pl, coord3d(4, 2, 0), coord3d(7, 2, 0), overhead), null)
+	ASSERT_EQUAL(command_x.build_wayobj(pl, coord3d(7, 2, 0), coord3d(7, 8, 0), overhead), null)
+	ASSERT_EQUAL(command_x.build_wayobj(pl, coord3d(7, 8, 0), coord3d(4, 8, 0), overhead), null)
+
+	// Stops and depot
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 3, 0), "TrainStop"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 7, 0), "TrainStop"), null)
+	ASSERT_EQUAL(command_x.build_depot(pl, coord3d(4, 9, 0), building_desc_x("TrainDepot")), null)
+
+	local halt_a = halt_x.get_halt(coord3d(4, 3, 0), pl)
+	local halt_b = halt_x.get_halt(coord3d(4, 7, 0), pl)
+	local sched  = create_simple_schedule(wt_rail, [ coord3d(4, 3, 0), coord3d(4, 7, 0) ])
+	local depot  = depot_x(4, 9, 0)
+
+	// Diesel loco: routes via direct (non-electrified) track and caches that route
+	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("1Diesellokomotive"))
+	local cnv_diesel = depot.get_convoy_list()[0]
+	cnv_diesel.change_schedule(pl, sched)
+	depot.start_all_convoys(pl)
+
+	// Wait for diesel to reach halt_b (direct route cached with need_electric=false),
+	// then sell it immediately so it does not block the single-track direct route.
+	while (halt_b.convoys[0] < 1) {
+		sleep()
+	}
+	cnv_diesel.destroy(pl)
+	sleep()
+	sleep()
+
+	// Electric loco: must route via electrified detour
+	//   With need_electric in cache key → cache miss  → A* finds detour
+	//   Without                         → cache hit   → is_passable fails at (4,4)
+	//                                                  → cache cleared → A* finds detour
+	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("E44"))
+	local cnv_elec = depot.get_convoy_list()[0]
+	cnv_elec.change_schedule(pl, sched)
+	depot.start_all_convoys(pl)
+
+	// Wait for electric to also reach halt_b via the detour
+	while (halt_b.convoys[0] < 2) {
+		sleep()
+	}
+	ASSERT_TRUE(halt_b.convoys[0] >= 2)
+
+	debug.set_game_speed(1)
+}
+
+
+function test_transport_two_convoys_on_same_line()
+{
+	local pl = player_x(0)
+
+	// Speed up simulation
+	debug.set_game_speed(5)
+
+	// Build road, two stops and a depot
+	ASSERT_EQUAL(command_x(tool_build_way).work(pl, coord3d(4, 2, 0), coord3d(4, 8, 0), "cobblestone_road"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 2, 0), "BusStop"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 7, 0), "BusStop"), null)
+	ASSERT_EQUAL(command_x.build_depot(pl, coord3d(4, 8, 0), building_desc_x("CarDepot")), null)
+
+	local halt_a = halt_x.get_halt(coord3d(4, 2, 0), pl)
+	local halt_b = halt_x.get_halt(coord3d(4, 7, 0), pl)
+	local sched  = create_simple_schedule(wt_road, [ coord3d(4, 7, 0), coord3d(4, 2, 0) ])
+
+	// First convoy: add, schedule, start
+	local depot = depot_x(4, 8, 0)
+	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("Buessig"))
+	local cnv1 = depot.get_convoy_list()[0]
+	cnv1.change_schedule(pl, sched)
+	depot.start_all_convoys(pl)  // cnv1 leaves the depot
+
+	// Second convoy: add, schedule, start
+	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("Buessig"))
+	local cnv2 = depot.get_convoy_list()[0]
+	cnv2.change_schedule(pl, sched)
+	depot.start_all_convoys(pl)  // cnv2 leaves the depot
+
+	// Wait until both convoys have visited halt_b at least once each
+	while (halt_b.convoys[0] < 2) {
+		sleep()
+	}
+	ASSERT_TRUE(halt_b.convoys[0] >= 2)
+
+	// Wait until both convoys have visited halt_a at least once each
 	while (halt_a.convoys[0] < 2) {
 		sleep()
 	}
-	// Long convoy (2+ tiles) advances further to fit: head at (4,2)
-	ASSERT_EQUAL(cnv_long.get_pos().tostring(), coord3d(4, 2, 0).tostring())
+	ASSERT_TRUE(halt_a.convoys[0] >= 2)
 
-	settings.set_advance_to_end(true)
+	// clean up
 	debug.set_game_speed(1)
+	cnv1.destroy(pl)
+	cnv2.destroy(pl)
+	sleep()
+	sleep()
+	ASSERT_EQUAL(command_x(tool_remover).work(pl, coord3d(4, 2, 0)), null)
+	ASSERT_EQUAL(command_x(tool_remover).work(pl, coord3d(4, 7, 0)), null)
+	ASSERT_EQUAL(command_x(tool_remover).work(pl, coord3d(4, 8, 0)), null)
+	ASSERT_EQUAL(command_x(tool_remove_way).work(pl, coord3d(4, 2, 0), coord3d(4, 8, 0), "" + wt_road), null)
+	RESET_ALL_PLAYER_FUNDS()
 }

--- a/tests/automated-tests/tests/test_transport.nut
+++ b/tests/automated-tests/tests/test_transport.nut
@@ -1256,3 +1256,83 @@ function test_transport_two_convoys_on_same_line()
 	ASSERT_EQUAL(command_x(tool_remove_way).work(pl, coord3d(4, 2, 0), coord3d(4, 8, 0), "" + wt_road), null)
 	RESET_ALL_PLAYER_FUNDS()
 }
+
+
+function test_transport_route_cache_convoy_length()
+{
+	local pl = player_x(0)
+
+	// Layout:
+	//   halt_a: (4,2)-(4,3) [2 tiles], halt_b: (4,7)-(4,8) [2 tiles]
+	//   depot: (4,10)
+	//   Rail: (4,2)-(4,3)-(4,4)-(4,5)-(4,6)-(4,7)-(4,8)-(4,9)-(4,10)
+	//
+	// Schedule: halt_b (4,7) -> halt_a (4,3).
+	// Convoy departs depot, goes to halt_b first (near depot), then to halt_a.
+	// We assert positions at halt_a (the 2nd schedule entry) so it is cache-aware.
+	// With advance_to_end=false:
+	//   cnv_short (1 loco, 1 tile): head stops at (4,3) — fits in 1 tile.
+	//   cnv_long (1 loco + 3 wagons, 2+ tiles): head advances to (4,2) to fit.
+	// Verifies that the route cache differentiates by convoy length.
+
+	debug.set_game_speed(5)
+	settings.set_advance_to_end(false)
+
+	local rail = way_desc_x.get_available_ways(wt_rail, st_flat)[0]
+	ASSERT_TRUE(rail != null)
+
+	// Build track, 2-tile stops, and depot
+	ASSERT_EQUAL(command_x.build_way(pl, coord3d(4, 2, 0), coord3d(4, 10, 0), rail, false), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 2, 0), "TrainStop"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 3, 0), "TrainStop"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 7, 0), "TrainStop"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 8, 0), "TrainStop"), null)
+	ASSERT_EQUAL(command_x.build_depot(pl, coord3d(4, 10, 0), building_desc_x("TrainDepot")), null)
+
+	local halt_a = halt_x.get_halt(coord3d(4, 3, 0), pl)
+	local halt_b = halt_x.get_halt(coord3d(4, 7, 0), pl)
+	local sched  = create_simple_schedule(wt_rail, [ coord3d(4, 7, 0), coord3d(4, 3, 0) ])
+	local depot  = depot_x(4, 10, 0)
+
+	// Create line and assign schedule
+	ASSERT_EQUAL(pl.create_line(wt_rail), true)
+	local line_list = pl.get_line_list()
+	local line = line_list[line_list.get_count() - 1]
+	line.change_schedule(pl, sched)
+
+	// Short convoy: 1 diesel loco only (1 tile)
+	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("1Diesellokomotive"))
+	local cnv_short = depot.get_convoy_list()[0]
+	cnv_short.set_line(pl, line)
+	depot.start_all_convoys(pl)
+
+	// Wait for short convoy to reach halt_a, check head position,
+	// then sell it so it does not block the single-track line.
+	while (halt_a.convoys[0] < 1) {
+		sleep()
+	}
+	// Short convoy (1 tile) stops with head at schedule pos (4,3)
+	ASSERT_EQUAL(cnv_short.get_pos().tostring(), coord3d(4, 3, 0).tostring())
+	cnv_short.destroy(pl)
+	sleep()
+	sleep()
+
+	// Long convoy: 1 diesel loco + 3 passenger wagons (2+ tiles)
+	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("1Diesellokomotive"))
+	local cnv_long = depot.get_convoy_list()[0]
+	depot.append_vehicle(pl, cnv_long, vehicle_desc_x("AdlerPersonenwagen"))
+	depot.append_vehicle(pl, cnv_long, vehicle_desc_x("AdlerPersonenwagen"))
+	depot.append_vehicle(pl, cnv_long, vehicle_desc_x("AdlerPersonenwagen"))
+	cnv_long.set_line(pl, line)
+	depot.start_all_convoys(pl)
+
+	// Wait for long convoy to reach halt_a
+	while (halt_a.convoys[0] < 2) {
+		sleep()
+	}
+	// Long convoy (2+ tiles) advances further to fit: head at (4,2)
+	ASSERT_EQUAL(cnv_long.get_pos().tostring(), coord3d(4, 2, 0).tostring())
+
+	settings.set_advance_to_end(true)
+	debug.set_game_speed(1)
+}

--- a/tests/automated-tests/tests/test_transport.nut
+++ b/tests/automated-tests/tests/test_transport.nut
@@ -1068,10 +1068,16 @@ function test_transport_route_cache_invalidation()
 	local sched  = create_simple_schedule(wt_road, [ coord3d(4, 3, 0), coord3d(4, 7, 0) ])
 	local depot  = depot_x(4, 9, 0)
 
+	// Create line and assign schedule
+	ASSERT_EQUAL(pl.create_line(wt_road), true)
+	local line_list = pl.get_line_list()
+	local line = line_list[line_list.get_count() - 1]
+	line.change_schedule(pl, sched)
+
 	// Convoy 1: routes halt_a->halt_b via short road (populates cache)
 	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("Buessig"))
 	local cnv1 = depot.get_convoy_list()[0]
-	cnv1.change_schedule(pl, sched)
+	cnv1.set_line(pl, line)
 	depot.start_all_convoys(pl)
 
 	// Wait until convoy 1 has arrived at halt_b (short route is now cached)
@@ -1087,10 +1093,10 @@ function test_transport_route_cache_invalidation()
 	// Sever the short road in the middle, invalidating the cached route
 	ASSERT_EQUAL(command_x(tool_remove_way).work(pl, coord3d(4, 4, 0), coord3d(4, 6, 0), "" + wt_road), null)
 
-	// Convoy 2: same schedule; is_passable() must reject the cached route and run A* again
+	// Convoy 2: same line; is_passable() must reject the cached route and run A* again
 	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("Buessig"))
 	local cnv2 = depot.get_convoy_list()[0]
-	cnv2.change_schedule(pl, sched)
+	cnv2.set_line(pl, line)
 	depot.start_all_convoys(pl)
 
 	// Wait for convoy 2 to arrive at halt_b via the detour
@@ -1150,10 +1156,16 @@ function test_transport_route_cache_need_electric()
 	local sched  = create_simple_schedule(wt_rail, [ coord3d(4, 3, 0), coord3d(4, 7, 0) ])
 	local depot  = depot_x(4, 9, 0)
 
+	// Create line and assign schedule
+	ASSERT_EQUAL(pl.create_line(wt_rail), true)
+	local line_list = pl.get_line_list()
+	local line = line_list[line_list.get_count() - 1]
+	line.change_schedule(pl, sched)
+
 	// Diesel loco: routes via direct (non-electrified) track and caches that route
 	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("1Diesellokomotive"))
 	local cnv_diesel = depot.get_convoy_list()[0]
-	cnv_diesel.change_schedule(pl, sched)
+	cnv_diesel.set_line(pl, line)
 	depot.start_all_convoys(pl)
 
 	// Wait for diesel to reach halt_b (direct route cached with need_electric=false),
@@ -1171,7 +1183,7 @@ function test_transport_route_cache_need_electric()
 	//                                                  → cache cleared → A* finds detour
 	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("E44"))
 	local cnv_elec = depot.get_convoy_list()[0]
-	cnv_elec.change_schedule(pl, sched)
+	cnv_elec.set_line(pl, line)
 	depot.start_all_convoys(pl)
 
 	// Wait for electric to also reach halt_b via the detour
@@ -1201,17 +1213,23 @@ function test_transport_two_convoys_on_same_line()
 	local halt_b = halt_x.get_halt(coord3d(4, 7, 0), pl)
 	local sched  = create_simple_schedule(wt_road, [ coord3d(4, 7, 0), coord3d(4, 2, 0) ])
 
-	// First convoy: add, schedule, start
+	// Create line and assign schedule
+	ASSERT_EQUAL(pl.create_line(wt_road), true)
+	local line_list = pl.get_line_list()
+	local line = line_list[line_list.get_count() - 1]
+	line.change_schedule(pl, sched)
+
+	// First convoy: add, assign line, start
 	local depot = depot_x(4, 8, 0)
 	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("Buessig"))
 	local cnv1 = depot.get_convoy_list()[0]
-	cnv1.change_schedule(pl, sched)
+	cnv1.set_line(pl, line)
 	depot.start_all_convoys(pl)  // cnv1 leaves the depot
 
-	// Second convoy: add, schedule, start
+	// Second convoy: add, assign line, start
 	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("Buessig"))
 	local cnv2 = depot.get_convoy_list()[0]
-	cnv2.change_schedule(pl, sched)
+	cnv2.set_line(pl, line)
 	depot.start_all_convoys(pl)  // cnv2 leaves the depot
 
 	// Wait until both convoys have visited halt_b at least once each


### PR DESCRIPTION
## 概要

編成の経路探索（A*）結果をライン単位でキャッシュし、同じ経路を繰り返し計算するコストを削減する。

## 変更内容

### キャッシュキー

3階層構造でエントリを管理する:
1. 外側キー: `linehandle_t`（ライン）
2. 中間キー: `uint8`（スケジュールエントリのインデックス）
3. 内側キー: `(start: koord3d, ziel: koord3d, max_speed_kmh: sint32, need_electric: bool)`

`need_electric` をキーに含めることで、電化必須の編成と非電化編成が異なるキャッシュエントリを持ち、互いに干渉しない。

### スケジュールエントリ単位のキャッシュ制限

振分信号等により発車地点が毎回異なるケースでは、異なる`start`座標のキャッシュが大量に蓄積される問題がある。これを解決するため、キャッシュをスケジュールエントリに紐づけ、エントリあたり最大4件（`MAX_ROUTES_PER_ENTRY`）に制限する。制限を超えた場合は最も古いエントリを削除する。

これにより:
- 発車地点がばらつくスケジュールエントリでは経路キャッシュが頻繁に上書きされ、メモリが節約される
- 毎回同じ発車地点のスケジュールエントリでは経路キャッシュが維持され、経路探索が節約される

### ライン限定キャッシュ

ラインに所属する編成のみキャッシュを使用・登録する。ラインに所属しない編成は常にA*で経路探索を行う。

### 有効期限

各エントリはゲーム内1ヶ月（`ticks_per_world_month`）で自動失効する。`find()` 時に期限切れエントリを検出・除去する。

### スケジュール変更時のキャッシュ無効化

`simlinemgmt_t::update_line()` でラインのスケジュールが更新された際、そのラインに属する全キャッシュエントリを一括削除する（`remove_line()`）。

### 実装

- **`dataobj/route_cache.h`** (`route_cache_t`): キャッシュ本体の宣言。`linehandle_t` → `uint8`(スケジュールエントリ) → `key_t` の3階層 `std::unordered_map`。`MAX_ROUTES_PER_ENTRY = 4` の定数と型エイリアス(`route_map_t`, `entry_map_t`, `line_map_t`)を定義。
- **`dataobj/route_cache.cc`**: `find` / `add` / `remove` / `remove_line` メソッドの実装。`add()` でエントリ数が上限を超えた場合、最も古い `added_ticks` のエントリを削除。
- **`dataobj/route.h` / `route.cc`**: `route_t::is_passable(welt, tdriver, need_electric)` を追加。キャッシュヒット時に全タイルの通行可能性を検証する。
- **`simworld.h`**: `karte_t` に `route_cache_t route_cache`（private）と `get_route_cache()` getter（public）を追加。セーブデータには保存しない。
- **`simconvoi.cc`** (`drive_to()`): `line.is_bound()` の場合のみキャッシュを使用。`schedule->get_current_stop()` をラムダ内で都度取得し、ウェイポイント連鎖中のインデックス変化に対応。キャッシュヒット→passability検証→失敗時はエントリ削除してA*フォールバック。
- **`simlinemgmt.cc`** (`update_line()`): スケジュール変更時に `remove_line()` を呼び出してキャッシュを無効化。

### テスト

| テスト名 | 検証内容 |
|---------|---------|
| `test_transport_two_convoys_on_same_line` | 同一ラインの2編成が正常に運行できること |
| `test_transport_route_cache_invalidation` | 経路上の道路が撤去された後、キャッシュが無効化され迂回路が選択されること |
| `test_transport_route_cache_need_electric` | 電気機関車がディーゼルのキャッシュした非電化経路を使わず、電化迂回路を正しく選択すること |

テストでは `pl.create_line()` でラインを作成し、`cnv.set_line()` で編成をラインに割り当てて検証している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)