### PR TITLE
reset coupling button update(set_uncouple_child=false)

### DIFF
--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -1143,7 +1143,7 @@ dbg->message("schedule_gui_t::action_triggered()","comp=%p combo=%p",comp,&line_
 	else if(comp == &bt_reset_coupling) {
 		if(!schedule->empty()) {
 			schedule->at(schedule->get_current_stop()).reset_coupling();
-			schedule->at(schedule->get_current_stop()).set_uncouple_child(true);
+			schedule->at(schedule->get_current_stop()).set_uncouple_child(false);
 			update_selection();
 		}
 	}


### PR DESCRIPTION
連結設定解除ボタンについて、現在は連結解放がtrueになってしまっているので、同ボタンを押した際に連結解放をfalseにするようにします