### PR TITLE
can make and start invalid convoy

### DIFF
--- a/gui/convoi_detail_t.cc
+++ b/gui/convoi_detail_t.cc
@@ -77,7 +77,7 @@ public:
 			// power
 			if(v->get_desc()->get_power()>0) {
 				l = new_component<gui_label_buf_t>();
-				l->buf().printf("%s %i kW, %s %.2f", translator::translate("Power:"), (v->get_desc()->get_engine_type()==vehicle_desc_t::electric&&!v->get_convoi()->get_use_electric())?0:v->get_desc()->get_power(), translator::translate("Gear:"), v->get_desc()->get_gear()/64.0 );
+				l->buf().printf("%s %i kW, %s %.2f", translator::translate("Power:"), ((v->get_desc()->get_engine_type()==vehicle_desc_t::electric&&!v->get_convoi()->get_use_electric())||v->get_convoi()->is_invalid_convoy())?0:v->get_desc()->get_power(), translator::translate("Gear:"), v->get_desc()->get_gear()/64.0 );
 				l->update();
 			}
 			// friction

--- a/gui/convoi_info_t.cc
+++ b/gui/convoi_info_t.cc
@@ -429,7 +429,14 @@ void convoi_info_t::draw(scr_coord pos, scr_size size)
 			go_home_button.pressed = gr->get_depot() != NULL;
 		}
 		no_load_button.pressed = cnv->get_no_load()||cnv->is_invalid_convoy();
-		no_load_button.enable();
+		if(  cnv->is_invalid_convoy()  ){
+			// this convoy is invalid convoy->out of service
+			no_load_button.set_text("Out of service");
+			no_load_button.disable();
+		}	
+		else {
+			no_load_button.enable();
+		}
 		set_recovery_button.pressed = cnv->is_in_delay_recovery();
 		set_recovery_button.enable();
 		if(  cnv->is_coupled() ){

--- a/gui/convoi_info_t.cc
+++ b/gui/convoi_info_t.cc
@@ -428,7 +428,7 @@ void convoi_info_t::draw(scr_coord pos, scr_size size)
 		if(  grund_t* gr=welt->lookup(cnv->get_schedule()->get_current_entry().pos)  ) {
 			go_home_button.pressed = gr->get_depot() != NULL;
 		}
-		no_load_button.pressed = cnv->get_no_load();
+		no_load_button.pressed = cnv->get_no_load()||cnv->is_invalid_convoy();
 		no_load_button.enable();
 		set_recovery_button.pressed = cnv->is_in_delay_recovery();
 		set_recovery_button.enable();
@@ -612,7 +612,7 @@ bool convoi_info_t::action_triggered( gui_action_creator_t *comp,value_t /* */)
 			}
 		}
 
-		if(  comp == &no_load_button    &&    !route_search_in_progress  ) {
+		if(  comp == &no_load_button    &&    !route_search_in_progress  &&  !cnv->is_invalid_convoy()  ) {
 			cnv->call_convoi_tool( 'n', NULL );
 			return true;
 		}

--- a/gui/depot_frame.cc
+++ b/gui/depot_frame.cc
@@ -1816,9 +1816,6 @@ bool depot_frame_t::action_triggered( gui_action_creator_t *comp, value_t p)
 		}
 		else if(  comp == &bt_allow_invalid_convoy  ) {
 			bt_allow_invalid_convoy.pressed = !bt_allow_invalid_convoy.pressed;
-			if(  cnv.is_bound() && cnv->pruefe_alle()  ) {
-				cnv->call_convoi_tool('i', "0");
-			}
 			return true;
 		}
 		// image list selection here ...

--- a/gui/depot_frame.cc
+++ b/gui/depot_frame.cc
@@ -583,6 +583,7 @@ void depot_frame_t::layout(scr_size *size)
 
 	bt_allow_invalid_convoy.set_pos(scr_size(D_MARGIN_LEFT+D_H_SPACE+BUTTON_WIDTH_DEPOT, CONVOI_VSTART + cont_convoi.get_size().h + (3+D_SCROLLBAR_HEIGHT)*(CLIST_WIDTH >= win_size.w-D_MARGIN_LEFT-D_MARGIN_RIGHT) + D_V_SPACE));
 	bt_allow_invalid_convoy.set_width(BUTTON_WIDTH_DEPOT);
+	// invalid convoy can not go alone!
 	bt_allow_invalid_convoy.set_visible(should_show_child_convoi_selector);
 
 	// place for description text

--- a/gui/depot_frame.cc
+++ b/gui/depot_frame.cc
@@ -1085,6 +1085,9 @@ void depot_frame_t::update_data()
 		if(  cnv.is_bound()  &&  c == cnv  ) {
 			// this convoy
 			convoy_selector.set_selection( convoy_selector.count_elements() - 1 );
+			if(  cnv->get_vehicle_count()>0  ) {
+				bt_show_tram.pressed = cnv->front()->get_desc()->get_waytype()==tram_wt;
+			}
 		} 
 	}
 
@@ -1814,7 +1817,7 @@ bool depot_frame_t::action_triggered( gui_action_creator_t *comp, value_t p)
 		else if(  comp == &bt_allow_invalid_convoy  ) {
 			bt_allow_invalid_convoy.pressed = !bt_allow_invalid_convoy.pressed;
 			if(  cnv.is_bound() && cnv->pruefe_alle()  ) {
-				cnv->call_convoi_tool('i',NULL);
+				cnv->call_convoi_tool('i', "0");
 			}
 			return true;
 		}

--- a/gui/depot_frame.cc
+++ b/gui/depot_frame.cc
@@ -236,6 +236,11 @@ DBG_DEBUG("depot_frame_t::depot_frame_t()","get_max_convoi_length()=%i",depot->g
 	bt_remove_all_vehicles.set_tooltip("remove all vehicles.");
 	add_component(&bt_remove_all_vehicles);
 
+	bt_allow_invalid_convoy.init(button_t::square_state,"allow invalid convoy");
+	bt_allow_invalid_convoy.add_listener(this);
+	bt_allow_invalid_convoy.set_tooltip("allow invalid coupling convoy start. If start invalid convoy, the power set as 0, and no load permitted!");
+	add_component(&bt_allow_invalid_convoy);
+
 	/*
 	* [PANEL]
 	*/
@@ -514,6 +519,8 @@ void depot_frame_t::layout(scr_size *size)
 	}
 	gui_frame_t::set_windowsize(win_size);
 	set_min_windowsize(scr_size(D_DEFAULT_WIDTH, MIN_TOTAL_HEIGHT));
+	const waytype_t wt = depot->get_waytype();
+	const bool should_show_child_convoi_selector = (wt != road_wt && wt != air_wt && wt != water_wt);
 
 	/*
 	 * DONE with layout planning - now build everything.
@@ -574,6 +581,10 @@ void depot_frame_t::layout(scr_size *size)
 	bt_remove_all_vehicles.set_pos(scr_size(D_MARGIN_LEFT, CONVOI_VSTART + cont_convoi.get_size().h + (3+D_SCROLLBAR_HEIGHT)*(CLIST_WIDTH >= win_size.w-D_MARGIN_LEFT-D_MARGIN_RIGHT) + D_V_SPACE));
 	bt_remove_all_vehicles.set_width(BUTTON_WIDTH_DEPOT);
 
+	bt_allow_invalid_convoy.set_pos(scr_size(D_MARGIN_LEFT+D_H_SPACE+BUTTON_WIDTH_DEPOT, CONVOI_VSTART + cont_convoi.get_size().h + (3+D_SCROLLBAR_HEIGHT)*(CLIST_WIDTH >= win_size.w-D_MARGIN_LEFT-D_MARGIN_RIGHT) + D_V_SPACE));
+	bt_allow_invalid_convoy.set_width(BUTTON_WIDTH_DEPOT);
+	bt_allow_invalid_convoy.set_visible(should_show_child_convoi_selector);
+
 	// place for description text
 	second_column_x = D_MARGIN_LEFT + (BUTTON_WIDTH_DEPOT+D_H_SPACE*2)*2;
 	second_column_w = (BUTTON_WIDTH_DEPOT+D_H_SPACE)*2;
@@ -603,8 +614,6 @@ void depot_frame_t::layout(scr_size *size)
 	/*
 	 * [ACTIONS]
 	 */
-	const waytype_t wt = depot->get_waytype();
-	const bool should_show_child_convoi_selector = (wt != road_wt && wt != air_wt && wt != water_wt);
 	lb_child_convoy.set_visible(should_show_child_convoi_selector);
 	child_convoi_selector.set_visible(should_show_child_convoi_selector);
 	lb_child_convoy.set_pos(scr_coord(D_MARGIN_LEFT, ACTIONS_VSTART - D_BUTTON_HEIGHT ));
@@ -1171,6 +1180,7 @@ void depot_frame_t::update_data()
 		bt_reverse.pressed=cnv->is_reversing_needed();
 		bt_uncouple.enable();
 		bt_remove_all_vehicles.enable();
+		bt_allow_invalid_convoy.pressed|=cnv->is_invalid_convoy();
 	}
 
 	repositioning_t& rep = repositioning_t::get_instance();
@@ -1684,7 +1694,7 @@ sint64 depot_frame_t::calc_restwert(const vehicle_desc_t *veh_type)
 
 void depot_frame_t::image_from_storage_list(gui_image_list_t::image_data_t *image_data)
 {
-	if(  image_data->lcolor != color_idx_to_rgb(COL_RED)  &&  image_data->rcolor != color_idx_to_rgb(COL_RED)  ) {
+	if(  (image_data->lcolor != color_idx_to_rgb(COL_RED)  &&  image_data->rcolor != color_idx_to_rgb(COL_RED))  ||  (bt_allow_invalid_convoy.pressed)) {
 		if(  veh_action == va_set_offset  ) {
 			repositioning_t::get_instance().set_offset(image_data->text);
 			welt->set_dirty();
@@ -1704,7 +1714,7 @@ void depot_frame_t::image_from_storage_list(gui_image_list_t::image_data_t *imag
 				// rather than one new convoi with multiple vehicles
 				depot->set_command_pending();
 			}
-			depot->call_depot_tool( veh_action == va_insert ? 'i' : 'a', cnv, image_data->text );
+			depot->call_depot_tool( veh_action == va_insert ? 'i' : bt_allow_invalid_convoy.pressed? 'A' : 'a', cnv, image_data->text );
 		}
 	}
 }
@@ -1720,7 +1730,7 @@ void depot_frame_t::image_from_convoi_list(uint nr, bool to_end)
 		while(  start_nr > 0  ) {
 			start_nr--;
 			const vehicle_desc_t *info = cnv->get_vehikel(start_nr)->get_desc();
-			if(  info->get_trailer_count() != 1  ) {
+			if(  info->get_trailer_count() != 1 || cnv->is_invalid_convoy()  ) {
 				start_nr++;
 				break;
 			}
@@ -1800,6 +1810,13 @@ bool depot_frame_t::action_triggered( gui_action_creator_t *comp, value_t p)
 			bt_reverse.pressed = !bt_reverse.pressed;
 			return true;
 		}
+		else if(  comp == &bt_allow_invalid_convoy  ) {
+			bt_allow_invalid_convoy.pressed = !bt_allow_invalid_convoy.pressed;
+			if(  cnv.is_bound() && cnv->pruefe_alle()  ) {
+				cnv->call_convoi_tool('i',NULL);
+			}
+			return true;
+		}
 		// image list selection here ...
 		else if(  comp == &convoi  ) {
 			image_from_convoi_list( p.i, last_meta_event_get_class() == EVENT_DOUBLE_CLICK);
@@ -1843,8 +1860,10 @@ bool depot_frame_t::action_triggered( gui_action_creator_t *comp, value_t p)
 			depot_t::update_all_win();
 		}
 		else if(  comp == &bt_show_tram  ) {
-			bt_show_tram.pressed = !bt_show_tram.pressed;
-			build_vehicle_lists();
+			if(  !cnv.is_bound()  ) {
+				bt_show_tram.pressed = !bt_show_tram.pressed;
+				build_vehicle_lists();
+			}
 			return true;
 		}
 		else if(  comp == &bt_sell_all  ) {

--- a/gui/depot_frame.h
+++ b/gui/depot_frame.h
@@ -108,6 +108,7 @@ private:
 	button_t bt_reverse;
 	button_t bt_uncouple;
 	button_t bt_remove_all_vehicles;
+	button_t bt_allow_invalid_convoy;
 	const char* no_child_text;
 	gui_label_t lb_child_convoy;
 	// coupling convoy selector

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -3668,7 +3668,11 @@ bool convoi_t::pruefe_alle()
 	if(ok) {
 		ok = pred->get_desc()->can_lead(NULL);
 	}
-	if(ok) {  invalid_convoy=false;  }
+	if(ok) {
+		// if the coupoling condition is good, this is valid convoy.
+		// we set invalid_convoy only fron depot_frame_t
+		invalid_convoy=false;
+	}
 
 	return ok;
 }

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -3668,11 +3668,6 @@ bool convoi_t::pruefe_alle()
 	if(ok) {
 		ok = pred->get_desc()->can_lead(NULL);
 	}
-	if(ok) {
-		// if the coupoling condition is good, this is valid convoy.
-		// we set invalid_convoy only fron depot_frame_t
-		invalid_convoy=false;
-	}
 
 	return ok;
 }

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -200,6 +200,7 @@ void convoi_t::init(player_t *player)
 	max_speed_kmh_of_convoi = 0;
 	max_balance_speed_convoi = 0;
 	unloading_done = false;
+	invalid_convoy = false;
 }
 
 
@@ -3442,6 +3443,11 @@ void convoi_t::rdwr(loadsave_t *file)
 		max_balance_speed_convoi = 0;
 		unloading_done = false;
 	}
+	if(  file->get_OTRP_version()>=54  ) {
+		file->rdwr_bool(invalid_convoy);
+	} else {
+		invalid_convoy = false;
+	}
 
 	if(  file->is_loading()  ) {
 		reserve_route();
@@ -3621,7 +3627,8 @@ void convoi_t::open_schedule_window( bool show )
  */
 bool convoi_t::pruefe_alle()
 {
-	bool ok = anz_vehikel == 0  ||  fahr[0]->get_desc()->can_follow(NULL);
+	if(  anz_vehikel==0  ) { return true; }
+	bool ok = fahr[0]->get_desc()->can_follow(NULL);
 	unsigned i;
 
 	const vehicle_t* pred = fahr[0];
@@ -3634,6 +3641,7 @@ bool convoi_t::pruefe_alle()
 	if(ok) {
 		ok = pred->get_desc()->can_lead(NULL);
 	}
+	if(ok) {  invalid_convoy=false;  }
 
 	return ok;
 }
@@ -3645,7 +3653,7 @@ uint32 convoi_t::get_total_sum_power() const{
 	uint32 temp_sum_power = 0;
 	convoihandle_t c = self;
 	while(c.is_bound()) {
-		temp_sum_power += c->sum_power;
+		temp_sum_power += c->is_invalid_convoy()? 0: c->sum_power;
 		c = c->get_coupling_convoi();
 	}
 	return temp_sum_power;
@@ -3772,7 +3780,7 @@ bool can_depart(convoihandle_t cnv, halthandle_t halt, uint32 arrived_time, uint
 		const bool loading_level_cond = (c->get_schedule()->get_current_entry().maximum_loading<c->get_schedule()->get_current_entry().minimum_loading)?(c->get_loading_level() >= e.minimum_loading):(c->get_capacity_left()<=0); // minimum loading
 		const bool waiting_time_cond = (e.waiting_time_shift > 0  &&  world()->get_ticks() - arrived_time > (world()->ticks_per_world_month / e.waiting_time_shift) ); // waiting time
 		bool c_cond = loading_level_cond; // condition of this convoy
-		c_cond |= c->get_no_load(); // no load
+		c_cond |= c->get_no_load()||c->is_invalid_convoy(); // no load
 		c_cond |= waiting_time_cond;
 		loading_cond &= c_cond;
 		c = c->get_coupling_convoi();
@@ -3889,7 +3897,7 @@ void calc_reachable_halts(vector_tpl<haltestelle_t::reachable_halt_t>& reachable
 	const schedule_t* schedule = cnv->get_schedule();
 	const schedule_t* line_schedule = cnv->get_line().is_bound() ? cnv->get_line()->get_schedule() : schedule;
 	const player_t* owner = cnv->get_owner();
-	if (  cnv->get_no_load()  ||  schedule->get_current_entry().is_no_load()  ) {
+	if (  cnv->get_no_load()  ||  schedule->get_current_entry().is_no_load()  ||  cnv->is_invalid_convoy()  ) {
 		// Nothing is allowed to load here.
 		return;
 	}
@@ -4053,7 +4061,7 @@ void convoi_t::hat_gehalten(halthandle_t halt, uint32 halt_length_in_vehicle_ste
 
 	// cargo type of previous vehicle that could not be filled
 	const goods_desc_t* cargo_type_prev = NULL;
-	bool loading_needed = !no_load  &&  !next_depot;
+	bool loading_needed = !get_no_load()  &&  !next_depot  &&  !is_invalid_convoy();
 	// When load_before_departure is enabled, load cargos only when the departure time condition is satisfied.
 	convoihandle_t leading_convoy = get_most_parent_convoi();
 	if(  leading_convoy->schedule->get_current_entry().get_wait_for_time()  &&  schedule->get_current_entry().is_load_before_departure()  ) {
@@ -5905,8 +5913,10 @@ void convoi_t::check_electrification() {
 	convoihandle_t c = most_parent_convoi;
 	// Are there electric cars?
 	while(  c.is_bound()  &&  !is_electric  ) {
-		for(uint8 i=0; i<c->get_vehicle_count(); i++) {
-			is_electric |= c->get_vehikel(i)->get_desc()->get_engine_type()==vehicle_desc_t::electric;
+		if(  !c->is_invalid_convoy()  ) {
+			for(uint8 i=0; i<c->get_vehicle_count(); i++) {
+				is_electric |= c->get_vehikel(i)->get_desc()->get_engine_type()==vehicle_desc_t::electric;
+			}
 		}
 		c = c->get_coupling_convoi();
 	}
@@ -5914,8 +5924,10 @@ void convoi_t::check_electrification() {
 	need_electric = is_electric;
 	// If electric cars are, do they have other engine?
 	while(  c.is_bound()  &&  need_electric  ) {
-		for(uint8 i=0;  i<c->get_vehicle_count();  i++) {
-			need_electric &= !(c->get_vehikel(i)->get_desc()->get_engine_type()!=vehicle_desc_t::electric && c->get_vehikel(i)->get_desc()->get_power()>0);
+		if(  !c->is_invalid_convoy()  ) {
+			for(uint8 i=0;  i<c->get_vehicle_count();  i++) {
+				need_electric &= !(c->get_vehikel(i)->get_desc()->get_engine_type()!=vehicle_desc_t::electric && c->get_vehikel(i)->get_desc()->get_power()>0);
+			}
 		}
 		c = c->get_coupling_convoi();
 	}

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -922,7 +922,7 @@ public:
 	/**
 	 * invalid convoy: invalid coupling condition
 	 */
-	const bool is_invalid_convoy() const { return invalid_convoy; }
+	bool is_invalid_convoy() const { return invalid_convoy; }
 	void set_invalid_convoy(bool y) { invalid_convoy = y; }
 
 	/**

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -415,6 +415,13 @@ private:
 	uint16 max_balance_speed_convoi;
 
 	/**
+	 * invalid convoy: invalid coupling condition, etc..
+	 * if set "allow invalid convoy" in depot, it can be.
+	 * no load/ no engine.
+	 */
+	bool invalid_convoy;
+
+	/**
 	* Initialize all variables with default values.
 	* Each constructor must call this method first!
 	*/
@@ -726,7 +733,7 @@ public:
 	 * @return total power of this convoi
 	 */
 	const uint32 & get_sum_power() const {return sum_power;}
-	const sint32 get_sum_gear_and_power() const {return use_electric? sum_gear_and_power: sum_gear_and_power-sum_gear_and_power_electric;}
+	const sint32 get_sum_gear_and_power() const {return invalid_convoy?0:(use_electric? sum_gear_and_power: sum_gear_and_power-sum_gear_and_power_electric);}
 	const sint32 & get_min_top_speed() const {return min_top_speed;}
 	const sint32 & get_speed_limit() const {return speed_limit;}
 
@@ -911,6 +918,12 @@ public:
 	* Check if this convoi has entered a depot.
 	*/
 	bool in_depot() const { return state == INITIAL; }
+
+	/**
+	 * invalid convoy: invalid coupling condition
+	 */
+	const bool is_invalid_convoy() const { return invalid_convoy; }
+	void set_invalid_convoy(bool y) { invalid_convoy = y; }
 
 	/**
 	* loading_level was minimum_loading before. Actual percentage loaded of loadable

--- a/simdepot.cc
+++ b/simdepot.cc
@@ -520,6 +520,18 @@ bool depot_t::start_convoi(convoihandle_t cnv, bool local_execution)
 			}
 		}
 	}
+	// check invalid convoy
+	convoihandle_t c = cnv;
+	while (c.is_bound())
+	{
+		if(  c->pruefe_alle()  ) {
+			// if the coupoling condition is good, this is valid convoy.
+			// we set invalid_convoy only fron depot_frame_t
+			c->set_invalid_convoy(false);
+		}
+		c = c->get_coupling_convoi();
+	}
+
 	// Check the start condition
 	if(  !can_start_convoi(cnv, local_execution)  ) {
 		return false;

--- a/simdepot.cc
+++ b/simdepot.cc
@@ -585,7 +585,7 @@ bool depot_t::can_start_convoi(convoihandle_t cnv, bool local_execution)
 		}
 
 		// check if convoi is complete
-		if( front_cnv->get_total_sum_power() == 0 || !cnv->pruefe_alle()) {
+		if( front_cnv->get_total_sum_power() == 0 || ( !cnv->pruefe_alle() && !cnv->is_invalid_convoy() ) ) {
 			if (local_execution) {
 				create_win( new news_img("Diese Zusammenstellung kann nicht fahren!\n"), w_time_delete, magic_none);
 			}

--- a/simtool.cc
+++ b/simtool.cc
@@ -8931,7 +8931,7 @@ bool tool_change_convoi_t::init( player_t *player )
 
 		case 'i':
 		{
-			cnv->set_invalid_convoy(!cnv->is_invalid_convoy());
+			cnv->set_invalid_convoy(atoi(p)!=0);
 		}
 	}
 

--- a/simtool.cc
+++ b/simtool.cc
@@ -8649,6 +8649,7 @@ bool scenario_check_convoy(karte_t *welt, player_t *player, convoihandle_t cnv, 
  * 'c' : reversing coupling convoys
  * 'm' : apply max speed of convoy
  * 'b' : apply balance speed (limit power)
+ * 'i' : set invalid convoy
  */
 bool tool_change_convoi_t::init( player_t *player )
 {
@@ -8919,6 +8920,11 @@ bool tool_change_convoi_t::init( player_t *player )
 			cnv->set_max_balance_speed_convoi(max_balance_speed_convoi);
 		}
 		break;
+
+		case 'i':
+		{
+			cnv->set_invalid_convoy(!cnv->is_invalid_convoy());
+		}
 	}
 
 	if(  cnv->in_depot()  &&  (tool=='g'  ||  tool=='l')  ) {
@@ -9281,6 +9287,7 @@ bool tool_change_line_t::init( player_t *player )
  * 'd' : disassembles convoi
  * 's' : sells a vehicle
  * 'a' : appends a vehicle (+vehikel_name) uses the oldest
+ * 'A' : appends a vehicle (for invalid convoy)
  * 'i' : inserts a vehicle in front (+vehikel_name) uses the oldest
  * 's' : sells a vehikel (+vehikel_name) uses the newest
  * 'S' : sells all vehicles in this depot
@@ -9412,7 +9419,8 @@ bool tool_change_depot_t::init( player_t *player )
 			}
 			break;
 		}
-		case 'a':   // append a vehicle
+		case 'a':   // append a vehicle(with some vehicles)
+		case 'A':   // append a vehicle(for invalid convoy)
 		case 'i':   // insert a vehicle in front
 		case 's':   // sells a vehicle
 		case 'S':	// sells all vehicles
@@ -9461,7 +9469,7 @@ bool tool_change_depot_t::init( player_t *player )
 					slist_tpl<const vehicle_desc_t *>new_vehicle_info;
 					const vehicle_desc_t *start_info = info;
 
-					if(tool!='a') {
+					if(tool!='a'&&tool!='A') {
 						// start of composition
 						while(  info->get_leader_count() == 1  &&  info->get_leader(0) != NULL  &&  info->get_leader(0) != vehicle_desc_t::any_vehicle  &&  !new_vehicle_info.is_contained(info->get_leader(0))) {
 							info = info->get_leader(0);
@@ -9470,7 +9478,7 @@ bool tool_change_depot_t::init( player_t *player )
 						info = start_info;
 					}
 					new_vehicle_info.append( info );
-					if (tool != 'i') {
+					if (tool != 'i'&&tool!='A') {
 						while(info->get_trailer_count() == 1  &&  info->get_trailer(0) != NULL  &&  info->get_trailer(0) != vehicle_desc_t::any_vehicle  &&  !new_vehicle_info.is_contained(info->get_trailer(0))) {
 							info = info->get_trailer(0);
 							new_vehicle_info.append(info);
@@ -9526,6 +9534,9 @@ bool tool_change_depot_t::init( player_t *player )
 								}
 								depot->append_vehicle( cnv, veh, tool=='i', can_use_gui() );
 							}
+						}
+						if(  tool=='A'  ) {
+							cnv->set_invalid_convoy(true);
 						}
 					}
 				}

--- a/simtool.cc
+++ b/simtool.cc
@@ -9441,13 +9441,18 @@ bool tool_change_depot_t::init( player_t *player )
 					int start_nr = atoi(p);
 					int nr = start_nr;
 
-					// find end
-					while(nr<cnv->get_vehicle_count()) {
-						const vehicle_desc_t *info = cnv->get_vehikel(nr)->get_desc();
-						nr ++;
-						if(info->get_trailer_count()!=1) {
-							break;
+					// find end (for invalid convoy, only remove 1 vehicle at a time)
+					if(  !cnv->is_invalid_convoy()  ) {
+						while(nr<cnv->get_vehicle_count()) {
+							const vehicle_desc_t *info = cnv->get_vehikel(nr)->get_desc();
+							nr ++;
+							if(info->get_trailer_count()!=1) {
+								break;
+							}
 						}
+					}
+					else {
+						nr = start_nr + 1;
 					}
 					// now remove the vehicles
 					if(  cnv->get_vehicle_count()==nr-start_nr  ||  (tool=='R'  &&  start_nr==0)  ) {
@@ -9477,8 +9482,9 @@ bool tool_change_depot_t::init( player_t *player )
 					slist_tpl<const vehicle_desc_t *>new_vehicle_info;
 					const vehicle_desc_t *start_info = info;
 
-					if(tool!='a'&&tool!='A') {
-						// start of composition
+					const bool is_invalid = cnv.is_bound() && cnv->is_invalid_convoy();
+					if(tool!='a'&&tool!='A'&&!is_invalid) {
+						// start of composition (skipped for invalid convoy: insert only 1 vehicle)
 						while(  info->get_leader_count() == 1  &&  info->get_leader(0) != NULL  &&  info->get_leader(0) != vehicle_desc_t::any_vehicle  &&  !new_vehicle_info.is_contained(info->get_leader(0))) {
 							info = info->get_leader(0);
 							new_vehicle_info.insert(info);
@@ -9486,7 +9492,8 @@ bool tool_change_depot_t::init( player_t *player )
 						info = start_info;
 					}
 					new_vehicle_info.append( info );
-					if (tool != 'i'&&tool!='A') {
+					if (tool != 'i'&&tool!='A'&&!is_invalid) {
+						// trailer chain (skipped for invalid convoy: append only 1 vehicle)
 						while(info->get_trailer_count() == 1  &&  info->get_trailer(0) != NULL  &&  info->get_trailer(0) != vehicle_desc_t::any_vehicle  &&  !new_vehicle_info.is_contained(info->get_trailer(0))) {
 							info = info->get_trailer(0);
 							new_vehicle_info.append(info);


### PR DESCRIPTION
連結設定上不完全な編成を組成・出発できるようにします。
- 車庫に`allow_invalid_convoy`ボタンを追加
- 連結設定を(路面電車-鉄道の連結を除き)無視して組成できる
- 最終的に組んだ編成が不完全な場合、編成は`invalid_convoy`フラグをもって走行する。
  - このとき、当該編成は出力0扱い/常時回送となる
  - そのため、不完全な編成は自走できない
※本機能は、甲種輸送/陸送等を再現するための機能になります。実用性はほぼ皆無です