### PR TITLE
BUG FIX: try coupling reservation update during loading file

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -3444,6 +3444,16 @@ void convoi_t::rdwr(loadsave_t *file)
 	}
 
 	if(  file->is_loading()  ) {
+		// A try-coupling convoy waiting at a guide signal (WAITING_FOR_CLEARANCE etc.) has
+		// next_coupling_index == INVALID_INDEX because the coupling route is not yet found.
+		// next_reservation_index may have been set too far ahead by a prior block_reserver(1001)
+		// call on the ORIGINAL route (past the guide signal). Cap it at next_stop_index before
+		// reserve_route() runs so the wrong tiles are never reserved in the first place.
+		if(  is_waiting()  &&  next_coupling_index == route_t::INVALID_INDEX
+		  &&  schedule != NULL  &&  schedule->get_current_entry().is_try_coupling()
+		  &&  next_reservation_index > next_stop_index  ) {
+			next_reservation_index = next_stop_index;
+		}
 		reserve_route();
 		recalc_catg_index();
 	}

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -1033,7 +1033,7 @@ public:
 	 */
 	uint16 get_next_coupling_index() const {return next_coupling_index;}
 	uint8 get_next_coupling_steps() const {return next_coupling_steps;}
-	void set_next_coupling(uint16 n, uint8 m) { next_coupling_index = n; next_coupling_steps = m; }
+	void set_next_coupling(uint16 n, uint8 m) { next_coupling_index = n; next_reservation_index = n; next_coupling_steps = m; }
 
 	convoihandle_t get_coupling_convoi() const {return coupling_convoi;}
 	void set_coupling_convoi(convoihandle_t c) {coupling_convoi = c;}


### PR DESCRIPTION
連結試行編成がセーブデータのロード等で不要な線路の予約を行う不具合を修正しました