### PR TITLE
read paks by makeobj 60.9 and set clip mode

### DIFF
--- a/boden/wege/weg.cc
+++ b/boden/wege/weg.cc
@@ -56,6 +56,13 @@ const slist_tpl <weg_t *> & weg_t::get_alle_wege()
 }
 
 
+bool weg_t::is_clipping_below_needed() const
+{
+	// elevated no clip?
+	return desc->is_clip_below();
+}
+
+
 // returns a way with matching waytype
 weg_t* weg_t::alloc(waytype_t wt)
 {

--- a/boden/wege/weg.h
+++ b/boden/wege/weg.h
@@ -323,6 +323,8 @@ public:
 
 	// correct maintenance
 	void finish_rd() OVERRIDE;
+
+	virtual bool is_clipping_below_needed() const OVERRIDE;
 } GCC_PACKED;
 
 #endif

--- a/dataobj/environment.cc
+++ b/dataobj/environment.cc
@@ -159,6 +159,7 @@ uint8 env_t::show_vehicle_states;
 bool env_t::show_only_own_vehicle_states;
 bool env_t::show_line_colors;
 bool env_t::show_convoy_loadinglevel;
+sint8 env_t::clip_below;
 bool env_t::visualize_schedule;
 sint8 env_t::daynight_level;
 bool env_t::left_to_right_graphs;
@@ -316,6 +317,7 @@ void env_t::init()
 	show_only_own_vehicle_states = false;
 	show_line_colors = true;
 	show_convoy_loadinglevel = true;
+	clip_below = CLIP_BELOW_PAK;
 
 	daynight_level = 0;
 
@@ -649,6 +651,9 @@ void env_t::rdwr(loadsave_t *file)
 	}
 	if(  file->get_OTRP_version()>=53  ) {
 		file->rdwr_bool(show_only_own_vehicle_states);
+	}
+	if(  file->get_OTRP_version()>=54  ) {
+		file->rdwr_byte((uint8&)clip_below);
 	}
 
 

--- a/dataobj/environment.h
+++ b/dataobj/environment.h
@@ -298,6 +298,15 @@ public:
 	static bool show_line_colors;
 	static bool show_convoy_loadinglevel;
 
+	/// Controls clipping of objects below elevated ways/bridges
+	/// 0 = never clip (no cut), 1 = always clip (all cut), 2 = use pak descriptor (pak dependence)
+	enum clip_below_mode {
+		CLIP_BELOW_NEVER  = 0,
+		CLIP_BELOW_ALWAYS = 1,
+		CLIP_BELOW_PAK    = 2
+	};
+	static sint8 clip_below;
+
 	/// show station coverage indicators
 	static uint8 station_coverage_show;
 

--- a/descriptor/bridge_desc.h
+++ b/descriptor/bridge_desc.h
@@ -40,6 +40,7 @@ private:
 
 	// number of seasons (0 = none, 1 = no snow/snow
 	sint8 number_of_seasons = 0;
+	bool  clip_below;  // default is true
 
 public:
 	/*
@@ -79,6 +80,8 @@ public:
 		}
 		return image != NULL ? image->get_id() : IMG_EMPTY;
 	}
+
+	bool is_clip_below() const { return clip_below; }
 
 	img_t get_straight(ribi_t::ribi ribi, uint8 height) const;
 	img_t get_start(slope_t::type slope) const;

--- a/descriptor/factory_desc.cc
+++ b/descriptor/factory_desc.cc
@@ -62,6 +62,22 @@ void factory_desc_t::correct_smoke()
 		smokeuplift = DEFAULT_SMOKE_UPLIFT;
 		smokelifetime = DEFAULT_FACTORYSMOKE_TIME;
 	}
+	// check for smoke outside of boundries
+	if (get_smoke()) {
+		for (int i = 0; i < smokerotations; i++) {
+			koord new_tile;
+			new_tile.x = clamp((int)smoketile[i].x, 0, get_building()->get_x(i) - 1);
+			new_tile.y = clamp((int)smoketile[i].y, 0, get_building()->get_y(i) - 1);
+			if (new_tile != smoketile[i]) {
+				// tile is outside => compensate with new offsets
+				smokeoffset[i].x += ((smoketile[i].x - new_tile.x) * get_tile_raster_width()) / 2 - ((smoketile[i].y - new_tile.y) * get_tile_raster_width()) / 2;
+				smokeoffset[i].y += ((smoketile[i].x - new_tile.x) * get_tile_raster_width()) / 4 + ((smoketile[i].y - new_tile.y) * get_tile_raster_width()) / 4;
+				smoketile[i] = new_tile;
+
+				dbg->warning("factory_desc_t::correct_smoke()", "smoke of \"%s\" in rotation %d, changed to (%s) and offsets %d,%d", get_name(), i, new_tile.get_str(), smoketile[i].x, smoketile[i].y);
+			}
+		}
+	}
 }
 
 

--- a/descriptor/reader/bridge_reader.cc
+++ b/descriptor/reader/bridge_reader.cc
@@ -172,6 +172,22 @@ obj_desc_t *bridge_reader_t::read_node(FILE *fp, obj_node_info_t &node)
 		desc->number_of_seasons = decode_uint8(p);
 
 	}
+	else if (version == 11) {
+		// cost/maintenance as 64 bit ints
+		desc->topspeed = decode_uint16(p);
+		desc->price = decode_sint64(p);
+		desc->maintenance = decode_sint64(p);
+		desc->wtyp = decode_uint8(p);
+		desc->pillars_every = decode_uint8(p);
+		desc->max_length = decode_uint8(p);
+		desc->intro_date = decode_uint16(p);
+		desc->retire_date = decode_uint16(p);
+		desc->pillars_asymmetric = decode_uint8(p) != 0;
+		desc->axle_load = decode_uint16(p);
+		desc->max_height = decode_uint8(p);
+		desc->number_of_seasons = decode_uint8(p);
+		desc->clip_below = decode_uint8(p);
+	}
 	else {
 		if( version ) {
 			dbg->fatal( "bridge_reader_t::read_node()", "Cannot handle too new node version %i", version );
@@ -192,6 +208,9 @@ obj_desc_t *bridge_reader_t::read_node(FILE *fp, obj_node_info_t &node)
 
 	if(  version < 9  ) {
 		desc->axle_load = 9999;
+	}
+	if (version < 11) {
+		desc->clip_below = desc->wtyp != powerline_wt;
 	}
 
 	DBG_DEBUG("bridge_reader_t::read_node()",

--- a/descriptor/reader/vehicle_reader.cc
+++ b/descriptor/reader/vehicle_reader.cc
@@ -271,6 +271,30 @@ obj_desc_t *vehicle_reader_t::read_node(FILE *fp, obj_node_info_t &node)
 		desc->trailer_count = decode_uint8(p);
 		desc->freight_image_type = decode_uint8(p);
 	}
+	else if (version == 13) {
+		// loading time as uint32
+		desc->price = decode_sint64(p);
+		desc->capacity = decode_uint16(p);
+		desc->loading_time = decode_uint32(p);
+		desc->topspeed = decode_uint16(p);
+		desc->weight = decode_uint32(p);
+		desc->axle_load = decode_uint16(p);
+		desc->power = decode_uint32(p);
+		desc->running_cost = decode_sint64(p);
+		desc->maintenance = decode_sint64(p);
+
+		desc->intro_date = decode_uint16(p);
+		desc->retire_date = decode_uint16(p);
+		desc->gear = decode_uint16(p);
+
+		desc->wtyp = decode_uint8(p);
+		desc->sound = decode_sint8(p);
+		desc->engine_type = decode_uint8(p);
+		desc->len = decode_uint8(p);
+		desc->leader_count = decode_uint8(p);
+		desc->trailer_count = decode_uint8(p);
+		desc->freight_image_type = decode_uint8(p);
+	}
 	else {
 		if( version ) {
 			dbg->fatal( "vehicle_reader_t::read_node()", "Cannot handle too new node version %i", version );

--- a/descriptor/reader/way_reader.cc
+++ b/descriptor/reader/way_reader.cc
@@ -66,7 +66,22 @@ obj_desc_t * way_reader_t::read_node(FILE *fp, obj_node_info_t &node)
 		const uint16 v = decode_uint16(p);
 		version = v & 0x7FFF;
 
-		if (version == 7) {
+		if (version == 8) {
+			// cost/maintenance as sint64
+			desc->price             = decode_sint64(p);
+			desc->maintenance       = decode_sint64(p);
+			desc->topspeed          = decode_uint32(p);
+			desc->max_weight        = decode_uint32(p);
+			desc->intro_date        = decode_uint16(p);
+			desc->retire_date       = decode_uint16(p);
+			desc->axle_load         = decode_uint16(p);
+			desc->wtyp              = decode_uint8(p);
+			desc->styp              = decode_uint8(p);
+			desc->draw_as_obj       = decode_uint8(p);
+			desc->clip_below 		= decode_uint8(p);
+			desc->number_of_seasons = decode_sint8(p);
+		}
+		else if (version == 7) {
 			// cost/maintenance as sint64
 			desc->price             = decode_sint64(p);
 			desc->maintenance       = decode_sint64(p);
@@ -173,7 +188,10 @@ obj_desc_t * way_reader_t::read_node(FILE *fp, obj_node_info_t &node)
 	if(  version < 6  ) {
 		desc->axle_load = 9999;
 	}
+	if(  version < 8  ) {
+				desc->clip_below = desc->wtyp != powerline_wt;
 
+	}
 	// front images from version 5 on
 	desc->front_images = version > 4;
 

--- a/descriptor/vehicle_desc.h
+++ b/descriptor/vehicle_desc.h
@@ -64,7 +64,7 @@ public:
 
 private:
 	uint16  capacity;
-	uint16  loading_time; // time per full loading/unloading
+	uint32  loading_time; // time per full loading/unloading
 	uint32  weight;
 	uint32  power;
 	sint64  running_cost;
@@ -270,7 +270,7 @@ public:
 	bool can_follow_any() const { return trailer_count==0; }
 
 	uint16 get_capacity() const { return capacity; }
-	uint16 get_loading_time() const { return loading_time; } // ms per full loading/unloading
+	uint32 get_loading_time() const { return loading_time; } // ms per full loading/unloading
 	uint32 get_weight() const { return weight; }
 	uint32 get_power() const { return power; }
 	sint64 get_running_cost() const { return running_cost; }

--- a/descriptor/way_desc.h
+++ b/descriptor/way_desc.h
@@ -60,6 +60,8 @@ private:
 	/// if true front_images lists exists as nodes
 	bool front_images;
 
+	bool clip_below; // only relevant for elevated ways
+
 	/**
 	 * calculates index of image list for flat ways
 	 * for winter and/or front images
@@ -99,6 +101,8 @@ public:
 	systemtype_t get_styp() const { return (systemtype_t)styp; }
 
 	bool is_tram() const { return wtyp == track_wt  &&  styp == type_tram; }
+
+	bool is_clip_below() const { return clip_below; }
 
 	image_id get_image_id(ribi_t::ribi ribi, uint8 season, bool front = false) const
 	{

--- a/gui/display_settings.cc
+++ b/gui/display_settings.cc
@@ -371,6 +371,15 @@ transparency_settings_t::transparency_settings_t()
 	factory_tooltip.set_selection( env_t::show_factory_storage_bar );
 	add_component( &factory_tooltip );
 	factory_tooltip.add_listener( this );
+
+	new_component<gui_label_t>( "Clip below elevated ways" );
+	clip_below_setting.set_focusable( false );
+	clip_below_setting.new_component<gui_scrolled_list_t::const_text_scrollitem_t>( translator::translate( "no cut" ), SYSCOL_TEXT );
+	clip_below_setting.new_component<gui_scrolled_list_t::const_text_scrollitem_t>( translator::translate( "all cut" ), SYSCOL_TEXT );
+	clip_below_setting.new_component<gui_scrolled_list_t::const_text_scrollitem_t>( translator::translate( "pak dependence" ), SYSCOL_TEXT );
+	clip_below_setting.set_selection( env_t::clip_below );
+	add_component( &clip_below_setting );
+	clip_below_setting.add_listener( this );
 }
 
 bool transparency_settings_t::action_triggered( gui_action_creator_t *comp, value_t v )
@@ -390,6 +399,11 @@ bool transparency_settings_t::action_triggered( gui_action_creator_t *comp, valu
 
 		return true;
 	}
+	if( comp == &clip_below_setting ) {
+		env_t::clip_below = (sint8)v.i;
+		world()->set_dirty();
+		return true;
+	}
 	return true;
 }
 
@@ -397,6 +411,7 @@ bool transparency_settings_t::action_triggered( gui_action_creator_t *comp, valu
 void transparency_settings_t::draw( scr_coord offset )
 {
 	hide_buildings.set_selection( env_t::hide_buildings );
+	clip_below_setting.set_selection( env_t::clip_below );
 
 	gui_aligned_container_t::draw(offset);
 }

--- a/gui/display_settings.h
+++ b/gui/display_settings.h
@@ -69,6 +69,7 @@ private:
 	gui_numberinput_t cursor_hide_range;
 	gui_combobox_t hide_buildings;
 	gui_combobox_t factory_tooltip;
+	gui_combobox_t clip_below_setting;
 public:
 	transparency_settings_t();
 	bool action_triggered( gui_action_creator_t *comp, value_t v ) OVERRIDE;

--- a/obj/bruecke.cc
+++ b/obj/bruecke.cc
@@ -24,6 +24,13 @@ bruecke_t::bruecke_t(loadsave_t* const file) : obj_no_info_t()
 }
 
 
+bool bruecke_t::is_clipping_below_needed() const
+{
+	// elevated no clip?
+	return desc->is_clip_below();
+}
+
+
 bruecke_t::bruecke_t(koord3d pos, player_t *player, const bridge_desc_t *desc, bridge_desc_t::img_t img) :
  obj_no_info_t(pos)
 {

--- a/obj/bruecke.h
+++ b/obj/bruecke.h
@@ -63,6 +63,8 @@ public:
 	 * @return NULL wenn OK, ansonsten eine Fehlermeldung
 	 */
 	const char *is_deletable(const player_t *player) OVERRIDE;
+
+	virtual bool is_clipping_below_needed() const OVERRIDE;
 };
 
 #endif

--- a/obj/simobj.h
+++ b/obj/simobj.h
@@ -213,6 +213,9 @@ public:
 	 */
 	virtual waytype_t get_waytype() const { return invalid_wt; }
 
+	/// true if clipping below is needed
+	virtual bool is_clipping_below_needed() const { return true; }
+
 	/**
 	 * called whenever the snowline height changes
 	 * return false and the obj_t will be deleted

--- a/simplan.cc
+++ b/simplan.cc
@@ -459,7 +459,7 @@ void planquadrat_t::display_obj(const sint16 xpos, const sint16 ypos, const sint
 		gr0->display_obj_all_quick_and_dirty( xpos, ypos, raster_tile_width, is_global  CLIP_NUM_PAR );
 	}
 	else {
-		if(  (i >= ground_size) || !gr0->obj_bei(0) || gr0->obj_bei(0)->get_typ()==obj_t::way || gr0->get_leitung()  ) {
+		if(  (i >= ground_size) || !gr0->obj_bei(0) || ((gr0->obj_bei(0)->get_typ()==obj_t::way || gr0->get_leitung())&&env_t::clip_below==env_t::CLIP_BELOW_NEVER)  ) {
 			// no tree or not on the ground
 			gr0->display_obj_all( xpos, ypos, raster_tile_width, is_global  CLIP_NUM_PAR );
 		}
@@ -481,6 +481,11 @@ void planquadrat_t::display_obj(const sint16 xpos, const sint16 ypos, const sint
 				}
 				// not too low?
 				if(  htop >= hmin  ) {
+					if (obj_t *o = data.some[j]->obj_bei(0)) {
+						if (env_t::clip_below==env_t::CLIP_BELOW_PAK&&!o->is_clipping_below_needed()) {
+							continue;
+						}
+					}
 					// something on top: clip horizontally to prevent trees etc shining trough bridges
 					const sint16 yh = ypos - tile_raster_scale_y( (h + corner_nw(data.some[j]->get_grund_hang()) - h0) * TILE_HEIGHT_STEP, raster_tile_width ) + ((3 * raster_tile_width) >> 2);
 					if(  yh >= p_cr.y  ) {

--- a/simversion.h
+++ b/simversion.h
@@ -30,7 +30,7 @@
 #define SIM_SERVER_MINOR    0
 // NOTE: increment before next release to enable save/load of new features
 
-#define OTRP_VERSION_MAJOR 53
+#define OTRP_VERSION_MAJOR 54
 #define OTRP_VERSION_MINOR 0
 #define OTRP_VERSION_PATCH 1
 // NOTE: increment OTRP_VERSION_MAJOR when the save data structure changes.


### PR DESCRIPTION
makeobj 60.9で作られたアドオンを読めるようにしました。また、`clip_below`引数が実装されたため`env_t::clip_below`フラグを用意しwayはクリップしない/全部クリップ/pakで定義されたもののみクリップを選択できるようにします