### PR TITLE
connect all factory with one click

### DIFF
--- a/simtool.cc
+++ b/simtool.cc
@@ -6885,6 +6885,7 @@ const char *tool_link_factory_t::do_work( player_t *, const koord3d &start, cons
 	}
 	else if(fab!=NULL  &&  last_fab!=NULL  &&  last_fab==fab  &&  is_shift_pressed()) {
 		// connect to all factories
+		fab->add_all_suppliers();
 		FOR(slist_tpl<fabrik_t*>, const f, welt->get_fab_list()) {
 			// connect to an existing one, if this is an producer
 			f->add_supplier(fab);

--- a/simtool.cc
+++ b/simtool.cc
@@ -6883,6 +6883,13 @@ const char *tool_link_factory_t::do_work( player_t *, const koord3d &start, cons
 			return NULL;
 		}
 	}
+	else if(fab!=NULL  &&  last_fab!=NULL  &&  last_fab==fab  &&  is_shift_pressed()) {
+		// connect to all factories
+		FOR(slist_tpl<fabrik_t*>, const f, welt->get_fab_list()) {
+			// connect to an existing one, if this is an producer
+			f->add_supplier(fab);
+		}
+	}
 	return "";
 }
 


### PR DESCRIPTION
生産物の需要先となりうる全産業への産業接続を1クリックで行えるようにします。
shiftを押したまま当該産業を2度クリックすると、その産業の生産物の需要先全てに産業網がつながります