### PR TITLE
Add properties to schedule_entry_x Squirrel API

### DIFF
--- a/script/api/api_schedule.cc
+++ b/script/api/api_schedule.cc
@@ -77,9 +77,12 @@ void append_entry(HSQUIRRELVM vm, SQInteger index, schedule_t* sched)
 	uint32 stop_flags = 0;
 	get_slot(vm, "flags", stop_flags, index);
 
+	uint8 maximum_loading = 100;
+	get_slot(vm, "maximum_load", maximum_loading, index);
+
 	grund_t *gr = welt->lookup(pos);
 	if (gr) {
-		sched->append(gr, minimum_loading, waiting_time_shift, stop_flags);
+		sched->append(gr, minimum_loading, waiting_time_shift, stop_flags, 0, 0, maximum_loading);
 	}
 }
 
@@ -163,6 +166,7 @@ void export_schedule(HSQUIRRELVM vm)
 #endif
 
 	create_slot(vm, "flags", 0);
+	create_slot(vm, "maximum_load", 100);
 
 	/**
 	 * Returns halt at this entry position.

--- a/script/api/api_schedule.cc
+++ b/script/api/api_schedule.cc
@@ -80,9 +80,20 @@ void append_entry(HSQUIRRELVM vm, SQInteger index, schedule_t* sched)
 	uint8 maximum_loading = 100;
 	get_slot(vm, "maximum_load", maximum_loading, index);
 
+	uint16 spacing = 1;
+	get_slot(vm, "spacing", spacing, index);
+
+	uint16 spacing_shift = 0;
+	get_slot(vm, "spacing_shift", spacing_shift, index);
+
+	uint16 delay_tolerance = 0;
+	get_slot(vm, "delay_tolerance", delay_tolerance, index);
+
 	grund_t *gr = welt->lookup(pos);
 	if (gr) {
-		sched->append(gr, minimum_loading, waiting_time_shift, stop_flags, 0, 0, maximum_loading);
+		if (sched->append(gr, minimum_loading, waiting_time_shift, stop_flags, 0, 0, maximum_loading)) {
+			sched->at(sched->get_count() - 1).set_spacing(spacing, spacing_shift, delay_tolerance);
+		}
 	}
 }
 
@@ -167,6 +178,9 @@ void export_schedule(HSQUIRRELVM vm)
 
 	create_slot(vm, "flags", 0);
 	create_slot(vm, "maximum_load", 100);
+	create_slot(vm, "spacing", 1);
+	create_slot(vm, "spacing_shift", 0);
+	create_slot(vm, "delay_tolerance", 0);
 
 	/**
 	 * Returns halt at this entry position.

--- a/script/api/api_schedule.cc
+++ b/script/api/api_schedule.cc
@@ -80,6 +80,9 @@ void append_entry(HSQUIRRELVM vm, SQInteger index, schedule_t* sched)
 	uint8 maximum_loading = 100;
 	get_slot(vm, "maximum_load", maximum_loading, index);
 
+	uint16 length_coupling_done = 0;
+	get_slot(vm, "length_coupling_done", length_coupling_done, index);
+
 	uint16 spacing = 1;
 	get_slot(vm, "spacing", spacing, index);
 
@@ -91,7 +94,7 @@ void append_entry(HSQUIRRELVM vm, SQInteger index, schedule_t* sched)
 
 	grund_t *gr = welt->lookup(pos);
 	if (gr) {
-		if (sched->append(gr, minimum_loading, waiting_time_shift, stop_flags, 0, 0, maximum_loading)) {
+		if (sched->append(gr, minimum_loading, waiting_time_shift, stop_flags, 0, length_coupling_done, maximum_loading)) {
 			sched->at(sched->get_count() - 1).set_spacing(spacing, spacing_shift, delay_tolerance);
 		}
 	}
@@ -178,6 +181,7 @@ void export_schedule(HSQUIRRELVM vm)
 
 	create_slot(vm, "flags", 0);
 	create_slot(vm, "maximum_load", 100);
+	create_slot(vm, "length_coupling_done", 0);
 	create_slot(vm, "spacing", 1);
 	create_slot(vm, "spacing_shift", 0);
 	create_slot(vm, "delay_tolerance", 0);

--- a/script/api/api_schedule.cc
+++ b/script/api/api_schedule.cc
@@ -83,6 +83,9 @@ void append_entry(HSQUIRRELVM vm, SQInteger index, schedule_t* sched)
 	uint16 length_coupling_done = 0;
 	get_slot(vm, "length_coupling_done", length_coupling_done, index);
 
+	uint16 max_speed = 0;
+	get_slot(vm, "max_speed", max_speed, index);
+
 	uint16 spacing = 1;
 	get_slot(vm, "spacing", spacing, index);
 
@@ -94,7 +97,7 @@ void append_entry(HSQUIRRELVM vm, SQInteger index, schedule_t* sched)
 
 	grund_t *gr = welt->lookup(pos);
 	if (gr) {
-		if (sched->append(gr, minimum_loading, waiting_time_shift, stop_flags, 0, length_coupling_done, maximum_loading)) {
+		if (sched->append(gr, minimum_loading, waiting_time_shift, stop_flags, max_speed, length_coupling_done, maximum_loading)) {
 			sched->at(sched->get_count() - 1).set_spacing(spacing, spacing_shift, delay_tolerance);
 		}
 	}
@@ -182,6 +185,7 @@ void export_schedule(HSQUIRRELVM vm)
 	create_slot(vm, "flags", 0);
 	create_slot(vm, "maximum_load", 100);
 	create_slot(vm, "length_coupling_done", 0);
+	create_slot(vm, "max_speed", 0);
 	create_slot(vm, "spacing", 1);
 	create_slot(vm, "spacing_shift", 0);
 	create_slot(vm, "delay_tolerance", 0);

--- a/script/api/api_schedule.cc
+++ b/script/api/api_schedule.cc
@@ -86,6 +86,9 @@ void append_entry(HSQUIRRELVM vm, SQInteger index, schedule_t* sched)
 	uint16 max_speed = 0;
 	get_slot(vm, "max_speed", max_speed, index);
 
+	uint16 balance_speed = 0;
+	get_slot(vm, "balance_speed", balance_speed, index);
+
 	uint16 spacing = 1;
 	get_slot(vm, "spacing", spacing, index);
 
@@ -97,7 +100,7 @@ void append_entry(HSQUIRRELVM vm, SQInteger index, schedule_t* sched)
 
 	grund_t *gr = welt->lookup(pos);
 	if (gr) {
-		if (sched->append(gr, minimum_loading, waiting_time_shift, stop_flags, max_speed, length_coupling_done, maximum_loading)) {
+		if (sched->append(gr, minimum_loading, waiting_time_shift, stop_flags, max_speed, length_coupling_done, maximum_loading, balance_speed)) {
 			sched->at(sched->get_count() - 1).set_spacing(spacing, spacing_shift, delay_tolerance);
 		}
 	}
@@ -186,6 +189,7 @@ void export_schedule(HSQUIRRELVM vm)
 	create_slot(vm, "maximum_load", 100);
 	create_slot(vm, "length_coupling_done", 0);
 	create_slot(vm, "max_speed", 0);
+	create_slot(vm, "balance_speed", 0);
 	create_slot(vm, "spacing", 1);
 	create_slot(vm, "spacing_shift", 0);
 	create_slot(vm, "delay_tolerance", 0);

--- a/script/api_param.cc
+++ b/script/api_param.cc
@@ -566,20 +566,29 @@ namespace script_api {
 
 	SQInteger param<schedule_entry_t>::push(HSQUIRRELVM vm, schedule_entry_t const& v)
 	{
-		if (&v) {
-			koord k = v.pos.get_2d();
-			// transform coordinates
-			coordinate_transform_t::koord_w2sq(k);
-			if (SQ_FAILED(push_instance(vm, "schedule_entry_x", k.x, k.y, v.pos.z))) {
-				return SQ_ERROR;
-			}
+		koord k = v.pos.get_2d();
+		// transform coordinates
+		coordinate_transform_t::koord_w2sq(k);
+		// Create instance without calling the Squirrel constructor
+		// (the Squirrel constructor expects a coord3d object as first arg, not integers)
+		if (SQ_FAILED(push_class(vm, "schedule_entry_x"))) {
+			return SQ_ERROR;
 		}
+		if (SQ_FAILED(sq_createinstance(vm, -1))) {
+			sq_pop(vm, 1); // remove class
+			return SQ_ERROR;
+		}
+		sq_remove(vm, -2); // remove class, leave instance on top
 
+		set_slot(vm, "x", k.x);
+		set_slot(vm, "y", k.y);
+		set_slot(vm, "z", v.pos.z);
 		set_slot(vm, "load", (sint32)v.minimum_loading);
+		set_slot(vm, "maximum_load", (sint32)v.maximum_loading);
 		set_slot(vm, "wait", (sint32)v.waiting_time_shift);
 		set_slot(vm, "flags", v.get_stop_flags());
 
-    return 1;
+		return 1;
 	}
 
 

--- a/script/api_param.cc
+++ b/script/api_param.cc
@@ -587,6 +587,9 @@ namespace script_api {
 		set_slot(vm, "maximum_load", (sint32)v.maximum_loading);
 		set_slot(vm, "wait", (sint32)v.waiting_time_shift);
 		set_slot(vm, "flags", v.get_stop_flags());
+		set_slot(vm, "spacing", (sint32)v.spacing);
+		set_slot(vm, "spacing_shift", (sint32)v.spacing_shift);
+		set_slot(vm, "delay_tolerance", (sint32)v.delay_tolerance);
 
 		return 1;
 	}

--- a/script/api_param.cc
+++ b/script/api_param.cc
@@ -589,6 +589,7 @@ namespace script_api {
 		set_slot(vm, "flags", v.get_stop_flags());
 		set_slot(vm, "length_coupling_done", (sint32)v.length_coupling_done);
 		set_slot(vm, "max_speed", (sint32)v.max_speed_kmh_of_convoi);
+		set_slot(vm, "balance_speed", (sint32)v.balance_speed_kmh_of_convoi);
 		set_slot(vm, "spacing", (sint32)v.spacing);
 		set_slot(vm, "spacing_shift", (sint32)v.spacing_shift);
 		set_slot(vm, "delay_tolerance", (sint32)v.delay_tolerance);

--- a/script/api_param.cc
+++ b/script/api_param.cc
@@ -587,6 +587,7 @@ namespace script_api {
 		set_slot(vm, "maximum_load", (sint32)v.maximum_loading);
 		set_slot(vm, "wait", (sint32)v.waiting_time_shift);
 		set_slot(vm, "flags", v.get_stop_flags());
+		set_slot(vm, "length_coupling_done", (sint32)v.length_coupling_done);
 		set_slot(vm, "spacing", (sint32)v.spacing);
 		set_slot(vm, "spacing_shift", (sint32)v.spacing_shift);
 		set_slot(vm, "delay_tolerance", (sint32)v.delay_tolerance);

--- a/script/api_param.cc
+++ b/script/api_param.cc
@@ -588,6 +588,7 @@ namespace script_api {
 		set_slot(vm, "wait", (sint32)v.waiting_time_shift);
 		set_slot(vm, "flags", v.get_stop_flags());
 		set_slot(vm, "length_coupling_done", (sint32)v.length_coupling_done);
+		set_slot(vm, "max_speed", (sint32)v.max_speed_kmh_of_convoi);
 		set_slot(vm, "spacing", (sint32)v.spacing);
 		set_slot(vm, "spacing_shift", (sint32)v.spacing_shift);
 		set_slot(vm, "delay_tolerance", (sint32)v.delay_tolerance);

--- a/tests/automated-tests/all_tests.nut
+++ b/tests/automated-tests/all_tests.nut
@@ -228,7 +228,8 @@ all_tests <- [
 	test_schedule_entry_maximum_load,
 	test_schedule_entry_spacing,
 	test_schedule_entry_length_coupling_done,
-	test_schedule_entry_max_speed
+	test_schedule_entry_max_speed,
+	test_schedule_entry_balance_speed
 ]
 
 

--- a/tests/automated-tests/all_tests.nut
+++ b/tests/automated-tests/all_tests.nut
@@ -225,7 +225,8 @@ all_tests <- [
 	test_stop_before_check_false_convoy_does_not_stop,
 	test_trees_plant_single_invalid_param,
 	test_way_tunnel_build_straight,
-	test_schedule_entry_maximum_load
+	test_schedule_entry_maximum_load,
+	test_schedule_entry_spacing
 ]
 
 

--- a/tests/automated-tests/all_tests.nut
+++ b/tests/automated-tests/all_tests.nut
@@ -227,7 +227,8 @@ all_tests <- [
 	test_way_tunnel_build_straight,
 	test_schedule_entry_maximum_load,
 	test_schedule_entry_spacing,
-	test_schedule_entry_length_coupling_done
+	test_schedule_entry_length_coupling_done,
+	test_schedule_entry_max_speed
 ]
 
 

--- a/tests/automated-tests/all_tests.nut
+++ b/tests/automated-tests/all_tests.nut
@@ -36,6 +36,7 @@ include("tests/test_way_runway")
 include("tests/test_way_tram")
 include("tests/test_way_tunnel")
 include("tests/test_wayobj")
+include("tests/test_schedule")
 
 
 all_tests <- [
@@ -223,7 +224,8 @@ all_tests <- [
 	test_stop_before_check_choose_signal_convoy_stops,
 	test_stop_before_check_false_convoy_does_not_stop,
 	test_trees_plant_single_invalid_param,
-	test_way_tunnel_build_straight
+	test_way_tunnel_build_straight,
+	test_schedule_entry_maximum_load
 ]
 
 

--- a/tests/automated-tests/all_tests.nut
+++ b/tests/automated-tests/all_tests.nut
@@ -226,7 +226,8 @@ all_tests <- [
 	test_trees_plant_single_invalid_param,
 	test_way_tunnel_build_straight,
 	test_schedule_entry_maximum_load,
-	test_schedule_entry_spacing
+	test_schedule_entry_spacing,
+	test_schedule_entry_length_coupling_done
 ]
 
 

--- a/tests/automated-tests/tests/test_schedule.nut
+++ b/tests/automated-tests/tests/test_schedule.nut
@@ -97,3 +97,31 @@ function test_schedule_entry_length_coupling_done()
 	local sched2 = cnv.get_schedule()
 	ASSERT_EQUAL(sched2.entries[0].length_coupling_done, 8)
 }
+
+// --- Property 4: schedule_entry_x.max_speed ---
+
+function test_schedule_entry_max_speed()
+{
+	local pl = player_x(0)
+
+	ASSERT_EQUAL(command_x(tool_build_way).work(pl, coord3d(4, 2, 0), coord3d(4, 8, 0), "sand_track"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 2, 0), "TrainStop"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 7, 0), "TrainStop"), null)
+	ASSERT_EQUAL(command_x.build_depot(pl, coord3d(4, 8, 0), building_desc_x("TrainDepot")), null)
+
+	local depot = depot_x(4, 8, 0)
+	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("1Diesellokomotive"))
+	local cnv = depot.get_convoy_list()[0]
+
+	cnv.change_schedule(pl, schedule_x(wt_rail, [
+		schedule_entry_x(coord3d(4, 2, 0), 0, 0),
+		schedule_entry_x(coord3d(4, 7, 0), 0, 0),
+	]))
+
+	local sched = cnv.get_schedule()
+	sched.entries[0].max_speed = 120
+	cnv.change_schedule(pl, sched)
+
+	local sched2 = cnv.get_schedule()
+	ASSERT_EQUAL(sched2.entries[0].max_speed, 120)
+}

--- a/tests/automated-tests/tests/test_schedule.nut
+++ b/tests/automated-tests/tests/test_schedule.nut
@@ -69,3 +69,31 @@ function test_schedule_entry_spacing()
 	ASSERT_EQUAL(sched2.entries[0].spacing_shift, 2)
 	ASSERT_EQUAL(sched2.entries[0].delay_tolerance, 1)
 }
+
+// --- Property 3: schedule_entry_x.length_coupling_done ---
+
+function test_schedule_entry_length_coupling_done()
+{
+	local pl = player_x(0)
+
+	ASSERT_EQUAL(command_x(tool_build_way).work(pl, coord3d(4, 2, 0), coord3d(4, 8, 0), "sand_track"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 2, 0), "TrainStop"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 7, 0), "TrainStop"), null)
+	ASSERT_EQUAL(command_x.build_depot(pl, coord3d(4, 8, 0), building_desc_x("TrainDepot")), null)
+
+	local depot = depot_x(4, 8, 0)
+	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("1Diesellokomotive"))
+	local cnv = depot.get_convoy_list()[0]
+
+	cnv.change_schedule(pl, schedule_x(wt_rail, [
+		schedule_entry_x(coord3d(4, 2, 0), 0, 0),
+		schedule_entry_x(coord3d(4, 7, 0), 0, 0),
+	]))
+
+	local sched = cnv.get_schedule()
+	sched.entries[0].length_coupling_done = 8
+	cnv.change_schedule(pl, sched)
+
+	local sched2 = cnv.get_schedule()
+	ASSERT_EQUAL(sched2.entries[0].length_coupling_done, 8)
+}

--- a/tests/automated-tests/tests/test_schedule.nut
+++ b/tests/automated-tests/tests/test_schedule.nut
@@ -125,3 +125,31 @@ function test_schedule_entry_max_speed()
 	local sched2 = cnv.get_schedule()
 	ASSERT_EQUAL(sched2.entries[0].max_speed, 120)
 }
+
+// --- Property 5: schedule_entry_x.balance_speed ---
+
+function test_schedule_entry_balance_speed()
+{
+	local pl = player_x(0)
+
+	ASSERT_EQUAL(command_x(tool_build_way).work(pl, coord3d(4, 2, 0), coord3d(4, 8, 0), "sand_track"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 2, 0), "TrainStop"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 7, 0), "TrainStop"), null)
+	ASSERT_EQUAL(command_x.build_depot(pl, coord3d(4, 8, 0), building_desc_x("TrainDepot")), null)
+
+	local depot = depot_x(4, 8, 0)
+	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("1Diesellokomotive"))
+	local cnv = depot.get_convoy_list()[0]
+
+	cnv.change_schedule(pl, schedule_x(wt_rail, [
+		schedule_entry_x(coord3d(4, 2, 0), 0, 0),
+		schedule_entry_x(coord3d(4, 7, 0), 0, 0),
+	]))
+
+	local sched = cnv.get_schedule()
+	sched.entries[0].balance_speed = 80
+	cnv.change_schedule(pl, sched)
+
+	local sched2 = cnv.get_schedule()
+	ASSERT_EQUAL(sched2.entries[0].balance_speed, 80)
+}

--- a/tests/automated-tests/tests/test_schedule.nut
+++ b/tests/automated-tests/tests/test_schedule.nut
@@ -37,3 +37,35 @@ function test_schedule_entry_maximum_load()
 	ASSERT_EQUAL(sched2.entries[0].maximum_load, 75)
 	ASSERT_EQUAL(sched2.entries[1].maximum_load, 50)
 }
+
+// --- Property 2: schedule_entry_x.spacing ---
+
+function test_schedule_entry_spacing()
+{
+	local pl = player_x(0)
+
+	ASSERT_EQUAL(command_x(tool_build_way).work(pl, coord3d(4, 2, 0), coord3d(4, 8, 0), "sand_track"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 2, 0), "TrainStop"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 7, 0), "TrainStop"), null)
+	ASSERT_EQUAL(command_x.build_depot(pl, coord3d(4, 8, 0), building_desc_x("TrainDepot")), null)
+
+	local depot = depot_x(4, 8, 0)
+	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("1Diesellokomotive"))
+	local cnv = depot.get_convoy_list()[0]
+
+	cnv.change_schedule(pl, schedule_x(wt_rail, [
+		schedule_entry_x(coord3d(4, 2, 0), 0, 0),
+		schedule_entry_x(coord3d(4, 7, 0), 0, 0),
+	]))
+
+	local sched = cnv.get_schedule()
+	sched.entries[0].spacing = 3
+	sched.entries[0].spacing_shift = 2
+	sched.entries[0].delay_tolerance = 1
+	cnv.change_schedule(pl, sched)
+
+	local sched2 = cnv.get_schedule()
+	ASSERT_EQUAL(sched2.entries[0].spacing, 3)
+	ASSERT_EQUAL(sched2.entries[0].spacing_shift, 2)
+	ASSERT_EQUAL(sched2.entries[0].delay_tolerance, 1)
+}

--- a/tests/automated-tests/tests/test_schedule.nut
+++ b/tests/automated-tests/tests/test_schedule.nut
@@ -1,0 +1,39 @@
+//
+// This file is part of the Simutrans project under the Artistic License.
+// (see LICENSE.txt)
+//
+
+// --- Property 1: schedule_entry_x.maximum_load ---
+
+function test_schedule_entry_maximum_load()
+{
+	local pl = player_x(0)
+
+	// Build minimal rail infrastructure: track, two stations, depot
+	ASSERT_EQUAL(command_x(tool_build_way).work(pl, coord3d(4, 2, 0), coord3d(4, 8, 0), "sand_track"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 2, 0), "TrainStop"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 7, 0), "TrainStop"), null)
+	ASSERT_EQUAL(command_x.build_depot(pl, coord3d(4, 8, 0), building_desc_x("TrainDepot")), null)
+
+	local depot = depot_x(4, 8, 0)
+	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("1Diesellokomotive"))
+	local cnv = depot.get_convoy_list()[0]
+
+	// Set initial schedule (convoy stays in depot)
+	cnv.change_schedule(pl, schedule_x(wt_rail, [
+		schedule_entry_x(coord3d(4, 2, 0), 0, 0),
+		schedule_entry_x(coord3d(4, 7, 0), 0, 0),
+	]))
+
+	// Read the current schedule and set non-default maximum_load values
+	local sched = cnv.get_schedule()
+	sched.entries[0].maximum_load = 75
+	sched.entries[1].maximum_load = 50
+	// change_schedule returns true in non-network mode (tool runs synchronously)
+	cnv.change_schedule(pl, sched)
+
+	// Read back and verify the values survived the round-trip
+	local sched2 = cnv.get_schedule()
+	ASSERT_EQUAL(sched2.entries[0].maximum_load, 75)
+	ASSERT_EQUAL(sched2.entries[1].maximum_load, 50)
+}


### PR DESCRIPTION
## 概要

`schedule_entry_x` クラスに、`schedule_entry_t` が持つ以下のプロパティを追加しました。

- `maximum_load` — 最大積載率（%）
- `spacing` / `spacing_shift` / `delay_tolerance` — 間隔制御関連
- `length_coupling_done` — 連結完了判定の長さ
- `max_speed` — この停留所での編成最大速度上書き（km/h）
- `balance_speed` — この停留所でのバランス速度上書き（km/h）

## 変更内容

- **`script/api/api_schedule.cc`**: `append_entry` で各スロットを読み取り `schedule_t::append` および `set_spacing()` に渡す。`export_schedule` にデフォルト値付きのスロット定義を追加。
- **`script/api_param.cc`**: `param<schedule_entry_t>::push` に全プロパティの `set_slot` を追加し、C++ → Squirrel 変換時に全フィールドを反映。
- **テスト**: 各プロパティのラウンドトリップ検証テストを追加（`change_schedule` で設定 → `get_schedule` で読み返し）。

## テスト

追加した5つのテストケースがすべて PASSED であることを確認済み。

```
✓ test_schedule_entry_maximum_load
✓ test_schedule_entry_spacing
✓ test_schedule_entry_length_coupling_done
✓ test_schedule_entry_max_speed
✓ test_schedule_entry_balance_speed
```