### PR TITLE
Add schedule-level properties to schedule_x Squirrel API

### DIFF
--- a/script/api/api_schedule.cc
+++ b/script/api/api_schedule.cc
@@ -135,6 +135,10 @@ schedule_t* script_api::param<schedule_t*>::get(HSQUIRRELVM vm, SQInteger index)
 		get_slot(vm, "base_waiting_time", wait, index);
 		sched->set_additional_base_waiting_time(wait);
 
+		uint8 current = 0;
+		get_slot(vm, "current", current, index);
+		sched->set_current_stop(current);
+
 		uint8 schedule_flags = 0;
 		get_slot(vm, "flags", schedule_flags, index);
 		sched->set_flags(schedule_flags);
@@ -242,6 +246,16 @@ void export_schedule(HSQUIRRELVM vm)
 	integer base_waiting_time;
 
 	/**
+	 * Current stop of schedule:
+	 * default first stop (schedule of line)
+	 * or next stop of convoy (schedule of convoy).
+	 *
+	 * In order to change this value for a convoy
+	 * call @ref convoy_x::change_schedule.
+	 */
+	integer current;
+
+	/**
 	 * Schedule-level flags bitmask (TEMPORARY=1, SAME_DEP_TIME=2, FULL_LOAD_ACCELERATION=4, FULL_LOAD_TIME=8, REVERSE_DEFAULT=16).
 	 */
 	integer flags;
@@ -254,6 +268,7 @@ void export_schedule(HSQUIRRELVM vm)
 	create_slot(vm, "entries", 0);
 	create_slot(vm, "waytype", 0);
 	create_slot(vm, "base_waiting_time", 0);
+	create_slot(vm, "current", 0);
 	create_slot(vm, "flags", 0);
 	create_slot(vm, "max_speed", 0);
 #endif

--- a/script/api/api_schedule.cc
+++ b/script/api/api_schedule.cc
@@ -115,7 +115,6 @@ schedule_t* script_api::param<schedule_t*>::get(HSQUIRRELVM vm, SQInteger index)
 	// get instance pointer
 	schedule_t* sched = get_attached_instance<schedule_t>(vm, index, param<schedule_t*>::tag());
 	if (sched) {
-		linehandle_t const next_line = sched->get_next_line();
 		sched->remove_all();
 		// now read the entries
 		sq_pushstring(vm, "entries", -1);
@@ -151,7 +150,11 @@ schedule_t* script_api::param<schedule_t*>::get(HSQUIRRELVM vm, SQInteger index)
 		get_slot(vm, "departure_slot_group_id", dsgid_handle, index);
 		sched->set_departure_slot_group_id(dsgid_handle);
 
-		sched->set_next_line(next_line);
+		linehandle_t next_line_handle;
+		get_slot(vm, "next_line", next_line_handle, index);
+		if (next_line_handle.is_bound()) {
+			sched->set_next_line(next_line_handle);
+		}
 	}
 	return sched;
 }
@@ -159,6 +162,18 @@ schedule_t* script_api::param<schedule_t*>::get(HSQUIRRELVM vm, SQInteger index)
 void* script_api::param<schedule_t*>::tag()
 {
 	return (void*)&script_api::param<schedule_t*>::get;
+}
+
+static SQInteger schedule_set_next_line(HSQUIRRELVM vm)
+{
+	schedule_t* sched = get_attached_instance<schedule_t>(vm, 1, param<schedule_t*>::tag());
+	if (sched == NULL) {
+		return sq_raise_error(vm, "schedule is null");
+	}
+	linehandle_t line = param<linehandle_t>::get(vm, 2);
+	sched->set_next_line(line);
+	set_slot(vm, "next_line", sched->get_next_line(), 1);
+	return 0;
 }
 
 void export_schedule(HSQUIRRELVM vm)
@@ -275,6 +290,21 @@ void export_schedule(HSQUIRRELVM vm)
 	 * null if not assigned to any departure slot group.
 	 */
 	line_x departure_slot_group_id;
+
+	/**
+	 * The line to which the convoy transitions when this schedule is completed.
+	 * Read-only: use @ref set_next_line to change this value.
+	 * null if not set.
+	 */
+	line_x next_line;
+
+	/**
+	 * Sets the next line, applying validity checks (waytype match, >=2 entries, stoppable halt at first stop).
+	 * Pass null to unset.
+	 * @param line the candidate next line, or null
+	 * @typemask void(line_x)
+	 */
+	void set_next_line(line_x line);
 #else
 	create_slot(vm, "entries", 0);
 	create_slot(vm, "waytype", 0);
@@ -283,6 +313,8 @@ void export_schedule(HSQUIRRELVM vm)
 	create_slot(vm, "flags", 0);
 	create_slot(vm, "max_speed", 0);
 	create_slot(vm, "departure_slot_group_id", linehandle_t());
+	create_slot(vm, "next_line", linehandle_t());
+	register_function(vm, schedule_set_next_line, "set_next_line", 2, "xt|x|y|o");
 #endif
 
 	end_class(vm);

--- a/script/api/api_schedule.cc
+++ b/script/api/api_schedule.cc
@@ -139,6 +139,10 @@ schedule_t* script_api::param<schedule_t*>::get(HSQUIRRELVM vm, SQInteger index)
 		get_slot(vm, "flags", schedule_flags, index);
 		sched->set_flags(schedule_flags);
 
+		uint16 schedule_max_speed = 0;
+		get_slot(vm, "max_speed", schedule_max_speed, index);
+		sched->set_max_speed(schedule_max_speed);
+
 		sched->set_next_line(next_line);
 	}
 	return sched;
@@ -241,11 +245,17 @@ void export_schedule(HSQUIRRELVM vm)
 	 * Schedule-level flags bitmask (TEMPORARY=1, SAME_DEP_TIME=2, FULL_LOAD_ACCELERATION=4, FULL_LOAD_TIME=8, REVERSE_DEFAULT=16).
 	 */
 	integer flags;
+
+	/**
+	 * Schedule-level operational maximum speed (km/h). 0 means no limit.
+	 */
+	integer max_speed;
 #else
 	create_slot(vm, "entries", 0);
 	create_slot(vm, "waytype", 0);
 	create_slot(vm, "base_waiting_time", 0);
 	create_slot(vm, "flags", 0);
+	create_slot(vm, "max_speed", 0);
 #endif
 
 	end_class(vm);

--- a/script/api/api_schedule.cc
+++ b/script/api/api_schedule.cc
@@ -147,6 +147,10 @@ schedule_t* script_api::param<schedule_t*>::get(HSQUIRRELVM vm, SQInteger index)
 		get_slot(vm, "max_speed", schedule_max_speed, index);
 		sched->set_max_speed(schedule_max_speed);
 
+		linehandle_t dsgid_handle;
+		get_slot(vm, "departure_slot_group_id", dsgid_handle, index);
+		sched->set_departure_slot_group_id(dsgid_handle);
+
 		sched->set_next_line(next_line);
 	}
 	return sched;
@@ -264,6 +268,13 @@ void export_schedule(HSQUIRRELVM vm)
 	 * Schedule-level operational maximum speed (km/h). 0 means no limit.
 	 */
 	integer max_speed;
+
+	/**
+	 * The leader line of the departure slot group.
+	 * A line in its own group has this set to its own line.
+	 * null if not assigned to any departure slot group.
+	 */
+	line_x departure_slot_group_id;
 #else
 	create_slot(vm, "entries", 0);
 	create_slot(vm, "waytype", 0);
@@ -271,6 +282,7 @@ void export_schedule(HSQUIRRELVM vm)
 	create_slot(vm, "current", 0);
 	create_slot(vm, "flags", 0);
 	create_slot(vm, "max_speed", 0);
+	create_slot(vm, "departure_slot_group_id", linehandle_t());
 #endif
 
 	end_class(vm);

--- a/script/api/api_schedule.cc
+++ b/script/api/api_schedule.cc
@@ -301,6 +301,9 @@ void export_schedule(HSQUIRRELVM vm)
 	/**
 	 * Sets the next line, applying validity checks (waytype match, >=2 entries, stoppable halt at first stop).
 	 * Pass null to unset.
+	 * @note The underlying C++ implementation calls unset_next_line() before running validity checks.
+	 *       Therefore, if a non-null line is passed and fails the checks, the existing next_line is
+	 *       still cleared. After a failed call, next_line will be null.
 	 * @param line the candidate next line, or null
 	 * @typemask void(line_x)
 	 */

--- a/script/api/api_schedule.cc
+++ b/script/api/api_schedule.cc
@@ -134,6 +134,11 @@ schedule_t* script_api::param<schedule_t*>::get(HSQUIRRELVM vm, SQInteger index)
 		uint16 wait = 0;
 		get_slot(vm, "base_waiting_time", wait, index);
 		sched->set_additional_base_waiting_time(wait);
+
+		uint8 schedule_flags = 0;
+		get_slot(vm, "flags", schedule_flags, index);
+		sched->set_flags(schedule_flags);
+
 		sched->set_next_line(next_line);
 	}
 	return sched;
@@ -229,13 +234,18 @@ void export_schedule(HSQUIRRELVM vm)
 	
 	/**
 	 * Additional base waiting time for this schedule.
-	 * 
 	 */
 	integer base_waiting_time;
+
+	/**
+	 * Schedule-level flags bitmask (TEMPORARY=1, SAME_DEP_TIME=2, FULL_LOAD_ACCELERATION=4, FULL_LOAD_TIME=8, REVERSE_DEFAULT=16).
+	 */
+	integer flags;
 #else
 	create_slot(vm, "entries", 0);
 	create_slot(vm, "waytype", 0);
 	create_slot(vm, "base_waiting_time", 0);
+	create_slot(vm, "flags", 0);
 #endif
 
 	end_class(vm);

--- a/script/api_param.cc
+++ b/script/api_param.cc
@@ -610,6 +610,7 @@ namespace script_api {
 			SQInteger result = push_instance(vm, "schedule_x", v->get_waytype(), v->get_entries(), v->get_additional_base_waiting_time());
 			if (result > 0) {
 				set_slot(vm, "flags", (sint32)v->get_flags());
+				set_slot(vm, "max_speed", (sint32)v->get_max_speed());
 			}
 			return result;
 		}

--- a/script/api_param.cc
+++ b/script/api_param.cc
@@ -612,6 +612,8 @@ namespace script_api {
 			const minivec_tpl<schedule_entry_t>& src = v->get_entries();
 			SQInteger result;
 			if (v->get_next_line().is_bound() && src.get_count() > 0) {
+				// The dummy entry must have no_load and unload_all set (set by set_next_line()).
+				assert(src.back().is_no_load() && src.back().is_unload_all());
 				minivec_tpl<schedule_entry_t> filtered;
 				for (uint32 i = 0; i < src.get_count() - 1; i++) {
 					filtered.append(src[i]);

--- a/script/api_param.cc
+++ b/script/api_param.cc
@@ -607,7 +607,11 @@ namespace script_api {
 	SQInteger param<const schedule_t*>::push(HSQUIRRELVM vm, const schedule_t* const& v)
 	{
 		if (v) {
-			return push_instance(vm, "schedule_x", v->get_waytype(), v->get_entries(), v->get_additional_base_waiting_time());
+			SQInteger result = push_instance(vm, "schedule_x", v->get_waytype(), v->get_entries(), v->get_additional_base_waiting_time());
+			if (result > 0) {
+				set_slot(vm, "flags", (sint32)v->get_flags());
+			}
+			return result;
 		}
 		else {
 			sq_pushnull(vm); return 1;

--- a/script/api_param.cc
+++ b/script/api_param.cc
@@ -609,6 +609,7 @@ namespace script_api {
 		if (v) {
 			SQInteger result = push_instance(vm, "schedule_x", v->get_waytype(), v->get_entries(), v->get_additional_base_waiting_time());
 			if (result > 0) {
+				set_slot(vm, "current", (sint32)v->get_current_stop());
 				set_slot(vm, "flags", (sint32)v->get_flags());
 				set_slot(vm, "max_speed", (sint32)v->get_max_speed());
 			}

--- a/script/api_param.cc
+++ b/script/api_param.cc
@@ -612,6 +612,7 @@ namespace script_api {
 				set_slot(vm, "current", (sint32)v->get_current_stop());
 				set_slot(vm, "flags", (sint32)v->get_flags());
 				set_slot(vm, "max_speed", (sint32)v->get_max_speed());
+				set_slot(vm, "departure_slot_group_id", v->get_departure_slot_group_id());
 			}
 			return result;
 		}

--- a/script/api_param.cc
+++ b/script/api_param.cc
@@ -607,12 +607,26 @@ namespace script_api {
 	SQInteger param<const schedule_t*>::push(HSQUIRRELVM vm, const schedule_t* const& v)
 	{
 		if (v) {
-			SQInteger result = push_instance(vm, "schedule_x", v->get_waytype(), v->get_entries(), v->get_additional_base_waiting_time());
+			// When next_line is set, the last entry is a dummy appended by set_next_line().
+			// Exclude it from the Squirrel entries so the round-trip doesn't double-append it.
+			const minivec_tpl<schedule_entry_t>& src = v->get_entries();
+			SQInteger result;
+			if (v->get_next_line().is_bound() && src.get_count() > 0) {
+				minivec_tpl<schedule_entry_t> filtered;
+				for (uint32 i = 0; i < src.get_count() - 1; i++) {
+					filtered.append(src[i]);
+				}
+				result = push_instance(vm, "schedule_x", v->get_waytype(), filtered, v->get_additional_base_waiting_time());
+			}
+			else {
+				result = push_instance(vm, "schedule_x", v->get_waytype(), src, v->get_additional_base_waiting_time());
+			}
 			if (result > 0) {
 				set_slot(vm, "current", (sint32)v->get_current_stop());
 				set_slot(vm, "flags", (sint32)v->get_flags());
 				set_slot(vm, "max_speed", (sint32)v->get_max_speed());
 				set_slot(vm, "departure_slot_group_id", v->get_departure_slot_group_id());
+				set_slot(vm, "next_line", v->get_next_line());
 			}
 			return result;
 		}

--- a/tests/automated-tests/all_tests.nut
+++ b/tests/automated-tests/all_tests.nut
@@ -234,6 +234,8 @@ all_tests <- [
 	test_schedule_max_speed,
 	test_schedule_departure_slot_group_id,
 	test_schedule_departure_slot_group_id_non_null,
+	test_schedule_next_line,
+	test_schedule_next_line_non_null,
 	test_schedule_current
 ]
 

--- a/tests/automated-tests/all_tests.nut
+++ b/tests/automated-tests/all_tests.nut
@@ -230,7 +230,8 @@ all_tests <- [
 	test_schedule_entry_length_coupling_done,
 	test_schedule_entry_max_speed,
 	test_schedule_entry_balance_speed,
-	test_schedule_flags
+	test_schedule_flags,
+	test_schedule_max_speed
 ]
 
 

--- a/tests/automated-tests/all_tests.nut
+++ b/tests/automated-tests/all_tests.nut
@@ -232,6 +232,8 @@ all_tests <- [
 	test_schedule_entry_balance_speed,
 	test_schedule_flags,
 	test_schedule_max_speed,
+	test_schedule_departure_slot_group_id,
+	test_schedule_departure_slot_group_id_non_null,
 	test_schedule_current
 ]
 

--- a/tests/automated-tests/all_tests.nut
+++ b/tests/automated-tests/all_tests.nut
@@ -231,7 +231,8 @@ all_tests <- [
 	test_schedule_entry_max_speed,
 	test_schedule_entry_balance_speed,
 	test_schedule_flags,
-	test_schedule_max_speed
+	test_schedule_max_speed,
+	test_schedule_current
 ]
 
 

--- a/tests/automated-tests/all_tests.nut
+++ b/tests/automated-tests/all_tests.nut
@@ -229,7 +229,8 @@ all_tests <- [
 	test_schedule_entry_spacing,
 	test_schedule_entry_length_coupling_done,
 	test_schedule_entry_max_speed,
-	test_schedule_entry_balance_speed
+	test_schedule_entry_balance_speed,
+	test_schedule_flags
 ]
 
 

--- a/tests/automated-tests/tests/test_schedule.nut
+++ b/tests/automated-tests/tests/test_schedule.nut
@@ -211,7 +211,68 @@ function test_schedule_max_speed()
 	ASSERT_EQUAL(sched2.max_speed, 100)
 }
 
-// --- Property 8: schedule_x.current ---
+// --- Property 8: schedule_x.departure_slot_group_id ---
+
+function test_schedule_departure_slot_group_id()
+{
+	local pl = player_x(0)
+
+	ASSERT_EQUAL(command_x(tool_build_way).work(pl, coord3d(4, 2, 0), coord3d(4, 8, 0), "sand_track"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 2, 0), "TrainStop"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 7, 0), "TrainStop"), null)
+	ASSERT_EQUAL(command_x.build_depot(pl, coord3d(4, 8, 0), building_desc_x("TrainDepot")), null)
+
+	local depot = depot_x(4, 8, 0)
+	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("1Diesellokomotive"))
+	local cnv = depot.get_convoy_list()[0]
+
+	cnv.change_schedule(pl, schedule_x(wt_rail, [
+		schedule_entry_x(coord3d(4, 2, 0), 0, 0),
+		schedule_entry_x(coord3d(4, 7, 0), 0, 0),
+	]))
+
+	// departure_slot_group_id defaults to null when not assigned to any group
+	local sched = cnv.get_schedule()
+	ASSERT_EQUAL(sched.departure_slot_group_id, null)
+	// round-trip preserves null
+	cnv.change_schedule(pl, sched)
+	local sched2 = cnv.get_schedule()
+	ASSERT_EQUAL(sched2.departure_slot_group_id, null)
+}
+
+function test_schedule_departure_slot_group_id_non_null()
+{
+	local pl = player_x(0)
+
+	ASSERT_EQUAL(command_x(tool_build_way).work(pl, coord3d(4, 2, 0), coord3d(4, 8, 0), "sand_track"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 2, 0), "TrainStop"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 7, 0), "TrainStop"), null)
+	ASSERT_EQUAL(command_x.build_depot(pl, coord3d(4, 8, 0), building_desc_x("TrainDepot")), null)
+
+	local depot = depot_x(4, 8, 0)
+	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("1Diesellokomotive"))
+	local cnv = depot.get_convoy_list()[0]
+
+	cnv.change_schedule(pl, schedule_x(wt_rail, [
+		schedule_entry_x(coord3d(4, 2, 0), 0, 0),
+		schedule_entry_x(coord3d(4, 7, 0), 0, 0),
+	]))
+
+	ASSERT_EQUAL(pl.create_line(wt_rail), true)
+	local line_list = pl.get_line_list()
+	local line = line_list[line_list.get_count() - 1]
+
+	// Set departure_slot_group_id to an existing line and verify round-trip
+	local sched = cnv.get_schedule()
+	sched.departure_slot_group_id = line
+	cnv.change_schedule(pl, sched)
+
+	local sched2 = cnv.get_schedule()
+	ASSERT_TRUE(sched2.departure_slot_group_id != null)
+	ASSERT_EQUAL(sched2.departure_slot_group_id.get_name(), line.get_name())
+}
+
+// --- Property 9: schedule_x.current ---
 
 function test_schedule_current()
 {

--- a/tests/automated-tests/tests/test_schedule.nut
+++ b/tests/automated-tests/tests/test_schedule.nut
@@ -182,3 +182,31 @@ function test_schedule_flags()
 	local sched2 = cnv.get_schedule()
 	ASSERT_EQUAL(sched2.flags, 6)
 }
+
+// --- Property 7: schedule_x.max_speed ---
+
+function test_schedule_max_speed()
+{
+	local pl = player_x(0)
+
+	ASSERT_EQUAL(command_x(tool_build_way).work(pl, coord3d(4, 2, 0), coord3d(4, 8, 0), "sand_track"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 2, 0), "TrainStop"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 7, 0), "TrainStop"), null)
+	ASSERT_EQUAL(command_x.build_depot(pl, coord3d(4, 8, 0), building_desc_x("TrainDepot")), null)
+
+	local depot = depot_x(4, 8, 0)
+	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("1Diesellokomotive"))
+	local cnv = depot.get_convoy_list()[0]
+
+	cnv.change_schedule(pl, schedule_x(wt_rail, [
+		schedule_entry_x(coord3d(4, 2, 0), 0, 0),
+		schedule_entry_x(coord3d(4, 7, 0), 0, 0),
+	]))
+
+	local sched = cnv.get_schedule()
+	sched.max_speed = 100
+	cnv.change_schedule(pl, sched)
+
+	local sched2 = cnv.get_schedule()
+	ASSERT_EQUAL(sched2.max_speed, 100)
+}

--- a/tests/automated-tests/tests/test_schedule.nut
+++ b/tests/automated-tests/tests/test_schedule.nut
@@ -153,3 +153,32 @@ function test_schedule_entry_balance_speed()
 	local sched2 = cnv.get_schedule()
 	ASSERT_EQUAL(sched2.entries[0].balance_speed, 80)
 }
+
+// --- Property 6: schedule_x.flags ---
+
+function test_schedule_flags()
+{
+	local pl = player_x(0)
+
+	ASSERT_EQUAL(command_x(tool_build_way).work(pl, coord3d(4, 2, 0), coord3d(4, 8, 0), "sand_track"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 2, 0), "TrainStop"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 7, 0), "TrainStop"), null)
+	ASSERT_EQUAL(command_x.build_depot(pl, coord3d(4, 8, 0), building_desc_x("TrainDepot")), null)
+
+	local depot = depot_x(4, 8, 0)
+	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("1Diesellokomotive"))
+	local cnv = depot.get_convoy_list()[0]
+
+	cnv.change_schedule(pl, schedule_x(wt_rail, [
+		schedule_entry_x(coord3d(4, 2, 0), 0, 0),
+		schedule_entry_x(coord3d(4, 7, 0), 0, 0),
+	]))
+
+	// SAME_DEP_TIME=2, FULL_LOAD_ACCELERATION=4 => flags=6
+	local sched = cnv.get_schedule()
+	sched.flags = 6
+	cnv.change_schedule(pl, sched)
+
+	local sched2 = cnv.get_schedule()
+	ASSERT_EQUAL(sched2.flags, 6)
+}

--- a/tests/automated-tests/tests/test_schedule.nut
+++ b/tests/automated-tests/tests/test_schedule.nut
@@ -210,3 +210,31 @@ function test_schedule_max_speed()
 	local sched2 = cnv.get_schedule()
 	ASSERT_EQUAL(sched2.max_speed, 100)
 }
+
+// --- Property 8: schedule_x.current ---
+
+function test_schedule_current()
+{
+	local pl = player_x(0)
+
+	ASSERT_EQUAL(command_x(tool_build_way).work(pl, coord3d(4, 2, 0), coord3d(4, 8, 0), "sand_track"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 2, 0), "TrainStop"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 7, 0), "TrainStop"), null)
+	ASSERT_EQUAL(command_x.build_depot(pl, coord3d(4, 8, 0), building_desc_x("TrainDepot")), null)
+
+	local depot = depot_x(4, 8, 0)
+	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("1Diesellokomotive"))
+	local cnv = depot.get_convoy_list()[0]
+
+	cnv.change_schedule(pl, schedule_x(wt_rail, [
+		schedule_entry_x(coord3d(4, 2, 0), 0, 0),
+		schedule_entry_x(coord3d(4, 7, 0), 0, 0),
+	]))
+
+	local sched = cnv.get_schedule()
+	sched.current = 1
+	cnv.change_schedule(pl, sched)
+
+	local sched2 = cnv.get_schedule()
+	ASSERT_EQUAL(sched2.current, 1)
+}

--- a/tests/automated-tests/tests/test_schedule.nut
+++ b/tests/automated-tests/tests/test_schedule.nut
@@ -272,7 +272,73 @@ function test_schedule_departure_slot_group_id_non_null()
 	ASSERT_EQUAL(sched2.departure_slot_group_id.get_name(), line.get_name())
 }
 
-// --- Property 9: schedule_x.current ---
+// --- Property 9: schedule_x.next_line ---
+
+function test_schedule_next_line()
+{
+	local pl = player_x(0)
+
+	ASSERT_EQUAL(command_x(tool_build_way).work(pl, coord3d(4, 2, 0), coord3d(4, 8, 0), "sand_track"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 2, 0), "TrainStop"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 7, 0), "TrainStop"), null)
+	ASSERT_EQUAL(command_x.build_depot(pl, coord3d(4, 8, 0), building_desc_x("TrainDepot")), null)
+
+	local depot = depot_x(4, 8, 0)
+	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("1Diesellokomotive"))
+	local cnv = depot.get_convoy_list()[0]
+
+	cnv.change_schedule(pl, schedule_x(wt_rail, [
+		schedule_entry_x(coord3d(4, 2, 0), 0, 0),
+		schedule_entry_x(coord3d(4, 7, 0), 0, 0),
+	]))
+
+	// next_line defaults to null when no connected route is set
+	local sched = cnv.get_schedule()
+	ASSERT_EQUAL(sched.next_line, null)
+	// round-trip preserves null
+	cnv.change_schedule(pl, sched)
+	local sched2 = cnv.get_schedule()
+	ASSERT_EQUAL(sched2.next_line, null)
+}
+
+function test_schedule_next_line_non_null()
+{
+	local pl = player_x(0)
+
+	ASSERT_EQUAL(command_x(tool_build_way).work(pl, coord3d(4, 2, 0), coord3d(4, 8, 0), "sand_track"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 2, 0), "TrainStop"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 7, 0), "TrainStop"), null)
+	ASSERT_EQUAL(command_x.build_depot(pl, coord3d(4, 8, 0), building_desc_x("TrainDepot")), null)
+
+	local depot = depot_x(4, 8, 0)
+	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("1Diesellokomotive"))
+	local cnv = depot.get_convoy_list()[0]
+
+	cnv.change_schedule(pl, schedule_x(wt_rail, [
+		schedule_entry_x(coord3d(4, 2, 0), 0, 0),
+		schedule_entry_x(coord3d(4, 7, 0), 0, 0),
+	]))
+
+	ASSERT_EQUAL(pl.create_line(wt_rail), true)
+	local line_list = pl.get_line_list()
+	local line = line_list[line_list.get_count() - 1]
+
+	// Give the line a valid schedule so it passes set_next_line() validity checks
+	line.change_schedule(pl, schedule_x(wt_rail, [
+		schedule_entry_x(coord3d(4, 2, 0), 0, 0),
+		schedule_entry_x(coord3d(4, 7, 0), 0, 0),
+	]))
+
+	// Set next_line via set_next_line() and verify round-trip
+	local sched = cnv.get_schedule()
+	sched.set_next_line(line)
+	cnv.change_schedule(pl, sched)
+
+	local sched2 = cnv.get_schedule()
+	ASSERT_EQUAL(sched2.next_line.get_name(), line.get_name())
+}
+
+// --- Property 10: schedule_x.current ---
 
 function test_schedule_current()
 {


### PR DESCRIPTION
## 概要

`schedule_x` クラスに、`schedule_t` が持つ以下のプロパティを追加しました。

- `flags` — スケジュールレベルのフラグビットマスク（TEMPORARY=1, SAME_DEP_TIME=2 など）
- `max_speed` — スケジュールレベルの最大速度上書き（km/h）。0 は無制限
- `departure_slot_group_id` — 出発スロットグループのリーダーライン
- `current` — 現在の停留所インデックス
- `next_line` — このスケジュール完了後に編成が移行するライン（読み取り専用）

## 変更内容

- **`script/api/api_schedule.cc`**: `param<schedule_t*>::get` で各スロットを読み取り C++ オブジェクトに反映。`export_schedule` にデフォルト値付きのスロット定義を追加。
- **`script/api_param.cc`**: `param<const schedule_t*>::push` に全プロパティの `set_slot` を追加し、C++ → Squirrel 変換時に全フィールドを反映。
- **`next_line` の設計**:
  - `next_line` は読み取り専用プロパティ。設定には `set_next_line(line)` メソッドを使用する。
  - `set_next_line()` は C++ の `schedule_t::set_next_line()` を経由し、ウェイタイプ一致・エントリ数 ≥2・停車可能停留所の存在チェックを行う。
  - `set_next_line()` が末尾に追加するダミーエントリは Squirrel 側の `entries` には含めず、デシリアライズ時に `set_next_line()` 呼び出しで再付加する。
  - `set_next_line_id()` は削除。
- **テスト**: 各プロパティのラウンドトリップ検証テストを追加。

## テスト

追加した6つのテストケースがすべて PASSED であることを確認済み。

```
✓ test_schedule_flags
✓ test_schedule_max_speed
✓ test_schedule_departure_slot_group_id
✓ test_schedule_current
✓ test_schedule_next_line
✓ test_schedule_next_line_non_null
```