### PR TITLE
Expose journey_time/waiting_time/convoy_stopping_time arrays on schedule_entry_x

### DIFF
--- a/script/api/api_schedule.cc
+++ b/script/api/api_schedule.cc
@@ -226,6 +226,29 @@ void export_schedule(HSQUIRRELVM vm)
 	create_slot(vm, "spacing_shift", 0);
 	create_slot(vm, "delay_tolerance", 0);
 
+#ifdef SQAPI_DOC // document members
+	/**
+	 * Array of last 5 journey times (ticks), most recent at index 0.
+	 * The journey time is the time between departure from the previous stop and arrival at this stop.
+	 * 0 means not yet recorded.
+	 */
+	array<integer> journey_time;
+	/**
+	 * Array of last 5 average waiting times of goods (ticks), most recent at index 0.
+	 * 0 means not yet recorded.
+	 */
+	array<integer> waiting_time;
+	/**
+	 * Array of last 5 convoy stopping times (ticks), most recent at index 0.
+	 * 0 means not yet recorded.
+	 */
+	array<integer> convoy_stopping_time;
+#endif
+
+	create_slot(vm, "journey_time", 0);
+	create_slot(vm, "waiting_time", 0);
+	create_slot(vm, "convoy_stopping_time", 0);
+
 	/**
 	 * Returns halt at this entry position.
 	 * @param pl player that wants to use halt here

--- a/script/api_param.cc
+++ b/script/api_param.cc
@@ -594,6 +594,25 @@ namespace script_api {
 		set_slot(vm, "spacing_shift", (sint32)v.spacing_shift);
 		set_slot(vm, "delay_tolerance", (sint32)v.delay_tolerance);
 
+		// time arrays: newest entry first (jt_at_index points to next-write slot)
+		vector_tpl<sint32> jt_arr(NUM_ARRIVAL_TIME_STORED);
+		for(int i = 0; i < NUM_ARRIVAL_TIME_STORED; i++) {
+			jt_arr.append((sint32)v.journey_time[(v.jt_at_index - 1 - i + NUM_ARRIVAL_TIME_STORED) % NUM_ARRIVAL_TIME_STORED]);
+		}
+		set_slot(vm, "journey_time", jt_arr);
+
+		vector_tpl<sint32> wt_arr(NUM_WAITING_TIME_STORED);
+		for(int i = 0; i < NUM_WAITING_TIME_STORED; i++) {
+			wt_arr.append((sint32)v.waiting_time[(v.wt_at_index - 1 - i + NUM_WAITING_TIME_STORED) % NUM_WAITING_TIME_STORED]);
+		}
+		set_slot(vm, "waiting_time", wt_arr);
+
+		vector_tpl<sint32> cs_arr(NUM_STOPPING_TIME_STORED);
+		for(int i = 0; i < NUM_STOPPING_TIME_STORED; i++) {
+			cs_arr.append((sint32)v.convoy_stopping_time[(v.cs_at_index - 1 - i + NUM_STOPPING_TIME_STORED) % NUM_STOPPING_TIME_STORED]);
+		}
+		set_slot(vm, "convoy_stopping_time", cs_arr);
+
 		return 1;
 	}
 

--- a/tests/automated-tests/all_tests.nut
+++ b/tests/automated-tests/all_tests.nut
@@ -236,7 +236,8 @@ all_tests <- [
 	test_schedule_departure_slot_group_id_non_null,
 	test_schedule_next_line,
 	test_schedule_next_line_non_null,
-	test_schedule_current
+	test_schedule_current,
+	test_schedule_entry_time_statistics
 ]
 
 

--- a/tests/automated-tests/tests/test_schedule.nut
+++ b/tests/automated-tests/tests/test_schedule.nut
@@ -365,3 +365,63 @@ function test_schedule_current()
 	local sched2 = cnv.get_schedule()
 	ASSERT_EQUAL(sched2.current, 1)
 }
+
+
+// --- Properties: schedule_entry_x journey_time / waiting_time / convoy_stopping_time ---
+
+function test_schedule_entry_time_statistics()
+{
+	local pl = player_x(0)
+
+	// Build 3-stop road route: A(4,2) - B(4,5) - C(4,8) - depot(4,9)
+	ASSERT_EQUAL(command_x(tool_build_way).work(pl, coord3d(4, 2, 0), coord3d(4, 9, 0), "cobblestone_road"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 2, 0), "BusStop"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 5, 0), "BusStop"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 8, 0), "BusStop"), null)
+	ASSERT_EQUAL(command_x.build_depot(pl, coord3d(4, 9, 0), building_desc_x("CarDepot")), null)
+
+	// Create line: stats are recorded on the line's schedule, not the convoy's.
+	ASSERT_TRUE(pl.create_line(wt_road))
+	local line_list = pl.get_line_list()
+	local line = line_list[line_list.get_count() - 1]
+	local the_schedule = schedule_x(wt_road, [
+		schedule_entry_x(coord3d(4, 2, 0), 0, 0),
+		schedule_entry_x(coord3d(4, 5, 0), 0, 0),
+		schedule_entry_x(coord3d(4, 8, 0), 0, 0),
+	])
+	line.change_schedule(pl, the_schedule)
+
+	local halt_b = halt_x.get_halt(coord3d(4, 5, 0), pl)
+
+	local depot = depot_x(4, 9, 0)
+	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("Buessig"))
+	local cnv = depot.get_convoy_list()[0]
+	// Assign to line while in depot (state=INITIAL) to avoid EDIT_SCHEDULE on set_line.
+	// This copies the line's schedule to the convoy without triggering re-routing.
+	cnv.set_line(pl, line)
+	depot.start_all_convoys(pl)
+	debug.set_game_speed(5)
+
+	// Wait until A->B routing graph is established (generate_goods returns ROUTE_OK=1).
+	while (world.generate_goods(coord(3, 2), coord(3, 5), good_desc_x.passenger, 1) == 0) {
+		sleep()
+	}
+
+	// Count 4 B arrivals after routing is ready to ensure 3 A visits with passengers.
+	local base_b = halt_b.convoys[0]
+	while (halt_b.convoys[0] < base_b + 4) {
+		world.generate_goods(coord(3, 2), coord(3, 5), good_desc_x.passenger, 30)
+		sleep()
+	}
+
+	// Read stats from the LINE's schedule (not the convoy's schedule).
+	local sched = line.get_schedule()
+	local entry_b = sched.entries[1]
+
+	// journey_time at B: A->B travel time, recorded on each arrival at B
+	ASSERT_EQUAL(typeof entry_b.journey_time, "array")
+	ASSERT_EQUAL(entry_b.journey_time.len(), 5)
+	ASSERT_TRUE(entry_b.journey_time[0] > 0)
+	ASSERT_TRUE(entry_b.journey_time[1] > 0)
+	ASSERT_TRUE(entry_b.journey_time[2] > 0)
+}


### PR DESCRIPTION
## 概要

`schedule_entry_t` が内部で保持している直近5回分の統計データ（走行時間・待機時間・停車時間）を、Squirrel スクリプトから参照できるように `schedule_entry_x` に配列プロパティとして追加しました。

- `journey_time` — 直近5回の所要時間（ticks）。前の停留所を出発してからこの停留所に到着するまでの時間。
- `waiting_time` — 直近5回の貨物平均待機時間（ticks）。貨物が停留所に到着してから積み込まれるまでの加重平均。
- `convoy_stopping_time` — 直近5回の編成停車時間（ticks）。到着から出発までの時間。

いずれも `index 0` が最新の記録値で、未記録の場合は `0`。

**注意：** これらの統計は路線のスケジュールに記録されます。したがって、値を参照するには `cnv.get_schedule()` ではなく `line.get_schedule()` を使用してください。

## 変更ファイル

- `script/api/api_schedule.cc` — `schedule_entry_x` にスロット定義とドキュメントを追加
- `script/api_param.cc` — `param<schedule_entry_t>::push()` で循環バッファから配列を構築して `set_slot`

## テスト

`test_schedule_entry_time_statistics` を追加しました。3停留所のバス路線（路線所属）を動かし、路線のスケジュールから以下を検証します。

- `entry_b.journey_time` が `array` 型、長さ5、かつ直近3回分（index 0〜2）が非ゼロであること

**`waiting_time` および `convoy_stopping_time` の assertion は省略しています。** これらの値が記録されるには乗客の積み込みが必要ですが、ルーティンググラフの確立タイミングと編成の訪問タイミングの依存関係が複雑で、テストセットアップ内で安定して3回分の非ゼロ値を保証することが難しかったためです。`journey_time` については編成が走行するだけで記録されるため、安定したテストが可能です。