### PR TITLE
BUG FIX: fix settings_t::rdwr

### DIFF
--- a/dataobj/settings.cc
+++ b/dataobj/settings.cc
@@ -1024,7 +1024,7 @@ void settings_t::rdwr(loadsave_t *file)
 			overloading_runningcost_increase = true;
 			default_reverse = false;
 		}
-		uint32 credit_per_MWs;
+		uint32 credit_per_MWs = 1024/cst_kw_per_credit;
 		if(  file->get_OTRP_version() >= 51  ) {
 			file->rdwr_bool(env_t::use_old_friction);
 			if(  file->get_OTRP_version() < 54  ) {
@@ -1089,12 +1089,11 @@ void settings_t::rdwr(loadsave_t *file)
 			file->rdwr_long(way_count_maximum);
 		}
 
-		uint32 cst_kw_per_credit = 1024/credit_per_MWs;
 		if (file->is_version_atleast(124, 4)||file->get_OTRP_version()>=54) {
 			file->rdwr_long(cst_kw_per_credit);
 		}
 		else {
-			cst_kw_per_credit = 512;
+			cst_kw_per_credit = credit_per_MWs>0 ? 1024/credit_per_MWs : 512;
 		}
 		// otherwise the default values of the last one will be used
 	}


### PR DESCRIPTION
`settings_t::rdwr()`の処理が不適切でセーブできない不具合を修正しました