### PR TITLE
BUG FIX: fix direction-dependent sideways image duration for reversing bus

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -2798,6 +2798,19 @@ void convoi_t::vorfahren()
 				}
 				inspecting = inspecting->get_coupling_convoi();
 			}
+			// Reset sideways image timer: the initial do_drive() above consumes different
+			// amounts per direction, so reset to turned_length for a uniform display time.
+			if(  !go_same_direction  ) {
+				inspecting = self;
+				while(  inspecting.is_bound()  ) {
+					for(  unsigned i = 0;  i < inspecting->get_vehicle_count();  i++  ) {
+						if(  road_vehicle_t* rv = dynamic_cast<road_vehicle_t*>(inspecting->get_vehikel(i))  ) {
+							rv->reset_sideways_image_timer();
+						}
+					}
+					inspecting = inspecting->get_coupling_convoi();
+				}
+			}
 			// if this convoy go to the same direction, we need to advance them to the initial step.
 			if(  go_same_direction ) {
 				inspecting = self;

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -2798,19 +2798,6 @@ void convoi_t::vorfahren()
 				}
 				inspecting = inspecting->get_coupling_convoi();
 			}
-			// Reset sideways image timer: the initial do_drive() above consumes different
-			// amounts per direction, so reset to turned_length for a uniform display time.
-			if(  !go_same_direction  ) {
-				inspecting = self;
-				while(  inspecting.is_bound()  ) {
-					for(  unsigned i = 0;  i < inspecting->get_vehicle_count();  i++  ) {
-						if(  road_vehicle_t* rv = dynamic_cast<road_vehicle_t*>(inspecting->get_vehikel(i))  ) {
-							rv->reset_sideways_image_timer();
-						}
-					}
-					inspecting = inspecting->get_coupling_convoi();
-				}
-			}
 			// if this convoy go to the same direction, we need to advance them to the initial step.
 			if(  go_same_direction ) {
 				inspecting = self;
@@ -2836,6 +2823,12 @@ void convoi_t::vorfahren()
 						}
 						inspecting = inspecting->get_coupling_convoi();
 					}
+				}
+			}
+			else if(  !get_coupling_convoi().is_bound()  &&  get_vehicle_count()==1  ) {
+				// In case that single car bus or truck is turning around...
+				if(  road_vehicle_t* rv = dynamic_cast<road_vehicle_t*>(self->front())  ) {
+					rv->set_sideways_image();
 				}
 			}
 			fahr[0]->set_leading(true);

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -2241,44 +2241,33 @@ void road_vehicle_t::calc_disp_lane()
 	disp_lane = get_direction() & test_dir ? 1 : 3;
 }
 
-void road_vehicle_t::calc_image()
+void road_vehicle_t::set_sideways_image()
 {
-	// Show sideways image when departing from a stop in the opposite direction.
-	// This happens when the vehicle turns 180° (e.g., departs a terminus in reverse).
-	if(  previous_direction != ribi_t::none
-		&&  direction == ribi_t::backward(previous_direction)  ) {
-		// Check if we departed from a halt tile
-		grund_t *prev_gr = welt->lookup(pos_prev);
-		if(  prev_gr  &&  prev_gr->is_halt()  ) {
-			// Determine effective drive side: drive-on-left XOR inverted_mode on current tile
-			strasse_t *str = (strasse_t*)welt->lookup(get_pos())->get_weg(road_wt);
-			const bool drives_left = welt->get_settings().is_drive_left();
-			const bool inverted    = str  &&  str->get_overtaking_mode() == inverted_mode;
-			const bool effective_drive_left = drives_left ^ inverted;
+	// Determine effective drive side: drive-on-left XOR inverted_mode on current tile
+	const strasse_t *str = (strasse_t*)welt->lookup(get_pos())->get_weg(road_wt);
+	const bool drives_left = welt->get_settings().is_drive_left();
+	const bool inverted    = str  &&  str->get_overtaking_mode() == inverted_mode;
+	const bool effective_drive_left = drives_left ^ inverted;
 
-			// Sideways direction: right side for drive-on-right, left side for drive-on-left
-			// rotate90l = CCW = right side of forward dir; rotate90 = CW = left side
-			ribi_t::ribi side_dir = effective_drive_left
-				? ribi_t::rotate90l(direction)  // left side -> turn left
-				: ribi_t::rotate90(direction);  // right side -> turn right
+	// Sideways direction: right side for drive-on-right, left side for drive-on-left
+	// rotate90l = CCW = right side of forward dir; rotate90 = CW = left side
+	const ribi_t::ribi side_dir = effective_drive_left
+		? ribi_t::rotate90l(direction)  // left side -> turn left
+		: ribi_t::rotate90(direction);  // right side -> turn right
 
-			image_id old_image = get_image();
-			const bool is_reversed    = (cnv == NULL || cnv == (convoi_t*)1) ? false : cnv->is_reversed();
-			const bool is_no_electric = (cnv == NULL || cnv == (convoi_t*)1) ? false : !cnv->get_use_electric();
-			if(  fracht.empty()  ) {
-				set_image(desc->get_image_id(ribi_t::get_dir(side_dir), NULL, is_reversed, is_no_electric));
-			}
-			else {
-				set_image(desc->get_image_id(ribi_t::get_dir(side_dir), fracht.front().get_desc(), is_reversed, is_no_electric));
-			}
-			if(  old_image != get_image()  ) {
-				set_flag(obj_t::dirty);
-			}
-			sideways_image_steps = (sint16)(turned_length + get_desc()->get_length_in_steps());
-			return;
-		}
+	const image_id old_image = get_image();
+	const bool is_reversed    = (cnv == NULL || cnv == (convoi_t*)1) ? false : cnv->is_reversed();
+	const bool is_no_electric = (cnv == NULL || cnv == (convoi_t*)1) ? false : !cnv->get_use_electric();
+	if(  fracht.empty()  ) {
+		set_image(desc->get_image_id(ribi_t::get_dir(side_dir), NULL, is_reversed, is_no_electric));
 	}
-	vehicle_t::calc_image();
+	else {
+		set_image(desc->get_image_id(ribi_t::get_dir(side_dir), fracht.front().get_desc(), is_reversed, is_no_electric));
+	}
+	if(  old_image != get_image()  ) {
+		set_flag(obj_t::dirty);
+	}
+	sideways_image_steps = turned_length;
 }
 
 

--- a/vehicle/simvehicle.h
+++ b/vehicle/simvehicle.h
@@ -549,6 +549,8 @@ public:
 	void calc_image() OVERRIDE;
 	uint32 do_drive(uint32 dist) OVERRIDE;
 
+	void reset_sideways_image_timer() { if(sideways_image_steps > 0) { sideways_image_steps = turned_length; } }
+
 	koord3d get_pos_prev() const { return pos_prev; }
 
 	schedule_t * generate_new_schedule() const OVERRIDE;

--- a/vehicle/simvehicle.h
+++ b/vehicle/simvehicle.h
@@ -546,10 +546,9 @@ public:
 
 	obj_t::typ get_typ() const OVERRIDE { return road_vehicle; }
 
-	void calc_image() OVERRIDE;
 	uint32 do_drive(uint32 dist) OVERRIDE;
 
-	void reset_sideways_image_timer() { if(sideways_image_steps > 0) { sideways_image_steps = turned_length; } }
+	void set_sideways_image();
 
 	koord3d get_pos_prev() const { return pos_prev; }
 


### PR DESCRIPTION
## 概要

折り返し時の横向き画像の表示時間が方向によって異なるバグを修正。

## 原因

以前の実装では、`convoi_t::vorfahren()` の折り返し出発時に `move_to()` → `initialise_journey()` → `calc_image()` の流れで `sideways_image_steps` がセットされていました。しかしその直後、初期配置のために `do_drive()` が呼ばれてカウンタが消費される際、この消費量が方向によって非対称となっていました。

- 南・東方向への出発：`do_drive()` で約128ステップ消費 → 残り8ステップ（ほぼ見えない）
- 北・西・対角方向への出発：`do_drive()` で16ステップしか消費されない → 残り120ステップ（長すぎる）

## 修正

`road_vehicle_t::calc_image()` 内で行っていた横向き画像とタイマーのセット処理を削除し、専用のメソッド `set_sideways_image()` に抽出しました。
`convoi_t::vorfahren()` において、初期配置のための `do_drive()` ループがすべて完了した後に、1両編成のバスやトラックが折り返す場合に限定して、明示的に `set_sideways_image()` を呼び出すように変更しました。

これにより、初期配置によるタイマーの不規則な消費を完全に回避し、全方向で均一な表示時間（`turned_length`）になるようにしています。また、不要な `calc_image` のオーバーライドも解消されました。

## 動作確認

https://github.com/user-attachments/assets/6980763c-479e-48b8-9124-e2d2a4ddc859