### PR TITLE
BUG FIX: save city of senke

### DIFF
--- a/obj/leitung2.cc
+++ b/obj/leitung2.cc
@@ -874,6 +874,24 @@ void senke_t::rdwr(loadsave_t *file)
 		delta_sum = 0;
 		next_t = 0;
 	}
+	if(  file->get_OTRP_version()>53  ) {
+		koord city_pos = koord::invalid;
+		if(  file->is_saving() && city!=NULL  ) {
+			city_pos = city->get_pos();
+		}
+		city_pos.rdwr(file);
+		if(  file->is_loading()  ) {
+			if(  city_pos==koord::invalid  ) {
+				city==NULL;
+			}
+			else {
+				city = welt->find_nearest_city(city_pos);
+				if(  city  ) {
+					city->add_substation(this);
+				}
+			}
+		}
+	}
 }
 
 void senke_t::finish_rd()


### PR DESCRIPTION
都市の変電所について、都市情報が保存されず、ロード直後のstepで破壊される不具合を修正しました