### PR TITLE
BUG FIX: assert when remove multitiles cityhall & crash in convoi_t::rdwr()

### DIFF
--- a/boden/wege/schiene.cc
+++ b/boden/wege/schiene.cc
@@ -84,7 +84,7 @@ bool schiene_t::reserve(convoihandle_t c, ribi_t::ribi dir  )
 		 * direction is a diagonal (i.e. on the switching part)
 		 * and there are switching graphics
 		 */
-		if(  ribi_t::is_threeway(get_ribi_unmasked())  &&  ribi_t::is_bend(dir)  &&  get_desc()->has_switch_image()  &&  get_desc()->get_finance_waytype() != tram_wt  &&  !get_is_ex_image()  ) {
+		if(  get_desc()!=NULL  &&  ribi_t::is_threeway(get_ribi_unmasked())  &&  ribi_t::is_bend(dir)  &&  get_desc()->has_switch_image()  &&  get_desc()->get_finance_waytype() != tram_wt  &&  !get_is_ex_image()  ) {
 			mark_image_dirty( get_image(), 0 );
 			mark_image_dirty( get_front_image(), 0 );
 			set_images(image_switch, get_ribi_unmasked(), is_snow(), (dir==ribi_t::northeast  ||  dir==ribi_t::southwest) );

--- a/obj/gebaeude.cc
+++ b/obj/gebaeude.cc
@@ -1018,9 +1018,7 @@ void gebaeude_t::rdwr(loadsave_t *file)
 			if(  welt->get_cities().is_contained( ptr.stadt )  ) {
 				city_index = welt->get_cities().index_of( ptr.stadt );
 			}
-			else {
-				ptr.stadt = NULL;
-			}
+			// else: city was removed; save city_index as -1 without touching ptr.stadt
 		}
 		file->rdwr_long(city_index);
 		if(  file->is_loading()  &&  (tile==NULL  ||  tile->get_desc()==NULL  ||  tile->get_desc()->is_connected_with_town())  ) {

--- a/obj/gebaeude.cc
+++ b/obj/gebaeude.cc
@@ -1015,7 +1015,12 @@ void gebaeude_t::rdwr(loadsave_t *file)
 	if(  file->is_version_atleast(99, 14)  ) {
 		sint32 city_index = -1;
 		if(  file->is_saving()  &&  ptr.stadt!=NULL  ) {
-			city_index = welt->get_cities().index_of( ptr.stadt );
+			if(  welt->get_cities().is_contained( ptr.stadt )  ) {
+				city_index = welt->get_cities().index_of( ptr.stadt );
+			}
+			else {
+				ptr.stadt = NULL;
+			}
 		}
 		file->rdwr_long(city_index);
 		if(  file->is_loading()  &&  (tile==NULL  ||  tile->get_desc()==NULL  ||  tile->get_desc()->is_connected_with_town())  ) {

--- a/simcity.cc
+++ b/simcity.cc
@@ -976,7 +976,19 @@ stadt_t::~stadt_t()
 					}
 				}
 				else {
-					gb->set_stadt( NULL );
+					// For multi-tile buildings: pop_back() removed only this one tile's entry,
+					// but hausbauer_t::remove will delete all tiles. Pre-clear all tiles from
+					// buildings and set stadt=NULL so their destructors skip
+					// remove_gebaeude_from_stadt (which would otherwise fail to find the
+					// already-popped tile and assert).
+					static vector_tpl<grund_t*> tile_list;
+					gb->get_tile_list(tile_list);
+					for (grund_t* gr : tile_list) {
+						if (gebaeude_t* tile_gb = gr->find<gebaeude_t>()) {
+							buildings.remove(tile_gb); // may return false for gb (already popped), that's OK
+							tile_gb->set_stadt(NULL);
+						}
+					}
 					hausbauer_t::remove(welt->get_public_player(),gb);
 				}
 			}

--- a/simcity.cc
+++ b/simcity.cc
@@ -989,6 +989,7 @@ stadt_t::~stadt_t()
 							tile_gb->set_stadt(NULL);
 						}
 					}
+					gb->set_stadt(NULL); // ensure the popped tile is also cleared
 					hausbauer_t::remove(welt->get_public_player(),gb);
 				}
 			}

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -313,7 +313,7 @@ void convoi_t::reserve_route()
 		// reservation is controlled by reserved_tiles
 		for(  uint32 idx = 0;  idx < reserved_tiles.get_count();  idx++  ) {
 			if(  grund_t *gr = welt->lookup( reserved_tiles[idx] )  ) {
-				if(  schiene_t *sch = dynamic_cast<schiene_t *>(gr->get_weg( front()->get_waytype() ))  ) {
+				if(  schiene_t *sch = (schiene_t *)gr->get_weg( front()->get_waytype() )  ) {
 					sch->reserve( self, ribi_type( reserved_tiles[max(1u,idx)-1u], reserved_tiles[min(reserved_tiles.get_count()-1u,idx+1u)] ) );
 				}
 			}

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -631,6 +631,21 @@ DBG_MESSAGE("convoi_t::finish_rd()","next_stop_index=%d", next_stop_index );
 		calc_min_top_speed();
 	}
 	calc_speedbonus_kmh();
+
+	// Restore track reservations after all convoy data and vehicle positions are settled.
+	// Done here (not in rdwr) so all convoys are fully loaded before any reservation is
+	// attempted, avoiding convoy-vs-convoy conflicts during sequential rdwr loading.
+	// Skip when realignment already reserved the occupied tiles directly.
+	if(  !realign_position  ) {
+		// A try-coupling convoy waiting at a guide signal may have next_reservation_index
+		// set beyond next_stop_index by a prior block_reserver(1001) call. Cap it first.
+		if(  is_waiting()  &&  next_coupling_index == route_t::INVALID_INDEX
+		  &&  schedule != NULL  &&  schedule->get_current_entry().is_try_coupling()
+		  &&  next_reservation_index > next_stop_index  ) {
+			next_reservation_index = min(next_stop_index, route.get_count());
+		}
+		reserve_route();
+	}
 }
 
 
@@ -3488,17 +3503,6 @@ void convoi_t::rdwr(loadsave_t *file)
 	}
 
 	if(  file->is_loading()  ) {
-		// A try-coupling convoy waiting at a guide signal (WAITING_FOR_CLEARANCE etc.) has
-		// next_coupling_index == INVALID_INDEX because the coupling route is not yet found.
-		// next_reservation_index may have been set too far ahead by a prior block_reserver(1001)
-		// call on the ORIGINAL route (past the guide signal). Cap it at next_stop_index before
-		// reserve_route() runs so the wrong tiles are never reserved in the first place.
-		if(  is_waiting()  &&  next_coupling_index == route_t::INVALID_INDEX
-		  &&  schedule != NULL  &&  schedule->get_current_entry().is_try_coupling()
-		  &&  next_reservation_index > next_stop_index  ) {
-			next_reservation_index = min(next_stop_index,route.get_count());
-		}
-		reserve_route();
 		recalc_catg_index();
 	}
 }

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -309,11 +309,11 @@ void convoi_t::unreserve_route()
  */
 void convoi_t::reserve_route()
 {
-	if(  reserved_tiles.get_count()>0  ) {
+	if(  reserved_tiles.get_count()>0  &&  anz_vehikel>0  ) {
 		// reservation is controlled by reserved_tiles
 		for(  uint32 idx = 0;  idx < reserved_tiles.get_count();  idx++  ) {
 			if(  grund_t *gr = welt->lookup( reserved_tiles[idx] )  ) {
-				if(  schiene_t *sch = (schiene_t *)gr->get_weg( front()->get_waytype() )  ) {
+				if(  schiene_t *sch = dynamic_cast<schiene_t *>(gr->get_weg( front()->get_waytype() ))  ) {
 					sch->reserve( self, ribi_type( reserved_tiles[max(1u,idx)-1u], reserved_tiles[min(reserved_tiles.get_count()-1u,idx+1u)] ) );
 				}
 			}


### PR DESCRIPTION
windows版にて複数タイル市役所を破壊した際にクラッシュするバグを修正します