### PR TITLE
add signal reverse front/back

### DIFF
--- a/dataobj/settings.cc
+++ b/dataobj/settings.cc
@@ -79,6 +79,8 @@ settings_t::settings_t() :
 	// since the turning rules are different, driving must now be saved here
 	drive_on_left = false;
 	signals_on_left = false;
+	signal_reverse_front_back = false;
+	roadsign_reverse_front_back = false;
 
 	// forest setting ...
 	forest_base_size = 36;                 // Base forest size - minimal size of forest - map independent
@@ -1046,6 +1048,13 @@ void settings_t::rdwr(loadsave_t *file)
 		} else {
 			use_route_cache = false;
 		}
+		if(  file->get_OTRP_version() >= 55  ) {
+			file->rdwr_bool(signal_reverse_front_back);
+			file->rdwr_bool(roadsign_reverse_front_back);
+		} else {
+			signal_reverse_front_back = false;
+			roadsign_reverse_front_back = false;
+		}
  		if(  file->is_version_atleast(122, 1)  ) {
 			file->rdwr_enum(climate_generator);
 			file->rdwr_byte( wind_direction );
@@ -1348,6 +1357,8 @@ void settings_t::parse_simuconf( tabfile_t& simuconf, sint16& disp_width, sint16
 
 	drive_on_left                  = contents.get_int( "drive_left",                     drive_on_left ) != 0;
 	signals_on_left                = contents.get_int( "signals_on_left",                signals_on_left ) != 0;
+	signal_reverse_front_back      = contents.get_int( "signal_reverse_front_back",      signal_reverse_front_back ) != 0;
+	roadsign_reverse_front_back    = contents.get_int( "roadsign_reverse_front_back",    roadsign_reverse_front_back ) != 0;
 	allow_underground_transformers = contents.get_int( "allow_underground_transformers", allow_underground_transformers ) != 0;
 	disable_make_way_public        = contents.get_int( "disable_make_way_public",        disable_make_way_public ) != 0;
 

--- a/dataobj/settings.h
+++ b/dataobj/settings.h
@@ -325,6 +325,8 @@ private:
 
 	bool drive_on_left;
 	bool signals_on_left;
+	bool signal_reverse_front_back;
+	bool roadsign_reverse_front_back;
 
 	// fraction of running costs charged for going on other players way
 	sint32 way_toll_runningcost_percentage;
@@ -719,6 +721,8 @@ public:
 
 	bool is_drive_left() const { return drive_on_left; }
 	bool is_signals_left() const { return signals_on_left; }
+	bool get_signal_reverse_front_back() const { return signal_reverse_front_back; }
+	bool get_roadsign_reverse_front_back() const { return roadsign_reverse_front_back; }
 
 	sint32 get_way_toll_runningcost_percentage() const { return way_toll_runningcost_percentage; }
 	sint32 get_way_toll_waycost_percentage() const { return way_toll_waycost_percentage; }

--- a/gui/settings_stats.cc
+++ b/gui/settings_stats.cc
@@ -77,6 +77,8 @@ void settings_general_stats_t::init(settings_t const* const sets)
 	SEPERATOR
 	INIT_BOOL( "drive_left", sets->is_drive_left() );
 	INIT_BOOL( "signals_on_left", sets->is_signals_left() );
+	INIT_BOOL( "signal_reverse_front_back", sets->get_signal_reverse_front_back() );
+	INIT_BOOL( "roadsign_reverse_front_back", sets->get_roadsign_reverse_front_back() );
 	SEPERATOR
 	INIT_NUM( "autosave", env_t::autosave, 0, 12, gui_numberinput_t::AUTOLINEAR, false );
 	INIT_NUM( "fast_forward", env_t::max_acceleration, 1, 1000, gui_numberinput_t::AUTOLINEAR, false );
@@ -122,6 +124,8 @@ void settings_general_stats_t::read(settings_t* const sets)
 	READ_BOOL_VALUE( sets->drive_on_left );
 	vehicle_base_t::set_overtaking_offsets( sets->drive_on_left );
 	READ_BOOL_VALUE( sets->signals_on_left );
+	READ_BOOL_VALUE( sets->signal_reverse_front_back );
+	READ_BOOL_VALUE( sets->roadsign_reverse_front_back );
 
 	READ_NUM_VALUE( env_t::autosave );
 	READ_NUM_VALUE( env_t::max_acceleration );

--- a/obj/roadsign.cc
+++ b/obj/roadsign.cc
@@ -4,6 +4,7 @@
  */
 
 #include <stdio.h>
+#include <algorithm>
 
 #include "../simunits.h"
 #include "../simdebug.h"
@@ -503,6 +504,14 @@ void roadsign_t::calc_image()
 				}
 			}
 
+		}
+	}
+	// swap front/back if the pak requires it
+	if(  !automatic || (desc->get_flags()&roadsign_desc_t::ONLY_BACKIMAGE)>0  ) {
+		if(  welt->get_settings().get_roadsign_reverse_front_back()  ) {
+			std::swap( tmp_image, foreground_image );
+			std::swap( xoff, after_xoffset );
+			std::swap( yoff, after_yoffset );
 		}
 	}
 	// set image and offsets

--- a/obj/roadsign.cc
+++ b/obj/roadsign.cc
@@ -507,7 +507,7 @@ void roadsign_t::calc_image()
 		}
 	}
 	// swap front/back if the pak requires it
-	if(  !automatic || (desc->get_flags()&roadsign_desc_t::ONLY_BACKIMAGE)>0  ) {
+	if(  !automatic && (desc->get_flags()&roadsign_desc_t::ONLY_BACKIMAGE)==0  ) {
 		if(  welt->get_settings().get_roadsign_reverse_front_back()  ) {
 			std::swap( tmp_image, foreground_image );
 			std::swap( xoff, after_xoffset );

--- a/obj/signal.cc
+++ b/obj/signal.cc
@@ -4,6 +4,7 @@
  */
 
 #include <stdio.h>
+#include <algorithm>
 
 #include "../simdebug.h"
 #include "../simworld.h"
@@ -174,6 +175,17 @@ void signal_t::calc_image()
 				}
 			}
 		}
+	}
+	if(  welt->get_settings().get_signal_reverse_front_back()  ) {
+		std::swap( image, foreground_image );
+		std::swap( xoff, after_xoffset );
+		std::swap( yoff, after_yoffset );
+	}
+	if(  desc->get_flags()&roadsign_desc_t::ONLY_BACKIMAGE  ) {
+		if(foreground_image!=IMG_EMPTY) {
+			image = foreground_image;
+		}
+		foreground_image = IMG_EMPTY;
 	}
 	set_xoff( xoff );
 	set_yoff( yoff );

--- a/obj/signal.cc
+++ b/obj/signal.cc
@@ -176,11 +176,12 @@ void signal_t::calc_image()
 			}
 		}
 	}
-	if(  welt->get_settings().get_signal_reverse_front_back()  ) {
+	if(  welt->get_settings().get_signal_reverse_front_back() && (desc->get_flags()&roadsign_desc_t::ONLY_BACKIMAGE)==0  ) {
 		std::swap( image, foreground_image );
 		std::swap( xoff, after_xoffset );
 		std::swap( yoff, after_yoffset );
 	}
+	// only background image used.
 	if(  desc->get_flags()&roadsign_desc_t::ONLY_BACKIMAGE  ) {
 		if(foreground_image!=IMG_EMPTY) {
 			image = foreground_image;

--- a/simversion.h
+++ b/simversion.h
@@ -30,7 +30,7 @@
 #define SIM_SERVER_MINOR    0
 // NOTE: increment before next release to enable save/load of new features
 
-#define OTRP_VERSION_MAJOR 54 // do not edit this!
+#define OTRP_VERSION_MAJOR 54
 #define OTRP_VERSION_MINOR 0
 #define OTRP_VERSION_PATCH 1
 // NOTE: increment OTRP_VERSION_MAJOR when the save data structure changes.

--- a/simversion.h
+++ b/simversion.h
@@ -30,7 +30,7 @@
 #define SIM_SERVER_MINOR    0
 // NOTE: increment before next release to enable save/load of new features
 
-#define OTRP_VERSION_MAJOR 54
+#define OTRP_VERSION_MAJOR 54 // do not edit this!
 #define OTRP_VERSION_MINOR 0
 #define OTRP_VERSION_PATCH 1
 // NOTE: increment OTRP_VERSION_MAJOR when the save data structure changes.


### PR DESCRIPTION
信号・道路標識の画像のFront/Backを高度な設定およびsimuconf.tabから反転させることができます
これにより、デフォルトで信号が左側に描画されているpak128.japanなどでも信号の描画順序が通常通りになります
※全信号のFront/Backを入れ替えるため、右側通行用信号と左側通行用信号の共存ができるわけではありません!