### PR TITLE
using axle_load of way

### DIFF
--- a/boden/wege/weg.cc
+++ b/boden/wege/weg.cc
@@ -305,6 +305,12 @@ void weg_t::info(cbuffer_t & buf) const
 	if( (get_waytype() != water_wt && get_waytype() != air_wt) && max_wayobj_speed ){
 		buf.printf("%s %u%s", translator::translate("Max. wayobj speed:"), max_wayobj_speed, translator::translate("km/h\n"));
 	}
+	if(  welt->get_settings().get_weight_mode() != settings_t::WEIGHT_UNLIMITED  ) {
+		const uint16 axle_load = get_desc()->get_axle_load();
+		if(  axle_load < 9999  ) {
+			buf.printf("%s %u t\n", translator::translate("Max. weight:"), axle_load);
+		}
+	}
 	buf.printf("%s%u",    translator::translate("\nRibi (unmasked)"), get_ribi_unmasked());
 	buf.printf("%s%u\n",  translator::translate("\nRibi (masked)"),   get_ribi());
 

--- a/dataobj/settings.cc
+++ b/dataobj/settings.cc
@@ -300,6 +300,7 @@ settings_t::settings_t() :
 	avoid_overcrowding = false;
 	overloading_revenue_reduced = false;
 	overloading_runningcost_increase = true;
+	weight_mode = WEIGHT_UNLIMITED;
 
 	allow_buying_obsolete_vehicles = true;
 
@@ -1046,6 +1047,9 @@ void settings_t::rdwr(loadsave_t *file)
 		} else {
 			use_route_cache = false;
 		}
+		if(  file->get_OTRP_version() >= 55  ) {
+			file->rdwr_enum(weight_mode);
+		}
  		if(  file->is_version_atleast(122, 1)  ) {
 			file->rdwr_enum(climate_generator);
 			file->rdwr_byte( wind_direction );
@@ -1507,6 +1511,7 @@ void settings_t::parse_simuconf( tabfile_t& simuconf, sint16& disp_width, sint16
 	allow_overloading					 = contents.get_int( "allow_overloading", allow_overloading) != 0;
 	overloading_revenue_reduced 		 = contents.get_int( "overloading_revenue_reduced", overloading_revenue_reduced) != 0;
 	overloading_runningcost_increase	 = contents.get_int( "overloading_runningcost_increase", overloading_runningcost_increase) != 0;
+	weight_mode = (weight_mode_t)clamp( contents.get_int( "weight_mode", (int)weight_mode ), (int)WEIGHT_UNLIMITED, (int)WEIGHT_PROHIBIT );
 
 	// city stuff
 	passenger_multiplier   = contents.get_int_clamped( "passenger_multiplier",   passenger_multiplier,   0, 100 );

--- a/dataobj/settings.h
+++ b/dataobj/settings.h
@@ -54,6 +54,13 @@ public:
 		MAP_BASED
 	} climate_generate_t;
 
+	typedef enum {
+		WEIGHT_UNLIMITED = 0,
+		WEIGHT_RUNNING_COST = 1,
+		WEIGHT_SPEED_LIMIT = 2,
+		WEIGHT_PROHIBIT = 3
+	} weight_mode_t;
+
 private:
 	sint32 size_x, size_y;
 	sint32 map_number;
@@ -303,6 +310,9 @@ private:
 	bool overloading_revenue_reduced;
 	/* if set, overcrowded car's running cost is increase*/
 	bool overloading_runningcost_increase;
+
+	/* way weight limit mode */
+	weight_mode_t weight_mode;
 
 	// lowest possible income with speedbonus (1000=1) default 125
 	sint32 bonus_basefactor;
@@ -612,6 +622,7 @@ public:
 	bool is_allow_overloading() const {return allow_overloading;}
 	bool is_overloading_revenue_reduced() const {return overloading_revenue_reduced;}
 	bool is_overloading_runningcost_increase() const {return overloading_runningcost_increase;}
+	weight_mode_t get_weight_mode() const { return weight_mode; }
 
 	sint16 get_river_number() const { return river_number; }
 	sint16 get_min_river_length() const { return min_river_length; }

--- a/gui/settings_stats.cc
+++ b/gui/settings_stats.cc
@@ -222,6 +222,22 @@ void settings_routing_stats_t::init(settings_t const* const sets)
 	INIT_BOOL( "allow overloading", sets->is_allow_overloading() );
 	INIT_BOOL( "overloading revenue reduced", sets->is_overloading_revenue_reduced() );
 	INIT_BOOL( "overloading runningcost increase", sets->is_overloading_runningcost_increase() );
+	{
+		static char const* const weight_mode_strings[] = {
+			"no weight limit",
+			"weight: increase running cost",
+			"weight: reduce speed limit",
+			"weight: prohibit entry"
+		};
+		weight_mode_selector.clear_elements();
+		for(  uint32 i=0;  i<lengthof(weight_mode_strings);  i++  ) {
+			weight_mode_selector.new_component<gui_scrolled_list_t::const_text_scrollitem_t>( weight_mode_strings[i], SYSCOL_TEXT );
+		}
+		weight_mode_selector.set_selection( (int)sets->get_weight_mode() );
+		weight_mode_selector.set_focusable( false );
+		add_component( &weight_mode_selector );
+		INIT_LB( "way weight limit mode" );
+	}
 	INIT_NUM( "station_coverage", sets->get_station_coverage(), 1, 127, gui_numberinput_t::AUTOLINEAR, false );
 	INIT_NUM( "allow_merge_distant_halt", sets->get_allow_merge_distant_halt(), 0, 0x7FFFFFFFul, gui_numberinput_t::POWER2, false );
 	SEPERATOR
@@ -275,6 +291,7 @@ void settings_routing_stats_t::read(settings_t* const sets)
 	READ_BOOL_VALUE( sets->allow_overloading );
 	READ_BOOL_VALUE( sets->overloading_revenue_reduced );
 	READ_BOOL_VALUE( sets->overloading_runningcost_increase );
+	sets->weight_mode = (settings_t::weight_mode_t)clamp( weight_mode_selector.get_selection(), (int)settings_t::WEIGHT_UNLIMITED, (int)settings_t::WEIGHT_PROHIBIT );
 	READ_NUM_VALUE( sets->station_coverage_size );
 	READ_NUM_VALUE( sets->allow_merge_distant_halt );
 	READ_NUM_VALUE( sets->max_route_steps );

--- a/gui/settings_stats.h
+++ b/gui/settings_stats.h
@@ -144,6 +144,8 @@ public:
 
 class settings_routing_stats_t : protected settings_stats_t, public gui_aligned_container_t
 {
+private:
+	gui_combobox_t weight_mode_selector;
 public:
 	void init(settings_t const*);
 	void read(settings_t*);

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -802,7 +802,21 @@ void convoi_t::add_running_cost( const weg_t *weg )
 		book( -toll-wayobj_toll, CONVOI_PROFIT);
 
 	}
-	sint64 const sum_running_costs = base_sum_running_costs * (welt->get_settings().is_overloading_runningcost_increase()?(sint64) max(loading_level,100) : (sint64) 100)/ (sint64) 100;
+	sint64 sum_running_costs = base_sum_running_costs * (welt->get_settings().is_overloading_runningcost_increase()?(sint64) max(loading_level,100) : (sint64) 100)/ (sint64) 100;
+	// weight-based running cost increase
+	if(  weg  &&  welt->get_settings().get_weight_mode() == settings_t::WEIGHT_RUNNING_COST  ) {
+		const uint32 axle_load = weg->get_desc()->get_axle_load();
+		if(  axle_load < 9999  ) {
+			const uint32 axle_load_kg = axle_load * 1000u;
+			uint32 max_veh_weight = 0;
+			for(  uint16 i = 0;  i < anz_vehikel;  i++  ) {
+				max_veh_weight = max( max_veh_weight, fahr[i]->get_total_weight() );
+			}
+			if(  max_veh_weight > axle_load_kg  ) {
+				sum_running_costs = sum_running_costs * max_veh_weight / axle_load_kg;
+			}
+		}
+	}
 	get_owner()->book_running_costs( sum_running_costs, get_schedule()->get_waytype());
 
 	book( sum_running_costs, CONVOI_OPERATIONS );

--- a/simtool.cc
+++ b/simtool.cc
@@ -2749,7 +2749,13 @@ const char* tool_build_way_t::get_tooltip(const player_t *) const
 	}
 	tooltip_with_price_maintenance( welt, desc->get_name(), -desc->get_price(), desc->get_maintenance() );
 	size_t n= strlen(toolstr);
-	sprintf(toolstr+n, ", %dkm/h", desc->get_topspeed() );
+	n += sprintf(toolstr+n, ", %dkm/h", desc->get_topspeed() );
+	if(  welt->get_settings().get_weight_mode() != settings_t::WEIGHT_UNLIMITED  ) {
+		const uint16 axle_load = desc->get_axle_load();
+		if(  axle_load < 9999  ) {
+			n += sprintf(toolstr+n, ", max %dt", axle_load );
+		}
+	}
 	return toolstr;
 }
 
@@ -3238,6 +3244,12 @@ const char* tool_build_bridge_t::get_tooltip(const player_t *) const
 	if(desc->get_max_length()>0) {
 		n += sprintf(toolstr+n, ", %dkm", desc->get_max_length());
 	}
+	if(  welt->get_settings().get_weight_mode() != settings_t::WEIGHT_UNLIMITED  ) {
+		const uint16 axle_load = desc->get_axle_load();
+		if(  axle_load < 9999  ) {
+			n += sprintf(toolstr+n, ", max %dt", axle_load );
+		}
+	}
 	return toolstr;
 }
 
@@ -3528,6 +3540,12 @@ const char* tool_build_tunnel_t::get_tooltip(const player_t *) const
 	size_t n= strlen(toolstr);
 	if(desc->get_waytype()!=powerline_wt) {
 		n += sprintf(toolstr+n, ", %dkm/h", desc->get_topspeed());
+	}
+	if(  welt->get_settings().get_weight_mode() != settings_t::WEIGHT_UNLIMITED  ) {
+		const uint16 axle_load = desc->get_axle_load();
+		if(  axle_load < 9999  ) {
+			n += sprintf(toolstr+n, ", max %dt", axle_load );
+		}
 	}
 	return toolstr;
 }

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -1320,6 +1320,17 @@ void vehicle_t::hop(grund_t* gr)
 		else{
 			speed_limit = kmh_to_speed( weg->get_max_speed() );
 		}
+		// apply weight-based speed reduction
+		if(  welt->get_settings().get_weight_mode() == settings_t::WEIGHT_SPEED_LIMIT  ) {
+			const uint32 axle_load = weg->get_desc()->get_axle_load();
+			if(  axle_load < 9999  ) {
+				const uint32 axle_load_kg = axle_load * 1000u;
+				const uint32 veh_weight   = get_total_weight();
+				if(  veh_weight > axle_load_kg  ) {
+					speed_limit = max( kmh_to_speed(10), (sint32)((sint64)speed_limit * axle_load_kg / veh_weight) );
+				}
+			}
+		}
 		if(  crossing_t* cr = gr->get_crossing()  ) {
 			cr->add_to_crossing(this);
 		}
@@ -2336,6 +2347,13 @@ bool road_vehicle_t::check_next_tile(const grund_t *bd, const bool need_electric
 	}
 	if(need_electric  &&  !str->is_electrified()) {
 		return false;
+	}
+	// check weight limit
+	if(  welt->get_settings().get_weight_mode() == settings_t::WEIGHT_PROHIBIT  ) {
+		const uint32 axle_load = str->get_desc()->get_axle_load();
+		if(  axle_load < 9999  &&  get_total_weight() > axle_load * 1000u  ) {
+			return false;
+		}
 	}
 	// check for signs
 	if(str->has_sign()) {
@@ -3567,6 +3585,14 @@ bool rail_vehicle_t::check_next_tile(const grund_t *bd, const bool need_electric
 	// also allow driving on foreign tracks ...
 	if(  (need_electric  &&  !sch->is_electrified())  ||  sch->get_max_speed() == 0  ) {
 		return false;
+	}
+
+	// check weight limit
+	if(  welt->get_settings().get_weight_mode() == settings_t::WEIGHT_PROHIBIT  ) {
+		const uint32 axle_load = sch->get_desc()->get_axle_load();
+		if(  axle_load < 9999  &&  get_total_weight() > axle_load * 1000u  ) {
+			return false;
+		}
 	}
 
 	if (depot_t *depot = bd->get_depot()) {


### PR DESCRIPTION
線路の重量制限を使用できるようにします
モードは4種類用意し、
- 使用しない(デフォルト)
- 線路維持費増額
- 速度制限強化
- 通行不可
を高度な設定から切り替えられます