### PR TITLE
Add convoy_x::get_cargo() API and good_x class for Squirrel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -542,6 +542,7 @@ SOURCES += script/api/api_const.cc
 SOURCES += script/api/api_control.cc
 SOURCES += script/api/api_convoy.cc
 SOURCES += script/api/api_factory.cc
+SOURCES += script/api/api_good.cc
 SOURCES += script/api/api_gui.cc
 SOURCES += script/api/api_halt.cc
 SOURCES += script/api/api_include.cc

--- a/script/api/api.h
+++ b/script/api/api.h
@@ -16,6 +16,7 @@ void export_city(HSQUIRRELVM vm);
 void export_control(HSQUIRRELVM vm);
 void export_convoy(HSQUIRRELVM vm);
 void export_factory(HSQUIRRELVM vm);
+void export_good(HSQUIRRELVM vm);
 void export_goods_desc(HSQUIRRELVM vm);
 void export_gui(HSQUIRRELVM vm, bool scenario);
 void export_halt(HSQUIRRELVM vm);

--- a/script/api/api_convoy.cc
+++ b/script/api/api_convoy.cc
@@ -15,6 +15,7 @@
 #include "../../simhalt.h"
 #include "../../simline.h"
 #include "../../simworld.h"
+#include "../../simware.h"
 #include "../../vehicle/simvehicle.h"
 #include "../../dataobj/schedule.h"
 
@@ -176,6 +177,26 @@ call_tool_init convoy_change_schedule(convoi_t *cnv, player_t *player, schedule_
 bool convoy_is_schedule_editor_open(convoi_t *cnv)
 {
 	return cnv->get_state() == convoi_t::EDIT_SCHEDULE;
+}
+
+
+SQInteger convoy_get_cargo(HSQUIRRELVM vm)
+{
+	convoi_t* cnv = param<convoi_t*>::get(vm, 1);
+	sq_newarray(vm, 0);
+	if (!cnv) {
+		return 1;
+	}
+	for (uint16 i = 0; i < cnv->get_vehicle_count(); i++) {
+		sq_newarray(vm, 0);
+		const slist_tpl<ware_t>& cargo = cnv->get_vehikel(i)->get_cargo();
+		for (const ware_t& ware : cargo) {
+			param<ware_t>::push(vm, ware);
+			sq_arrayappend(vm, -2);
+		}
+		sq_arrayappend(vm, -2);
+	}
+	return 1;
 }
 
 bool convoy_is_loading(convoi_t *cnv)
@@ -383,6 +404,13 @@ void export_convoy(HSQUIRRELVM vm)
 	 * @returns returns the number of station tiles covered by the convoy.
 	 */
 	register_method(vm, &convoi_t::get_tile_length, "get_tile_length");
+	/**
+	 * Returns cargo loaded in each vehicle of this convoy.
+	 * @returns array of arrays: outer array indexed by vehicle position,
+	 *          inner array contains good_x instances for each goods packet.
+	 * @typemask array(array(good_x))()
+	 */
+	register_function(vm, convoy_get_cargo, "get_cargo", 1, "x");
 
 #define STATIC
 	/**

--- a/script/api/api_good.cc
+++ b/script/api/api_good.cc
@@ -1,0 +1,127 @@
+/*
+ * This file is part of the Simutrans project under the Artistic License.
+ * (see LICENSE.txt)
+ */
+
+/** @file api_good.cc exports goods packet (ware_t) as good_x. */
+
+#include "api_obj_desc_base.h"
+#include "../api_class.h"
+#include "../api_function.h"
+#include "../../simware.h"
+#include "../../descriptor/goods_desc.h"
+#include "../../halthandle_t.h"
+#include "../../tpl/vector_tpl.h"
+
+using namespace script_api;
+
+
+static void* ware_t_tag = &ware_t_tag;
+
+
+void* script_api::param<ware_t*>::tag()
+{
+	return ware_t_tag;
+}
+
+
+ware_t* script_api::param<ware_t*>::get(HSQUIRRELVM vm, SQInteger index)
+{
+	return get_attached_instance<ware_t>(vm, index, param<ware_t*>::tag());
+}
+
+
+SQInteger script_api::param<ware_t*>::push(HSQUIRRELVM vm, ware_t* const& v)
+{
+	if (!v) { sq_pushnull(vm); return 1; }
+	return param<ware_t>::push(vm, *v);
+}
+
+
+void* script_api::param<ware_t>::tag()
+{
+	return ware_t_tag;
+}
+
+
+ware_t script_api::param<ware_t>::get(HSQUIRRELVM vm, SQInteger index)
+{
+	ware_t* w = get_attached_instance<ware_t>(vm, index, param<ware_t*>::tag());
+	return w ? *w : ware_t();
+}
+
+
+SQInteger script_api::param<ware_t>::push(HSQUIRRELVM vm, ware_t const& v)
+{
+	if (SQ_FAILED(push_class(vm, "good_x"))) {
+		return SQ_ERROR;
+	}
+	if (SQ_FAILED(sq_createinstance(vm, -1))) {
+		sq_pop(vm, 1);
+		return SQ_ERROR;
+	}
+	sq_remove(vm, -2);
+	attach_instance(vm, -1, new ware_t(v));
+	return 1;
+}
+
+
+static halthandle_t good_get_destination(ware_t* ware)
+{
+	return ware->get_ziel();
+}
+
+
+static const vector_tpl<halthandle_t>& good_get_transit_halts(ware_t* ware)
+{
+	return ware->get_transit_halts();
+}
+
+
+static koord good_get_destination_pos(ware_t* ware)
+{
+	return ware->get_zielpos();
+}
+
+
+static const goods_desc_t* good_get_desc(ware_t* ware)
+{
+	return ware->get_desc();
+}
+
+
+void export_good(HSQUIRRELVM vm)
+{
+	/**
+	 * Represents a goods packet being transported by a vehicle.
+	 * Obtained via @ref convoy_x::get_cargo.
+	 */
+	create_class(vm, "good_x");
+	sq_settypetag(vm, -1, param<ware_t*>::tag());
+
+	/**
+	 * Destination halt of this goods packet.
+	 * @returns halt_x or null if no destination halt
+	 */
+	register_method(vm, &good_get_destination, "get_destination", true);
+
+	/**
+	 * Transit halts for this goods packet (including the final destination halt).
+	 * @returns array of halt_x
+	 */
+	register_method(vm, &good_get_transit_halts, "get_transit_halts", true);
+
+	/**
+	 * Destination position of this goods packet (target tile coordinate).
+	 * @returns coord
+	 */
+	register_method(vm, &good_get_destination_pos, "get_destination_pos", true);
+
+	/**
+	 * Goods type descriptor of this goods packet.
+	 * @returns good_desc_x
+	 */
+	register_method(vm, &good_get_desc, "get_desc", true);
+
+	end_class(vm);
+}

--- a/script/api_param.h
+++ b/script/api_param.h
@@ -44,6 +44,7 @@ class player_t;
 class stadt_t;
 class tool_t;
 class ware_production_t;
+class ware_t;
 class weg_t;
 class strasse_t;
 class wayobj_t;
@@ -384,6 +385,8 @@ namespace script_api {
 	declare_param_mask(ware_production_t*, "t|x|y", "factory_production_x");
 	declare_specialized_param(tool_t*, "x", "command_x");
 	declare_specialized_param(way_builder_t*, "t|x|y", "way_planner_x");
+	declare_specialized_param(ware_t, "t|x|y", "good_x");
+	declare_specialized_param(ware_t*, "t|x|y", "good_x");
 
 	// export of obj_t derived classes in api/map_objects.cc
 	declare_specialized_param(obj_t*, "t|x|y", "map_object_x");

--- a/script/export_objs.cc
+++ b/script/export_objs.cc
@@ -23,6 +23,7 @@ void register_export_function(HSQUIRRELVM vm, bool scenario)
 	export_control(vm);
 	export_convoy(vm);
 	export_factory(vm);
+	export_good(vm);
 	export_goods_desc(vm);
 	export_gui(vm, scenario);
 	export_halt(vm);

--- a/tests/automated-tests/all_tests.nut
+++ b/tests/automated-tests/all_tests.nut
@@ -14,6 +14,7 @@ include("tests/test_climate")
 include("tests/test_depot")
 include("tests/test_dir")
 include("tests/test_factory")
+include("tests/test_convoy_cargo")
 include("tests/test_good")
 include("tests/test_groundobj")
 include("tests/test_halt")
@@ -93,6 +94,8 @@ all_tests <- [
 	test_factory_build_with_fields,
 	test_factory_build_climate,
 	test_factory_link,
+	test_convoy_cargo_empty,
+	test_convoy_cargo_loaded,
 	test_good_is_interchangeable,
 	test_good_speed_bonus,
 	test_groundobj_build_invalid_param,

--- a/tests/automated-tests/tests/test_convoy_cargo.nut
+++ b/tests/automated-tests/tests/test_convoy_cargo.nut
@@ -1,0 +1,108 @@
+//
+// This file is part of the Simutrans project under the Artistic License.
+// (see LICENSE.txt)
+//
+
+
+//
+// Tests for convoy_x::get_cargo() and good_x
+//
+
+function create_convoy_cargo_schedule(waytype, stop_positions)
+{
+	return schedule_x(waytype, stop_positions.map(@(pos) schedule_entry_x(pos, 0, 0)))
+}
+
+
+function test_convoy_cargo_empty()
+{
+	local pl = player_x(0)
+
+	ASSERT_EQUAL(command_x(tool_build_way).work(pl, coord3d(4, 2, 0), coord3d(4, 3, 0), "cobblestone_road"), null)
+	ASSERT_EQUAL(command_x.build_depot(pl, coord3d(4, 3, 0), building_desc_x("CarDepot")), null)
+
+	local depot = depot_x(4, 3, 0)
+	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("Buessig"))
+	local cnv = depot.get_convoy_list()[0]
+
+	local cargo = cnv.get_cargo()
+	ASSERT_EQUAL(typeof cargo, "array")
+	ASSERT_EQUAL(cargo.len(), 1)
+	ASSERT_EQUAL(typeof cargo[0], "array")
+	ASSERT_EQUAL(cargo[0].len(), 0)
+
+	// clean up
+	cnv.destroy(pl)
+	sleep()
+	ASSERT_EQUAL(command_x(tool_remover).work(player_x(0), coord3d(4, 3, 0)), null)
+	ASSERT_EQUAL(command_x(tool_remove_way).work(player_x(0), coord3d(4, 2, 0), coord3d(4, 3, 0), "" + wt_road), null)
+	RESET_ALL_PLAYER_FUNDS()
+}
+
+
+function test_convoy_cargo_loaded()
+{
+	local pl = player_x(0)
+
+	ASSERT_EQUAL(command_x(tool_build_way).work(pl, coord3d(4, 2, 0), coord3d(4, 8, 0), "cobblestone_road"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 2, 0), "BusStop"), null)
+	ASSERT_EQUAL(command_x(tool_build_station).work(pl, coord3d(4, 7, 0), "BusStop"), null)
+	ASSERT_EQUAL(command_x.build_depot(pl, coord3d(4, 8, 0), building_desc_x("CarDepot")), null)
+
+	local from_halt = halt_x.get_halt(coord3d(4, 7, 0), pl)
+	local to_halt   = halt_x.get_halt(coord3d(4, 2, 0), pl)
+	local depot = depot_x(4, 8, 0)
+
+	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("Buessig"))
+	local cnv = depot.get_convoy_list()[0]
+	cnv.change_schedule(pl, create_convoy_cargo_schedule(wt_road, [ coord3d(4, 7, 0), coord3d(4, 2, 0) ]))
+	depot.start_all_convoys(pl)
+
+	sleep()
+	sleep()
+
+	ASSERT_EQUAL(world.generate_goods(coord(3, 7), coord(3, 2), good_desc_x.passenger, 30), 1)
+
+	// wait for convoy to arrive at from_halt and pick up passengers
+	while (from_halt.convoys[0] == 0) { sleep() }
+	while (from_halt.waiting[0] > 0)  { sleep() }
+
+	// cargo is loaded: check structure without advancing simulation
+	local cargo = cnv.get_cargo()
+	ASSERT_EQUAL(typeof cargo, "array")
+	ASSERT_TRUE(cargo.len() >= 1)
+
+	local v0_cargo = cargo[0]
+	ASSERT_EQUAL(typeof v0_cargo, "array")
+	ASSERT_TRUE(v0_cargo.len() >= 1)
+
+	local good = v0_cargo[0]
+	ASSERT_TRUE(good != null)
+
+	// get_desc
+	local desc = good.get_desc()
+	ASSERT_TRUE(desc != null)
+	ASSERT_EQUAL(desc.get_name(), good_desc_x.passenger.get_name())
+
+	// get_destination: may be null (no halt destination for pax in this setup) or valid
+	local dest = good.get_destination()
+	ASSERT_TRUE(dest == null || dest.is_valid())
+
+	// get_destination_pos: always a coord
+	local dest_pos = good.get_destination_pos()
+	ASSERT_EQUAL(typeof dest_pos, "coord")
+
+	// get_transit_halts: always an array
+	local transit = good.get_transit_halts()
+	ASSERT_EQUAL(typeof transit, "array")
+
+	// clean up
+	cnv.destroy(pl)
+	sleep()
+	sleep()
+	ASSERT_EQUAL(command_x(tool_remover).work(player_x(0), coord3d(4, 2, 0)), null)
+	ASSERT_EQUAL(command_x(tool_remover).work(player_x(0), coord3d(4, 7, 0)), null)
+	ASSERT_EQUAL(command_x(tool_remover).work(player_x(0), coord3d(4, 8, 0)), null)
+	ASSERT_EQUAL(command_x(tool_remove_way).work(player_x(0), coord3d(4, 2, 0), coord3d(4, 8, 0), "" + wt_road), null)
+	RESET_ALL_PLAYER_FUNDS()
+}


### PR DESCRIPTION
## 概要

編成が積載している貨物をSquirrelスクリプトから取得できるようにするAPIを追加します。

- `ware_t` を `good_x` としてSquirrelに公開
- `convoy_x` に `get_cargo()` メソッドを追加
- 各車両の貨物リストを `[[good_x]]` 形式で返す（外側の配列が車両ごと、内側の配列が貨物パケットごと）

## good_x のメソッド

| メソッド | 戻り値 | 説明 |
|---|---|---|
| `get_destination()` | `halt_x` or `null` | 目的地停留所 |
| `get_transit_halts()` | `array[halt_x]` | 経由停留所のリスト（最終目的地を含む） |
| `get_destination_pos()` | `coord` | 目的地の座標 |
| `get_desc()` | `good_desc_x` | 貨物の種別 |

## テスト

- `test_convoy_cargo_empty`: 空の編成の `get_cargo()` が正しい構造を返すことを確認
- `test_convoy_cargo_loaded`: 乗客を積載した編成の `get_cargo()` で `good_x` の各メソッドが正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)