### PR TITLE
ADD: GitHub Actions workflow to publish Squirrel API docs to GitHub Pages

### DIFF
--- a/.github/workflows/otrp-sqapi-docs.yml
+++ b/.github/workflows/otrp-sqapi-docs.yml
@@ -1,0 +1,61 @@
+name: Generate Squirrel API Docs
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version_string:
+        description: 'Version string shown in docs header (e.g. v51_1)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: sudo apt-get -y install doxygen gawk
+
+      - name: Set version string
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "OTRP_VERSION=OTRP ${{ inputs.version_string }}" >> $GITHUB_ENV
+          else
+            echo "OTRP_VERSION=OTRP ${{ github.ref_name }}" >> $GITHUB_ENV
+          fi
+
+      - name: Generate documentation
+        run: |
+          mkdir -p doxygen/sqapi
+          cd script/api && doxygen Doxyfile_SQAPI
+
+      - name: Arrange pages structure
+        run: |
+          mkdir -p pages-root/otrp-squirrel-api
+          cp -r doxygen/sqapi/html/. pages-root/otrp-squirrel-api/
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: pages-root/
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/script/api/Doxyfile_SQAPI
+++ b/script/api/Doxyfile_SQAPI
@@ -5,6 +5,7 @@
 
 # Doxygen file to generate documentation for Squirrel API
 PROJECT_NAME           = Simutrans-Squirrel-API
+PROJECT_NUMBER         = $(OTRP_VERSION)
 OUTPUT_DIRECTORY       = ../../doxygen/sqapi
 
 EXTRACT_PRIVATE        = YES
@@ -20,11 +21,13 @@ INPUT                  = api_factory.cc \
 			 api_const.cc \
 			 api_control.cc \
 			 api_convoy.cc \
+			 api_good.cc \
 			 api_gui.cc \
 			 api_halt.cc \
 			 api_include.cc \
 			 api_line.cc \
 			 api_map_objects.cc \
+			 api_obj_desc_base.cc \
 			 api_obj_desc.cc \
 			 api_pathfinding.cc \
 			 api_player.cc \
@@ -36,7 +39,7 @@ INPUT                  = api_factory.cc \
 			 api_tiles.cc
 
 INPUT_FILTER           = ./filter_cpp.sh
-FILTER_PATTERNS        = *.nut=
+FILTER_PATTERNS        =
 
 FILTER_SOURCE_FILES    = YES
 FILTER_SOURCE_PATTERNS = ./filter_sq.sh
@@ -46,5 +49,5 @@ SOURCE_BROWSER         = YES
 ENABLE_PREPROCESSING   = YES
 PREDEFINED             = SQAPI_DOC
 
-EXAMPLE_PATH           = ../../simutrans/pak/scenario/
+EXAMPLE_PATH           =
 EXAMPLE_PATTERNS       = *.nut

--- a/script/api/api_doc.h
+++ b/script/api/api_doc.h
@@ -341,7 +341,7 @@
 /**
  * @defgroup tool_only Tool only functions
  *
- * These classes and methods are only available for scripted scenarios.
+ * These classes and methods are only available for scripted tools.
  *
  */
 

--- a/script/api/api_skeleton.cc
+++ b/script/api/api_skeleton.cc
@@ -370,7 +370,7 @@ register_function("mark_tile");
  * @param pos position to test
  * @param start first tile clicked by user
  * @ingroup tool_skel
- * @typemask void(player_x, coord3d, coord3d)
+ * @typemask integer(player_x, coord3d, coord3d)
  */
 register_function("is_valid_pos");
 


### PR DESCRIPTION
## 概要

OTRPのSquirrel APIリファレンスをDoxygenで生成し、GitHub Pagesで公開するための仕組みを整備した。
併せて、既存ドキュメントのいくつかの誤りを修正した。

## 変更内容

### GitHub Actions / Doxygen設定

- `.github/workflows/otrp-sqapi-docs.yml` を新規追加
  - `v*` タグのpush時に自動実行
  - `workflow_dispatch` による手動実行にも対応（バージョン文字列を引数で指定可能）
  - 生成したHTMLを `https://teamhimeh.github.io/simutrans/otrp-squirrel-api/` にデプロイ
- `Doxyfile_SQAPI` を修正
  - `PROJECT_NUMBER` に環境変数 `OTRP_VERSION` を使用し、ヘッダに "OTRP v51_1" 等のバージョンを表示
  - OTRPで追加した `api_good.cc`・`api_obj_desc_base.cc` を `INPUT` に追加
  - CI環境に存在しない `EXAMPLE_PATH` を空に
  - 新バージョンのDoxygenで不正となる `FILTER_PATTERNS = *.nut=` を空に修正

### ドキュメント誤り修正

- `api_doc.h`: `tool_only` グループの説明文が "scripted scenarios" となっていたのを "scripted tools" に修正
- `api_skeleton.cc`: `is_valid_pos` の `@typemask` が `void` になっていたのを `integer` に修正（実際は 0〜3 を返す）

## 事前に必要なリポジトリ設定

GitHub Pages を有効化するため、Settings → Pages → Source を **"GitHub Actions"** に変更してください。