### PR TITLE
FIX: install graphviz to fix missing class diagrams in Squirrel API docs

### DIFF
--- a/.github/workflows/otrp-sqapi-docs.yml
+++ b/.github/workflows/otrp-sqapi-docs.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install dependencies
-        run: sudo apt-get -y install doxygen gawk
+        run: sudo apt-get -y install doxygen gawk graphviz
 
       - name: Set version string
         run: |


### PR DESCRIPTION
## 概要

Squirrel APIドキュメントの継承図（Inheritance Graph）およびコラボレーション図（Collaboration Graph）が表示されない問題を修正します。

## 原因

`otrp-sqapi-docs.yml` の依存パッケージインストールに `graphviz` が含まれていなかったため、Doxygen がクラス図の生成に使用する `dot` コマンドが利用できず、PNG画像ファイルが生成されていませんでした。

## 修正内容

- `apt-get install` に `graphviz` を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)