### PR TITLE
ADD: expose get_amount, is_passenger, is_mail, is_freight on good_x

### DIFF
--- a/script/api/api_good.cc
+++ b/script/api/api_good.cc
@@ -90,6 +90,30 @@ static const goods_desc_t* good_get_desc(ware_t* ware)
 }
 
 
+static uint32 good_get_amount(ware_t* ware)
+{
+	return ware->menge;
+}
+
+
+static bool good_is_passenger(ware_t* ware)
+{
+	return ware->is_passenger();
+}
+
+
+static bool good_is_mail(ware_t* ware)
+{
+	return ware->is_mail();
+}
+
+
+static bool good_is_freight(ware_t* ware)
+{
+	return ware->is_freight();
+}
+
+
 void export_good(HSQUIRRELVM vm)
 {
 	/**
@@ -122,6 +146,30 @@ void export_good(HSQUIRRELVM vm)
 	 * @returns good_desc_x
 	 */
 	register_method(vm, &good_get_desc, "get_desc", true);
+
+	/**
+	 * Amount of goods in this packet.
+	 * @returns integer
+	 */
+	register_method(vm, &good_get_amount, "get_amount", true);
+
+	/**
+	 * Whether this goods packet carries passengers.
+	 * @returns bool
+	 */
+	register_method(vm, &good_is_passenger, "is_passenger", true);
+
+	/**
+	 * Whether this goods packet carries mail.
+	 * @returns bool
+	 */
+	register_method(vm, &good_is_mail, "is_mail", true);
+
+	/**
+	 * Whether this goods packet carries freight (neither passengers nor mail).
+	 * @returns bool
+	 */
+	register_method(vm, &good_is_freight, "is_freight", true);
 
 	end_class(vm);
 }

--- a/tests/automated-tests/tests/test_convoy_cargo.nut
+++ b/tests/automated-tests/tests/test_convoy_cargo.nut
@@ -96,6 +96,14 @@ function test_convoy_cargo_loaded()
 	local transit = good.get_transit_halts()
 	ASSERT_EQUAL(typeof transit, "array")
 
+	// get_amount: we generated 30 passengers so at least 1 was loaded
+	ASSERT_TRUE(good.get_amount() > 0)
+
+	// is_passenger / is_mail / is_freight: cargo is passengers
+	ASSERT_TRUE(good.is_passenger())
+	ASSERT_FALSE(good.is_mail())
+	ASSERT_FALSE(good.is_freight())
+
 	// clean up
 	cnv.destroy(pl)
 	sleep()


### PR DESCRIPTION
## 概要

`good_x`（Squirrel APIにおける貨物パケットクラス）に以下のメソッドを追加しました。

- `get_amount()` — 貨物パケットの数量（`ware_t::menge`）を返す
- `is_passenger()` — 旅客かどうかを返す
- `is_mail()` — 郵便かどうかを返す
- `is_freight()` — 貨物（旅客・郵便以外）かどうかを返す

各メソッドは既存の `ware_t` のメンバ・メソッドをそのままラップしています。

## テスト

`test_convoy_cargo_loaded` に以下のアサーションを追加し、旅客シナリオで動作を確認しました。

- `get_amount() > 0`
- `is_passenger() == true`
- `is_mail() == false`
- `is_freight() == false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)