### PR TITLE
FIX: fall back to first language when English is unavailable on startup

### DIFF
--- a/dataobj/translator.cc
+++ b/dataobj/translator.cc
@@ -522,8 +522,11 @@ bool translator::load(const string &path_to_pakset)
 		dr_chdir( env_t::data_dir );
 	}
 
-	// use english if available
+	// use english if available, otherwise fall back to first loaded language
 	current_langinfo = get_lang_by_iso("en");
+	if(  current_langinfo == NULL  ) {
+		current_langinfo = langs;
+	}
 
 	// it's all ok
 	return true;


### PR DESCRIPTION
## 概要

`settings.xml` が存在しない状態で起動すると、英語以外の言語のみがインストールされている環境でクラッシュする問題を修正しました。

## 原因

`translator::load()` の末尾で `current_langinfo = get_lang_by_iso("en")` を実行していましたが、英語の言語ファイルが存在しない場合は `NULL` が代入されます。

- `settings.xml` が **ある** 場合: `found_settings = true` となり、その後 `translator::set_language(env_t::language_iso)` が呼ばれて `current_langinfo` が正しく設定される
- `settings.xml` が **ない** 場合: `found_settings = false` となり、`set_language()` が呼ばれないため `current_langinfo` が `NULL` のままになる → `simmain.cc:1240` の `translator::translate("Loading paks ...")` でクラッシュ

スタックトレース:
```
translator::lang_info::translate(this=0x0000000000000000, text="Loading paks ...")
translator::translate(str="Loading paks ...") at translator.cc:604
simu_main(...) at simmain.cc:1240
```

## 修正内容

`dataobj/translator.cc` の `translator::load()` 末尾で、`get_lang_by_iso("en")` が `NULL` を返した場合に最初にロードされた言語 (`langs[0]`) へフォールバックするよう修正しました。

`settings.xml` が存在する場合は直後に `translator::set_language()` が呼ばれて上書きされるため、既存の挙動には影響しません。

## 動作確認

日本語（`ja`）のみがインストールされた環境で `settings.xml` がない状態から正常に起動することを確認しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)