### PR TITLE
FIX: clear route cache on karte_t::destroy()

### DIFF
--- a/dataobj/route_cache.h
+++ b/dataobj/route_cache.h
@@ -54,6 +54,7 @@ struct route_cache_t {
 		}
 	};
 
+private:
 	static const size_t MAX_ROUTES_PER_ENTRY = 4;
 
 	typedef std::unordered_map<key_t, entry_t, key_hash> route_map_t;
@@ -63,6 +64,7 @@ struct route_cache_t {
 	// Outer key: linehandle_t, Middle key: schedule entry index, Inner key: route key
 	line_map_t map;
 
+public:
 	route_t* find(linehandle_t line, uint8 schedule_entry, koord3d start, koord3d ziel,
 	              sint32 max_speed_kmh, uint16 convoy_length, bool need_electric);
 
@@ -75,6 +77,9 @@ struct route_cache_t {
 
 	// Erase all cache entries for a given line
 	void remove_line(linehandle_t line);
+
+	// Erase all cache entries
+	void clear() { map.clear(); }
 };
 
 #endif

--- a/simworld.cc
+++ b/simworld.cc
@@ -418,6 +418,7 @@ void karte_t::destroy()
 		dbg->fatal( "karte_t::destroy()","Map cannot be cleanly destroyed in any rotation!" );
 	}
 
+	route_cache.clear();
 	goods_in_game.clear();
 
 	DBG_MESSAGE("karte_t::destroy()", "label clear");


### PR DESCRIPTION
## 概要

ゲームを再読み込み（セーブデータのロード）した際に、ルートキャッシュ（`route_cache_t`）がクリアされていなかったバグを修正します。

`karte_t::destroy()` はゲームのアンロード時に呼ばれますが、この関数内でルートキャッシュをクリアする処理が欠けていたため、古いキャッシュエントリが残り続ける可能性がありました。

## 変更内容

- `route_cache_t` に `clear()` メソッドを追加（`map.clear()` を呼ぶだけのシンプルな実装）
- `route_cache_t` の `map` メンバを `private:` に変更（カプセル化の改善）
- `karte_t::destroy()` 内で `route_cache.clear()` を呼び出すように修正

## 確認方法

デバッグ出力により、ゲームを再読み込みした際にルートキャッシュが空になっていることを確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)