### PR TITLE
FIX: out-of-bounds access in reverse_base_offsets index in can_couple()

### DIFF
--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -4715,7 +4715,7 @@ bool rail_vehicle_t::can_couple(const route_t* route, uint16 start_index, uint16
 			cnv->set_convoi_coupling_in_progress(coupling_target);
 			coupling_index = i;
 			// if the target vehicle overlaps another tile, fix index and steps
-			c_step -= ((coupling_target_ribi&dir)==0) ? env_t::reverse_base_offsets[coupling_target_ribi][2] + VEHICLE_STEPS_PER_TILE / 2 : 0;
+			c_step -= ((coupling_target_ribi&dir)==0) ? env_t::reverse_base_offsets[ribi_t::get_dir(coupling_target_ribi)][2] + VEHICLE_STEPS_PER_TILE / 2 : 0;
 			while(c_step<0&&coupling_index>0) {
 				coupling_index--;
 				grund_t* gr_coupling = welt->lookup(route->at(coupling_index));


### PR DESCRIPTION
## 概要

`rail_vehicle_t::can_couple()` 内で `env_t::reverse_base_offsets` を誤ったインデックスでアクセスしていたバグを修正します。

## 原因

`reverse_base_offsets` は方向インデックス（`ribi_t::dir`、値 0〜3）でインデックスされる配列ですが、修正前のコードでは `coupling_target_ribi`（`ribi_t::ribi` ビットマスク、値 1/2/4/8）をそのままインデックスとして使用していました。値が 3 を超えた場合に配列境界外アクセスが発生し、ASANで検知されました。

## 修正

`ribi_t::get_dir(coupling_target_ribi)` を使って `ribi` ビットマスクを 0〜3 の方向インデックスに変換してからアクセスするよう修正しました。同ファイル内の他の `reverse_base_offsets` 使用箇所はすべて方向インデックスを使っており、この修正後のパターンと一致しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)