### PR TITLE
BUGFIX: fix client speed adjustment not working in network mode

### DIFF
--- a/simworld.cc
+++ b/simworld.cc
@@ -7357,7 +7357,7 @@ void karte_t::process_network_commands(sint32 *ms_difference)
 					// already waiting longer than how far we're ahead, so set wait time shorter to the time ahead.
 					next_step_time = (sint64)timems - frame_timediff;
 			}
-			else if(  nwcid == NWC_CHECK  ) {
+			else {
 					// gentle slowing down
 					*ms_difference = timediff;
 				}
@@ -7369,7 +7369,7 @@ void karte_t::process_network_commands(sint32 *ms_difference)
 					next_step_time = timems;
 					*ms_difference = frame_timediff;
 				}
-				else if(  nwcid == NWC_CHECK  ) {
+				else {
 					// gentle catching up
 					*ms_difference = timediff;
 				}

--- a/simworld.cc
+++ b/simworld.cc
@@ -7009,7 +7009,7 @@ void karte_t::change_time_multiplier(sint32 delta)
 		if(time_multiplier<=0) {
 			time_multiplier = 1;
 		}
-		if(step_mode!=NORMAL) {
+		if(  !env_t::networkmode  &&  step_mode!=NORMAL  ) {
 			step_mode = NORMAL;
 			reset_timer();
 		}


### PR DESCRIPTION
## 問題

ネットワークモードのクライアントがサーバーから遅れた（または進みすぎた）状態が長時間続く問題を修正します。

## 原因

`process_network_commands`（`simworld.cc`）内に2種類のバグがあります。

### バグ1: スピード調整が機能しない

`ms_difference` はゲームループをまたいで持続し、毎フレーム少しずつ消費されることでクライアントの速度を調整する変数です。しかし `process_network_commands` の冒頭で `*ms_difference = 0` に無条件リセットされます。

修正前のコードでは、クライアントが遅れている（`frame_timediff > 0`）または進みすぎている（`frame_timediff < 0`）場合のジェントルな速度調整が、`NWC_CHECK` 受信時のみ `ms_difference` を設定していました。

サーバーは毎ステップ `NWC_STEP` を、24ステップに1回だけ `NWC_CHECK` を送ります。`NWC_CHECK` で速度調整が発動しても、翌フレームの `NWC_STEP` で `ms_difference` が 0 にリセットされるため、継続的な速度調整が不可能でした。

### バグ2: ゲーム速度変更時に FIX_RATIO モードが失われる

`change_time_multiplier` がネットワークモードでも `step_mode` を `NORMAL` に変更していたため、ゲーム速度変更のたびに `FIX_RATIO` モードが失われていました。

## 修正

### バグ1

`frame_timediff > 0`（遅れている）・`frame_timediff < 0`（進みすぎている）それぞれの gentle adjustment ブランチにある `else if( nwcid == NWC_CHECK )` を `else` に変更。`NWC_STEP` 受信時も `ms_difference = timediff` を設定するようにし、毎フレーム継続的に速度調整が効くようにしました。

### バグ2

`change_time_multiplier` に `!env_t::networkmode` の条件を追加し、ネットワークモードでは `FIX_RATIO` モードを維持するようにしました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)