### PR TITLE
BUG FIX: crash when coupling target lost

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -2082,7 +2082,7 @@ void convoi_t::ziel_erreicht()
 	if(  next_coupling_index!=route_t::INVALID_INDEX  &&  next_coupling_index<=v->get_route_index()  ) {
 		const uint16 route_index = v->get_route_index();
 		// compute search depth
-		uint32 max_length_steps = max((uint32)convoi_coupling_in_progress->front()->get_desc()->get_length_in_steps(), (uint32)convoi_coupling_in_progress->back()->get_desc()->get_length_in_steps());
+		uint32 max_length_steps = convoi_coupling_in_progress.is_bound()?max((uint32)convoi_coupling_in_progress->front()->get_desc()->get_length_in_steps(), (uint32)convoi_coupling_in_progress->back()->get_desc()->get_length_in_steps()):255;
 		const uint8 depth = (uint8)(max_length_steps / vehicle_base_t::get_diagonal_vehicle_steps_per_tile()) + 1;
 		const uint8 grc_count = depth + 2;
 		const grund_t* grc[grc_count];  // depth is at most ~16 for any realistic vehicle


### PR DESCRIPTION
連結待機編成が、連結予約後連結完了までに駅を発車/除去した場合にクラッシュするバグを修正しました