### PR TITLE
save with old version

### DIFF
--- a/documentation/ja.OTRP.tab
+++ b/documentation/ja.OTRP.tab
@@ -663,6 +663,8 @@ Electrified
 Convoi has been sent\nto the selected depot\nof appropriate type.\n
 編成は指定された\n車庫に向かいました.\n
 #------その他の翻訳------
+v%d (current version)
+v%d (現在のバージョン)
 Freight ton-kilo
 輸送量(人キロ/トンキロ)
 Rotate Building

--- a/gui/loadsave_frame.cc
+++ b/gui/loadsave_frame.cc
@@ -96,17 +96,23 @@ bool loadsave_frame_t::item_action(const char *filename)
 			// and now we need to copy the servergame to the map ...
 #endif
 		}
+		static char otrp_ver_str[32];
+		const bool use_old_otrp_ver = (otrp_version_input.get_value() < OTRP_VERSION_MAJOR);
 		if(  save_as_standard.pressed  ) {
 			// save as standard data
 			#define STD_SAVEGAME_VER_NR "0." QUOTEME(SIM_VERSION_MAJOR) "." QUOTEME(SIM_SAVE_MINOR)
 			env_t::savegame_version_str = STD_SAVEGAME_VER_NR;
+		}
+		else if(  use_old_otrp_ver  ) {
+			sprintf( otrp_ver_str, "0." QUOTEME(SIM_VERSION_MAJOR) "." QUOTEME(SIM_SAVE_MINOR) ".%d", otrp_version_input.get_value() );
+			env_t::savegame_version_str = otrp_ver_str;
 		}
 		long start_save = dr_time();
 		welt->save( filename, loadsave_t::save_mode, env_t::savegame_version_str, false );
 		DBG_MESSAGE( "loadsave_frame_t::item_action", "save world %li ms", dr_time() - start_save );
 		welt->set_dirty();
 		welt->reset_timer();
-		if(  save_as_standard.pressed  ) {
+		if(  save_as_standard.pressed  ||  use_old_otrp_ver  ) {
 			// restore savegame_version_str
 			env_t::savegame_version_str = SAVEGAME_VER_NR;
 		}
@@ -140,6 +146,15 @@ loadsave_frame_t::loadsave_frame_t(bool do_load) : savegame_frame_t(".sve",false
 	else {
 		save_as_standard.init( button_t::square_automatic, "Readable by standard.");
 		bottom_left_frame.add_component(&save_as_standard);
+		{
+			gui_aligned_container_t *row = bottom_left_frame.add_table(2, 1);
+			row->add_component(&otrp_version_label);
+			otrp_version_label.buf().append(translator::translate("Save as OTRP version:"));
+			otrp_version_label.update();
+			otrp_version_input.init(OTRP_VERSION_MAJOR, 54, OTRP_VERSION_MAJOR, 1, false, 3, true);
+			row->add_component(&otrp_version_input);
+			bottom_left_frame.end_table();
+		}
 		env_t::previous_OTRP_data = false;
 		set_filename(welt->get_settings().get_filename());
 		set_name(translator::translate("Speichern"));

--- a/gui/loadsave_frame.cc
+++ b/gui/loadsave_frame.cc
@@ -100,6 +100,7 @@ bool loadsave_frame_t::item_action(const char *filename)
 		const int sel = save_version_combo.get_selection();
 		const int last_idx = (int)save_ver_labels.size() - 1;
 		const bool version_overridden = (sel != 0);
+		const char *const original_version_str = env_t::savegame_version_str;
 		if(  sel == last_idx  ) {
 			// "Readable by standard."
 			#define STD_SAVEGAME_VER_NR "0." QUOTEME(SIM_VERSION_MAJOR) "." QUOTEME(SIM_SAVE_MINOR)
@@ -116,8 +117,7 @@ bool loadsave_frame_t::item_action(const char *filename)
 		welt->set_dirty();
 		welt->reset_timer();
 		if(  version_overridden  ) {
-			// restore savegame_version_str
-			env_t::savegame_version_str = SAVEGAME_VER_NR;
+			env_t::savegame_version_str = original_version_str;
 		}
 	}
 
@@ -148,14 +148,14 @@ loadsave_frame_t::loadsave_frame_t(bool do_load) : savegame_frame_t(".sve",false
 	}
 	else {
 		// Build combo labels: index 0 = current, 1..N-1 = older OTRP versions descending, N = standard
-		char buf[32];
-		sprintf( buf, "current version (v%d)", OTRP_VERSION_MAJOR );
+		char buf[64];
+		sprintf( buf, translator::translate("current version (v%d)"), OTRP_VERSION_MAJOR );
 		save_ver_labels.push_back( buf );
 		for(  int v = OTRP_VERSION_MAJOR - 1;  v >= 54;  v--  ) {
 			sprintf( buf, "v%d", v );
 			save_ver_labels.push_back( buf );
 		}
-		save_ver_labels.push_back( "Readable by standard." );
+		save_ver_labels.push_back( translator::translate("Readable by standard.") );
 
 		save_version_combo.set_unsorted();
 		for(  const std::string &s : save_ver_labels  ) {

--- a/gui/loadsave_frame.cc
+++ b/gui/loadsave_frame.cc
@@ -97,14 +97,17 @@ bool loadsave_frame_t::item_action(const char *filename)
 #endif
 		}
 		static char otrp_ver_str[32];
-		const bool use_old_otrp_ver = (otrp_version_input.get_value() < OTRP_VERSION_MAJOR);
-		if(  save_as_standard.pressed  ) {
-			// save as standard data
+		const int sel = save_version_combo.get_selection();
+		const int last_idx = (int)save_ver_labels.size() - 1;
+		const bool version_overridden = (sel != 0);
+		if(  sel == last_idx  ) {
+			// "Readable by standard."
 			#define STD_SAVEGAME_VER_NR "0." QUOTEME(SIM_VERSION_MAJOR) "." QUOTEME(SIM_SAVE_MINOR)
 			env_t::savegame_version_str = STD_SAVEGAME_VER_NR;
 		}
-		else if(  use_old_otrp_ver  ) {
-			sprintf( otrp_ver_str, "0." QUOTEME(SIM_VERSION_MAJOR) "." QUOTEME(SIM_SAVE_MINOR) ".%d", otrp_version_input.get_value() );
+		else if(  sel > 0  ) {
+			// older OTRP version: index 1 => v(OTRP_VERSION_MAJOR-1), index 2 => v(OTRP_VERSION_MAJOR-2), ...
+			sprintf( otrp_ver_str, "0." QUOTEME(SIM_VERSION_MAJOR) "." QUOTEME(SIM_SAVE_MINOR) ".%d", OTRP_VERSION_MAJOR - sel );
 			env_t::savegame_version_str = otrp_ver_str;
 		}
 		long start_save = dr_time();
@@ -112,7 +115,7 @@ bool loadsave_frame_t::item_action(const char *filename)
 		DBG_MESSAGE( "loadsave_frame_t::item_action", "save world %li ms", dr_time() - start_save );
 		welt->set_dirty();
 		welt->reset_timer();
-		if(  save_as_standard.pressed  ||  use_old_otrp_ver  ) {
+		if(  version_overridden  ) {
 			// restore savegame_version_str
 			env_t::savegame_version_str = SAVEGAME_VER_NR;
 		}
@@ -144,17 +147,23 @@ loadsave_frame_t::loadsave_frame_t(bool do_load) : savegame_frame_t(".sve",false
 		bottom_left_frame.add_component(&show_unused_addons);
 	}
 	else {
-		save_as_standard.init( button_t::square_automatic, "Readable by standard.");
-		bottom_left_frame.add_component(&save_as_standard);
-		{
-			gui_aligned_container_t *row = bottom_left_frame.add_table(2, 1);
-			row->add_component(&otrp_version_label);
-			otrp_version_label.buf().append(translator::translate("Save as OTRP version:"));
-			otrp_version_label.update();
-			otrp_version_input.init(OTRP_VERSION_MAJOR, 54, OTRP_VERSION_MAJOR, 1, false, 3, true);
-			row->add_component(&otrp_version_input);
-			bottom_left_frame.end_table();
+		// Build combo labels: index 0 = current, 1..N-1 = older OTRP versions descending, N = standard
+		char buf[32];
+		sprintf( buf, "current version (v%d)", OTRP_VERSION_MAJOR );
+		save_ver_labels.push_back( buf );
+		for(  int v = OTRP_VERSION_MAJOR - 1;  v >= 54;  v--  ) {
+			sprintf( buf, "v%d", v );
+			save_ver_labels.push_back( buf );
 		}
+		save_ver_labels.push_back( "Readable by standard." );
+
+		save_version_combo.set_unsorted();
+		for(  const std::string &s : save_ver_labels  ) {
+			save_version_combo.new_component<gui_scrolled_list_t::const_text_scrollitem_t>( s.c_str(), SYSCOL_TEXT );
+		}
+		save_version_combo.set_selection( 0 );
+		bottom_left_frame.add_component( &save_version_combo );
+
 		env_t::previous_OTRP_data = false;
 		set_filename(welt->get_settings().get_filename());
 		set_name(translator::translate("Speichern"));

--- a/gui/loadsave_frame.cc
+++ b/gui/loadsave_frame.cc
@@ -149,10 +149,10 @@ loadsave_frame_t::loadsave_frame_t(bool do_load) : savegame_frame_t(".sve",false
 	else {
 		// Build combo labels: index 0 = current, 1..N-1 = older OTRP versions descending, N = standard
 		char buf[64];
-		sprintf( buf, translator::translate("current version (v%d)"), OTRP_VERSION_MAJOR );
+		snprintf( buf, sizeof(buf), translator::translate("v%d (current version)"), OTRP_VERSION_MAJOR );
 		save_ver_labels.push_back( buf );
 		for(  int v = OTRP_VERSION_MAJOR - 1;  v >= 54;  v--  ) {
-			sprintf( buf, "v%d", v );
+			snprintf( buf, sizeof(buf), "v%d", v );
 			save_ver_labels.push_back( buf );
 		}
 		save_ver_labels.push_back( translator::translate("Readable by standard.") );

--- a/gui/loadsave_frame.h
+++ b/gui/loadsave_frame.h
@@ -10,9 +10,10 @@
 #include <time.h>
 
 #include "savegame_frame.h"
-#include "components/gui_numberinput.h"
+#include "components/gui_combobox.h"
 #include "../tpl/stringhashtable_tpl.h"
 #include <string>
+#include <vector>
 
 class loadsave_t;
 
@@ -35,10 +36,9 @@ private:
 
 	button_t easy_server; // only active on loading savegames
 	button_t previous_OTRP; // only active on loading savegames
-	button_t save_as_standard; // only active on saving savegames
 	button_t show_unused_addons; // show unused pak descriptors in current map
-	gui_label_buf_t otrp_version_label; // only active on saving savegames
-	gui_numberinput_t otrp_version_input; // only active on saving savegames
+	gui_combobox_t save_version_combo; // only active on saving savegames
+	std::vector<std::string> save_ver_labels; // backing storage for combo entry strings
 
 	static stringhashtable_tpl<sve_info_t *> cached_info;
 

--- a/gui/loadsave_frame.h
+++ b/gui/loadsave_frame.h
@@ -10,6 +10,7 @@
 #include <time.h>
 
 #include "savegame_frame.h"
+#include "components/gui_numberinput.h"
 #include "../tpl/stringhashtable_tpl.h"
 #include <string>
 
@@ -36,6 +37,8 @@ private:
 	button_t previous_OTRP; // only active on loading savegames
 	button_t save_as_standard; // only active on saving savegames
 	button_t show_unused_addons; // show unused pak descriptors in current map
+	gui_label_buf_t otrp_version_label; // only active on saving savegames
+	gui_numberinput_t otrp_version_input; // only active on saving savegames
 
 	static stringhashtable_tpl<sve_info_t *> cached_info;
 


### PR DESCRIPTION
古いバージョンで保存できるようにします。ここでは、ひとまずv54までさかのぼれるようにしました
注意点：今後本家統合等を行った際にできるだけ`get_OTRP_version()==0,get_OTRP_version()>0`の分岐を作らない（マージしたバージョンによってセーブデータの長さが変わり得るため）