### PR TITLE
Fix: minimap navigate zoom jump

### DIFF
--- a/siminteraction.cc
+++ b/siminteraction.cc
@@ -264,13 +264,7 @@ void interaction_t::interactive_event( const event_t &ev )
 }
 
 void interaction_t::zoom_view(const event_t &ev, const bool isOut) {
-	// Compute the tile under the mouse directly from screen coordinates instead of
-	// using the zeiger, which may be stale after minimap navigation.
-	// The zeiger is only updated by move_cursor() on EVENT_MOVE/DRAG/RELEASE events,
-	// not on the EVENT_CLICK (mouse wheel) event that triggers zoom_view.
-	// If the viewport was moved via minimap click without subsequent mouse movement,
-	// the zeiger would still hold the old pre-navigation position, causing a wild
-	// viewport jump when zooming.
+	// use mouse screen pos directly: zeiger may be stale after minimap navigation
 	tool_t *tool = world->get_tool(world->get_active_player_nr());
 	const koord3d cursor_pos = viewport->get_new_cursor_position(
 		scr_coord(ev.mx, ev.my), tool->is_grid_tool());

--- a/siminteraction.cc
+++ b/siminteraction.cc
@@ -264,10 +264,19 @@ void interaction_t::interactive_event( const event_t &ev )
 }
 
 void interaction_t::zoom_view(const event_t &ev, const bool isOut) {
-	const koord3d cursor_pos = world->get_zeiger()->get_pos();
-	// old screen position of centered tile
+	// Compute the tile under the mouse directly from screen coordinates instead of
+	// using the zeiger, which may be stale after minimap navigation.
+	// The zeiger is only updated by move_cursor() on EVENT_MOVE/DRAG/RELEASE events,
+	// not on the EVENT_CLICK (mouse wheel) event that triggers zoom_view.
+	// If the viewport was moved via minimap click without subsequent mouse movement,
+	// the zeiger would still hold the old pre-navigation position, causing a wild
+	// viewport jump when zooming.
+	tool_t *tool = world->get_tool(world->get_active_player_nr());
+	const koord3d cursor_pos = viewport->get_new_cursor_position(
+		scr_coord(ev.mx, ev.my), tool->is_grid_tool());
+	// old screen position of tile under mouse
 	const scr_coord s = viewport->get_screen_coord(cursor_pos, koord(0,0));
-	
+
 	if(  !win_change_zoom_factor(isOut)  ) {
 		// zoom failed.
 		return;

--- a/siminteraction.cc
+++ b/siminteraction.cc
@@ -266,8 +266,7 @@ void interaction_t::interactive_event( const event_t &ev )
 void interaction_t::zoom_view(const event_t &ev, const bool isOut) {
 	// use mouse screen pos directly: zeiger may be stale after minimap navigation
 	tool_t *tool = world->get_tool(world->get_active_player_nr());
-	const koord3d cursor_pos = viewport->get_new_cursor_position(
-		scr_coord(ev.mx, ev.my), tool->is_grid_tool());
+	const koord3d cursor_pos = viewport->get_new_cursor_position(scr_coord(ev.mx,ev.my), tool->is_grid_tool());
 	// old screen position of tile under mouse
 	const scr_coord s = viewport->get_screen_coord(cursor_pos, koord(0,0));
 


### PR DESCRIPTION
## 概要

ミニマップをクリックして移動した直後にズームすると、ビューポートが意図しない場所に飛ぶバグを修正。

## 原因

`zoom_view()` は「ズーム前後でマウス下のタイルが同じ画面位置に見えるようにビューポートを調整する」処理で、基準タイルの取得に `world->get_zeiger()->get_pos()` を使っていた。

zeiger はマウス移動（`EVENT_MOVE`）時に `move_cursor()` で更新されるが、ズームのトリガーであるマウスホイール（`EVENT_CLICK`）では更新されない。そのため、ミニマップクリック後にメインマップ上でマウスを動かさずにホイールを回すと、zeiger がナビゲーション前の古い位置を指したままになる。

この状態で zeiger の画面座標を計算すると、現在のビューポートから数百タイル離れた完全に画面外の値になる。`change_world_position()` はその座標を基準に計算するため、ビューポートが全く関係ない場所へ飛ぶ。

## 修正

`zoom_view()` 内で `world->get_zeiger()->get_pos()` の代わりに `viewport->get_new_cursor_position(ev.mx, ev.my)` を使い、マウスの現在の画面座標から直接タイルを求めるよう変更した。

通常時（ミニマップ操作なし）は zeiger と同じ結果になるため、既存の動作に変化はない。