### PR TITLE
fix: Replace Stop tool fails when scheduled tile is not the clicked tile on multi-tile platforms

### DIFF
--- a/simtool.cc
+++ b/simtool.cc
@@ -7369,7 +7369,7 @@ const char *tool_stop_mover_t::do_work( player_t *player, const koord3d &last_po
 					grund_t *gr = welt->lookup(start_pos);
 					while(true) {
 						gr->get_neighbour(gr, wt, dir);
-						if(  !gr  ||  !gr->is_halt()  ||  !gr->get_weg(wt)  || (ribi=gr->get_weg_ribi_unmasked(wt))==0  ||  gr->get_pos()==last_pos  ) {
+						if(  !gr  ||  !gr->is_halt()  ||  gr->get_halt()!=last_halt  ||  !gr->get_weg(wt)  || (ribi=gr->get_weg_ribi_unmasked(wt))==0  ||  gr->get_pos()==last_pos  ) {
 							// maybe reach last tile
 							break;
 						}
@@ -7389,7 +7389,7 @@ const char *tool_stop_mover_t::do_work( player_t *player, const koord3d &last_po
 					while(true) {
 						old_platform.append(start_pos);
 						gr->get_neighbour(gr, wt, dir);
-						if(!gr  ||  !gr->is_halt()  ||  !gr->get_weg(wt)  || (ribi=gr->get_weg_ribi_unmasked(wt))==0  ||  gr->get_pos()==end_pos  ) {
+						if(!gr  ||  !gr->is_halt()  ||  gr->get_halt()!=last_halt  ||  !gr->get_weg(wt)  || (ribi=gr->get_weg_ribi_unmasked(wt))==0  ||  gr->get_pos()==end_pos  ) {
 							// maybe reach last tile
 							break;
 						}

--- a/simtool.cc
+++ b/simtool.cc
@@ -7375,7 +7375,8 @@ const char *tool_stop_mover_t::do_work( player_t *player, const koord3d &last_po
 						}
 						const ribi_t::ribi new_dir = ribi & ~(ribi_t::backward(dir));
 						if( new_dir==0 ) {
-							// maybe reach last tile
+							// reached the far end of platform
+							start_pos = gr->get_pos();
 							break;
 						}
 						dir = new_dir;
@@ -7394,7 +7395,8 @@ const char *tool_stop_mover_t::do_work( player_t *player, const koord3d &last_po
 						}
 						const ribi_t::ribi new_dir = ribi & ~(ribi_t::backward(dir));
 						if( new_dir==0 ) {
-							// maybe reach last tile
+							// reached the near end of platform
+							old_platform.append(gr->get_pos());
 							break;
 						}
 						dir = new_dir;


### PR DESCRIPTION
## 概要

「Replace Stop（スケジュール移動）」ツール (`tool_stop_mover_t`) において、
2タイル以上のプラットフォームで移動が反映されないことがある問題、および隣接する別停車場に走査が侵入する問題を修正します。

## 原因

`do_work` 内のプラットフォーム走査アルゴリズムは、クリックされたタイルを起点に
プラットフォームの全タイルを `old_platform` に収集し、スケジュールエントリと照合します。

走査ループに以下のバグがありました。

**第1ループ（プラットフォームの遠端を探す）**

```cpp
if( new_dir==0 ) {
    // maybe reach last tile
    break;  // ← 遠端タイルを start_pos に保存せずに break していた
}
```

**第2ループ（タイルを収集する）**

```cpp
if( new_dir==0 ) {
    // maybe reach last tile
    break;  // ← 近端タイルを old_platform に追加せずに break していた
}
```

`new_dir == 0` はそのタイルが道路の終端（デッドエンド）であることを意味します。
この break はプラットフォームの両端タイルに対して発生するため、
**端タイルが常に `old_platform` から抜け落ちる**という結果になっていました。

### 2タイルプラットフォームの例

`[A(西端), B(東端)]` で、スケジュール登録タイル=B、クリック位置=A の場合：

| | 修正前 | 修正後 |
|---|---|---|
| `old_platform` | `{A}` | `{B, A}` |
| `is_contained(B)` | `false` → 移動しない | `true` → 移動する |

### 3タイルプラットフォームの例

`[A(西端), B(中央), C(東端)]` で、スケジュール登録タイル=A、クリック位置=A の場合：

| | 修正前 | 修正後 |
|---|---|---|
| `old_platform` | `{B}` | `{C, B, A}` |
| `is_contained(A)` | `false` → 移動しない | `true` → 移動する |

3タイル以上では、クリックしたタイルが端タイルである場合、
クリック位置とスケジュール登録タイルが一致していても失敗します。

## 修正内容

### ① プラットフォーム端タイルの欠落修正

- 第1ループ: `new_dir==0` 時に `start_pos = gr->get_pos()` を追加（遠端を保存）
- 第2ループ: `new_dir==0` 時に `old_platform.append(gr->get_pos())` を追加（近端を収集）

### ② 隣接する別停車場への走査漏れ防止

隣接する別々の停車場が同一道路上につながっている場合、走査が隣の停車場のタイルに
侵入して `old_platform` に混入する可能性があったため、両ループの break 条件に
`gr->get_halt() != last_halt` を追加しました。

## 影響範囲

- 対象: 道路・鉄道・路面電車など `catch_all_halt == false` の全 waytype
- 対象外: 水路（船舶）・空路（航空機）は `catch_all_halt == true` のため別コードパスを使用しており影響なし
- Ctrl キー押下時は単一タイル処理（`old_platform.append(last_pos)`）のため影響なし

Discord https://discord.com/channels/973792214696202271/1508505300595114014