### PR TITLE
add: copy convoy as template format to system clipboard on Ctrl+copy [CONVOI_TEMPLATE]

### DIFF
--- a/gui/depot_frame.cc
+++ b/gui/depot_frame.cc
@@ -11,6 +11,8 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "../sys/simsys.h"
+
 #include "../simunits.h"
 #include "../simworld.h"
 #include "../vehicle/simvehicle.h"
@@ -2306,6 +2308,15 @@ bool depot_frame_t::action_triggered( gui_action_creator_t *comp, value_t p)
 					if(  event_get_last_control_shift() == 2  ) {
 						// ctrl pressed -> copy to clipboard
 						welt->set_copy_convoi(cnv);
+					} else if(  event_get_last_control_shift() == 1  ) {
+						// shift pressed -> copy vehicle list as convoy template format to clipboard
+						cbuffer_t buf;
+						for(  uint16 i = 0;  i < cnv->get_vehicle_count();  i++  ) {
+							buf.printf("vehicle[%u]=%s\n", i, cnv->get_vehikel(i)->get_desc()->get_name());
+						}
+						if(  buf.len() > 0  ) {
+							dr_copy(buf, buf.len());
+						}
 					} else {
 						depot->call_depot_tool('c', cnv, NULL);
 					}

--- a/gui/depot_frame.cc
+++ b/gui/depot_frame.cc
@@ -2306,10 +2306,9 @@ bool depot_frame_t::action_triggered( gui_action_creator_t *comp, value_t p)
 			if(  cnv.is_bound()  ) {
 				if(  !welt->use_timeline()  ||  welt->get_settings().get_allow_buying_obsolete_vehicles()  ||  depot->check_obsolete_inventory( cnv )  ) {
 					if(  event_get_last_control_shift() == 2  ) {
-						// ctrl pressed -> copy to clipboard
+						// ctrl pressed -> copy convoy to game clipboard, and also copy vehicle list
+						// as convoy template format to system clipboard
 						welt->set_copy_convoi(cnv);
-					} else if(  event_get_last_control_shift() == 1  ) {
-						// shift pressed -> copy vehicle list as convoy template format to clipboard
 						cbuffer_t buf;
 						for(  uint16 i = 0;  i < cnv->get_vehicle_count();  i++  ) {
 							buf.printf("vehicle[%u]=%s\n", i, cnv->get_vehikel(i)->get_desc()->get_name());


### PR DESCRIPTION
## 概要

Ctrl を押しながら「編成をコピー」を押したとき、ゲーム内クリップボードへのコピーに加えて、編成の車両リストを convoy template 書式でOSのシステムクリップボードにもコピーします。

## 変更内容（`gui/depot_frame.cc`）

Ctrl+「編成をコピー」の動作を拡張します。

**変更前：** ゲーム内クリップボードへの編成コピーのみ

**変更後：** ゲーム内クリップボードへのコピーに加え、以下の書式でシステムクリップボードにもコピーする

vehicle[0]=<vehicle_name>
vehicle[1]=<vehicle_name>
...

このテキストはそのまま convoy template ファイル（`.tab`）に貼り付けて利用できます。

## 依存PR

- #531 convoy template tab の depot window への統合