### PR TITLE
BUG FIX: bmp files reading in Windows

### DIFF
--- a/io/raw_image_bmp.cc
+++ b/io/raw_image_bmp.cc
@@ -84,6 +84,11 @@ bool raw_image_t::read_bmp(const char *filename)
 
 	bitmap_file_header_t bmp_header;
 
+	if (!file) {
+		dbg->warning("raw_image_t::read_bmp", "Cannot open bmp file '%s'", filename);
+		return false;
+	}
+
 	if (fread(&bmp_header, sizeof(bitmap_file_header_t), 1, file) != 1) {
 		dbg->warning("raw_image_t::read_bmp", "Malformed bmp file");
 		fclose(file);
@@ -395,7 +400,7 @@ bool raw_image_t::write_bmp(const char *filename) const
 	fheader.file_size            = endian(uint32(headers_size + gap1_size + image_data_size));
 
 	// now actually write the data
-	FILE *f = fopen(filename, "wb");
+	FILE *f = dr_fopen(filename, "wb");
 
 	if (!f) {
 		return false;

--- a/io/raw_image_png.cc
+++ b/io/raw_image_png.cc
@@ -14,6 +14,7 @@
 
 #include "../simmem.h"
 #include "../simdebug.h"
+#include "../sys/simsys.h"
 
 
 static std::string filename_;
@@ -167,7 +168,7 @@ bool raw_image_t::read_png(const char *fname)
 	// remember the file name for better error messages.
 	filename_ = fname;
 
-	FILE* file = fopen(fname, "rb");
+	FILE* file = dr_fopen(fname, "rb");
 
 	if (file) {
 		const bool ok = read_png_data(file);
@@ -188,7 +189,7 @@ bool raw_image_t::write_png(const char *file_name) const
 
 	png_structp png_ptr = NULL;
 	png_infop info_ptr = NULL;
-	FILE *fp = fopen(file_name, "wb");
+	FILE *fp = dr_fopen(file_name, "wb");
 	if (!fp) {
 		return false;
 	}

--- a/simworld.cc
+++ b/simworld.cc
@@ -1847,8 +1847,11 @@ void karte_t::enlarge_map(settings_t const* sets, sint8 const* const h_field)
 	dbg->message("karte_t::enlarge_map()","heightfield name is %s",settings.heightfield.c_str());
 	if(  !settings.heightfield.empty()  ) {
 		// init from file
-		for(  sint16 y = 0;  y<=new_size_y;  y++  ) {
-			for(  sint16 x = (y>old_y) ? 0 : old_x+1;  x<=new_size_x;  x++  ) {
+		// h_field has new_size_x * new_size_y pixels; the grid has one extra row and column.
+		// The rightmost column is mirrored by the per-row copy below; the bottom row is
+		// mirrored by the memcpy below — so the inner loops must stay within h_field bounds.
+		for(  sint16 y = 0;  y<new_size_y;  y++  ) {
+			for(  sint16 x = (y>old_y) ? 0 : old_x+1;  x<new_size_x;  x++  ) {
 				grid_hgts[x + y*(cached_grid_size.x+1)] = h_field[x+(y*(sint32)cached_grid_size.x)]+1;
 			}
 			grid_hgts[cached_grid_size.x + y*(cached_grid_size.x+1)] = grid_hgts[cached_grid_size.x-1 + y*(cached_grid_size.x+1)];


### PR DESCRIPTION
windowsでbmpファイルをマップの生成・拡張用にロードできない不具合を修正します