### PR TITLE
add: copy convoy template in convoy_detail window

### DIFF
--- a/documentation/ja.OTRP.tab
+++ b/documentation/ja.OTRP.tab
@@ -418,8 +418,8 @@ Full Get on/off Time
 Always use maximum boarding and alighting time, regardless of boardings and alightings.
 乗降数に関わらず、常に最大乗降時間を使用します
 #------運行中編成のコピー------
-Copy this convoi
-この編成をコピーします
+Copy this convoi (ctrl pressed: copy vehicle list as template format to clipboard)
+この編成をコピーします（ctrlキーを押すと編成をテンプレート書式でクリップボードにコピーします）
 Paste Convoi
 編成を貼り付け
 Paste the copied convoi

--- a/gui/convoi_detail_t.cc
+++ b/gui/convoi_detail_t.cc
@@ -243,7 +243,7 @@ void convoi_detail_t::init(convoihandle_t cnv)
 			new_component<gui_fill_t>();
 
 			copy_convoi_button.init(button_t::roundbox| button_t::flexible, "Copy Convoi");
-			copy_convoi_button.set_tooltip("Copy this convoi (ctrl pressed: copy vehicle list as template format to clipboard)");
+			copy_convoi_button.set_tooltip(translator::translate("Copy this convoi (ctrl pressed: copy vehicle list as template format to clipboard)"));
 			copy_convoi_button.add_listener(this);
 			add_component(&copy_convoi_button);
 		}

--- a/gui/convoi_detail_t.cc
+++ b/gui/convoi_detail_t.cc
@@ -22,6 +22,8 @@
 #include "../dataobj/loadsave.h"
 #include "../dataobj/environment.h"
 
+#include "../sys/simsys.h"
+
 #include "../player/simplay.h"
 
 #include "../utils/simstring.h"
@@ -241,7 +243,7 @@ void convoi_detail_t::init(convoihandle_t cnv)
 			new_component<gui_fill_t>();
 
 			copy_convoi_button.init(button_t::roundbox| button_t::flexible, "Copy Convoi");
-			copy_convoi_button.set_tooltip("Copy this convoi");
+			copy_convoi_button.set_tooltip("Copy this convoi (ctrl: copy vehicle list as template format to clipboard)");
 			copy_convoi_button.add_listener(this);
 			add_component(&copy_convoi_button);
 		}
@@ -430,7 +432,19 @@ bool convoi_detail_t::action_triggered(gui_action_creator_t *comp,value_t /* */)
 			return true;
 		}
 		else if(comp==&copy_convoi_button) {
-			welt->set_copy_convoi(cnv);
+			if(  event_get_last_control_shift() == 2  ) {
+				// Ctrl+click: copy vehicle list as convoy template format to system clipboard
+				welt->set_copy_convoi(cnv);
+				cbuffer_t buf;
+				for(  uint16 i = 0;  i < cnv->get_vehicle_count();  i++  ) {
+					buf.printf("vehicle[%u]=%s\n", i, cnv->get_vehikel(i)->get_desc()->get_name());
+				}
+				if(  buf.len() > 0  ) {
+					dr_copy(buf, buf.len());
+				}
+			} else {
+				welt->set_copy_convoi(cnv);
+			}
 			return true;
 		}
 		else if(comp==&trade_convoi_button) {

--- a/gui/convoi_detail_t.cc
+++ b/gui/convoi_detail_t.cc
@@ -243,7 +243,7 @@ void convoi_detail_t::init(convoihandle_t cnv)
 			new_component<gui_fill_t>();
 
 			copy_convoi_button.init(button_t::roundbox| button_t::flexible, "Copy Convoi");
-			copy_convoi_button.set_tooltip("Copy this convoi (ctrl: copy vehicle list as template format to clipboard)");
+			copy_convoi_button.set_tooltip("Copy this convoi (ctrl pressed: copy vehicle list as template format to clipboard)");
 			copy_convoi_button.add_listener(this);
 			add_component(&copy_convoi_button);
 		}


### PR DESCRIPTION
編成詳細ウィンドウの「編成をコピー」を、ctrlを押しながら押下すると、template書式でクリップボードにコピーされます。
ja.OTRP.tabも併せて修正しています。