### PR TITLE
fix: convoy templates not refreshed across game loads or after adding

### DIFF
--- a/gui/depot_frame.cc
+++ b/gui/depot_frame.cc
@@ -596,10 +596,8 @@ DBG_DEBUG("depot_frame_t::depot_frame_t()","get_max_convoi_length()=%i",depot->g
 	tram_waggons.set_player_nr(depot->get_owner_nr());
 	tram_waggons.add_listener(this);
 
-	// Convoy template tab setup
-	if (welt->get_convoy_templates().empty()) {
-		welt->load_convoy_templates();
-	}
+	// Convoy template tab setup: always reload to pick up any new .tab files
+	welt->load_convoy_templates();
 	template_panel = new gui_template_panel_t();
 	template_panel->init(welt->get_convoy_templates(), (sint8)depot->get_owner_nr(), depot);
 	template_panel->add_listener(this);

--- a/simworld.cc
+++ b/simworld.cc
@@ -521,6 +521,8 @@ void karte_t::destroy()
 
 assert( depot_t::get_depot_list().empty() );
 
+	convoy_templates.clear();
+
 	DBG_MESSAGE("karte_t::destroy()", "world destroyed");
 	destroying = false;
 }


### PR DESCRIPTION
## 概要

convoy_template 機能に関する2つのバグを修正します。

---

## 修正内容

### バグ1: 別のゲームを開いてもテンプレートが残り続ける

テンプレートあり → テンプレートなし（`convoy_template/` フォルダが存在しない）の順にゲームをロードすると、
前のゲームのテンプレートがデポウィンドウに表示され続けていた。

**原因**: `karte_t::destroy()` で `convoy_templates` がクリアされていなかったため、
ゲームをまたいでもデータが残り続けていた。

**修正**: `karte_t::destroy()` の末尾に `convoy_templates.clear()` を追加。

---

### バグ2: 起動後にテンプレートファイルを追加しても反映されない

テンプレートなしで起動した後、`convoy_template/` フォルダを作成してテンプレートを追加・再ロードすると読み込まれる。
しかしその後さらにファイルを追加しても反映されなかった。

**原因**: デポコンストラクタで `if (welt->get_convoy_templates().empty())` のガードにより、
一度テンプレートを読み込んだ後は `load_convoy_templates()` が呼ばれなくなっていた。

**修正**: ガードを除去し、デポウィンドウを開くたびに常に `load_convoy_templates()` を呼ぶよう変更。
`.tab` ファイルのスキャンは軽量であるため、パフォーマンスへの影響は無視できると考えられる。

---

## 変更ファイル

- `simworld.cc` — `karte_t::destroy()` に `convoy_templates.clear()` を追加
- `gui/depot_frame.cc` — `if (empty())` ガードを除去し常に再読み込み.