### PR TITLE
FIX: speed drops to 25 km/h at priority signals when longblock signal reserved far ahead

### DIFF
--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -4149,8 +4149,11 @@ bool rail_vehicle_t::is_priority_signal_clear(signal_t *sig, uint16 next_block, 
 		if(  next_signal == route_t::INVALID_INDEX  ||  cnv->get_route()->at(next_signal) == cnv->get_route()->back()  ||  is_signal_clear( next_signal, restart_speed, call_by_step )  ) {
 			// ok, end of route => we can go
 			sig->set_state( roadsign_t::STATE_GREEN );
-			cnv->set_next_stop_index( min( next_signal, next_crossing ) );
-
+			// do not shorten next_stop_index set by recursive call (e.g. longblock signal)
+			// unless a crossing requires stopping before the next signal
+			if(  next_crossing <= next_signal  ||  cnv->get_next_stop_index() <= next_signal + 1  ) {
+				cnv->set_next_stop_index( min( next_signal, next_crossing ) );
+			}
 			return true;
 		}
 


### PR DESCRIPTION
## 不具合の内容

priority signal（3現示信号）と long block signal を組み合わせた配置で、longblock が経路先まで一気に予約した場合に、列車がpriority signalを通過するたびに速度が25km/hまで低下する不具合を修正しました。

## 原因

`is_priority_signal_clear()` はcascadeで再帰的に次の信号を確認します。

例えば以下のような配置の場合：

Priority A → Priority B → LongBlock C → end



ステップ処理でcascadeが成功すると：

1. `check_longblock_signal` が `next_stop_index` を経路終端（end）にセット
2. **B のhandlerが `set_next_stop_index(C の位置)` で上書き**
3. **A のhandlerが `set_next_stop_index(B の位置)` でさらに上書き**

結果として列車がBを通過した瞬間、`tiles_left = 1` となり25km/hのブレーキ処理が発動します。Cを通過する際にも同様のことが起きるため、priority signalを通過するたびに25km/hへの速度低下が繰り返されていました。

## 修正内容

`vehicle/simvehicle.cc` の `is_priority_signal_clear()` 内（line 4152）

再帰呼び出し（`is_signal_clear`）が `next_stop_index` をより遠くにセットしていた場合、それを縮めないよう条件を追加しました。

```cpp
// do not shorten next_stop_index set by recursive call (e.g. longblock signal)
// unless a crossing requires stopping before the next signal
if(  next_crossing <= next_signal  ||  cnv->get_next_stop_index() <= next_signal + 1  ) {
    cnv->set_next_stop_index( min( next_signal, next_crossing ) );
}