### PR TITLE
fix: stop_before_check incorrectly turns ON when loading old saves

### DIFF
--- a/obj/roadsign.cc
+++ b/obj/roadsign.cc
@@ -52,6 +52,7 @@ roadsign_t::roadsign_t(loadsave_t *file) : obj_t ()
 {
 	image = foreground_image = IMG_EMPTY;
 	preview = false;
+	choose_sign_flag = 0; // must initialize before rdwr(): old save formats use bitwise-OR on this field
 	rdwr(file);
 	if(desc) {
 		/* if more than one state, we will switch direction and phase for traffic lights
@@ -712,6 +713,10 @@ void roadsign_t::rdwr(loadsave_t *file)
 		file->rdwr_byte(flag8);
 		if(  file->is_loading()  ) {
 			choose_sign_flag = flag8;
+			if(  file->get_OTRP_version()<=52  ) {
+				// stop_before_check was added in v53
+				set_stop_before_check(false);
+			}
 		}
 	}
 	else if(file->get_OTRP_version()>=22) {

--- a/obj/roadsign.cc
+++ b/obj/roadsign.cc
@@ -52,6 +52,7 @@ roadsign_t::roadsign_t(loadsave_t *file) : obj_t ()
 {
 	image = foreground_image = IMG_EMPTY;
 	preview = false;
+	choose_sign_flag = 0; // must initialize before rdwr(): old save formats use bitwise-OR on this field
 	rdwr(file);
 	if(desc) {
 		/* if more than one state, we will switch direction and phase for traffic lights
@@ -711,7 +712,15 @@ void roadsign_t::rdwr(loadsave_t *file)
 		uint8 flag8 = (uint8)choose_sign_flag;
 		file->rdwr_byte(flag8);
 		if(  file->is_loading()  ) {
-			choose_sign_flag = flag8;
+			if(  file->get_OTRP_version()<=52  ) {
+				// v46-52: bit5 was skip_default_route; stop_before_check added mid-v52 shifted it to bit6
+				choose_sign_flag = flag8 & 0x1F;
+				if(  flag8 & (1<<5)  ) { choose_sign_flag |= skip_default_route; }
+				if(  flag8 & (1<<7)  ) { choose_sign_flag |= start_signal; }
+			}
+			else {
+				choose_sign_flag = flag8;
+			}
 		}
 	}
 	else if(file->get_OTRP_version()>=22) {


### PR DESCRIPTION
## 問題

古いセーブデータを開いたとき、信号の `stop_before_check` オプションが意図せず ON になることがある。

## 原因

2つの経路でビット5（`stop_before_check`）にゴミ値が入り込む。

**① ロードコンストラクタでの未初期化（v22–45 形式）**

`roadsign_t(loadsave_t*)` コンストラクタが `choose_sign_flag` を初期化せずに `rdwr()` を呼んでいた。
OTRP v22–45 形式のロードパスは `choose_sign_flag` に対してビット OR で各フラグを書き込む実装のため、
ヒープ上のゴミ値にビット5が立っていた場合、そのまま残ってしまっていた。

**② v52 以前のセーブに stop_before_check が存在しない（v46–52 形式）**

`stop_before_check` は v53 で実装された。
しかし v46–52 形式のセーブを読み込む際に、ファイル上のビット5を `stop_before_check` として解釈していたため、
無関係なデータが入っていた場合に ON になっていた。

## 修正

- ロードコンストラクタで `choose_sign_flag = 0` に初期化する
- v46–52 形式のセーブをロードした後、`set_stop_before_check(false)` で明示的にクリアする