### PR TITLE
BUG FIX: speed drops to 25 km/h when passing the signal right after a longblock signal

### DIFF
--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -3775,7 +3775,15 @@ bool rail_vehicle_t::check_longblock_signal(signal_t *sig, uint16 next_block, si
 	if(  next_signal != route_t::INVALID_INDEX  ) {
 		// success, and there is a signal before end of route => finished
 		sig->set_state( roadsign_t::STATE_GREEN );
-		cnv->set_next_stop_index( min( next_crossing, next_signal ) );
+		// cascade through the next signal (same logic as is_priority_signal_clear)
+		if(  cnv->get_route()->at(next_signal) != cnv->get_route()->back()  ) {
+			sint32 dummy = restart_speed;
+			is_signal_clear( next_signal, dummy, true );
+		}
+		// do not shorten next_stop_index set by cascaded signal
+		if(  next_crossing <= next_signal  ||  cnv->get_next_stop_index() <= next_signal + 1  ) {
+			cnv->set_next_stop_index( min( next_crossing, next_signal ) );
+		}
 		return true;
 	}
 


### PR DESCRIPTION
## 不具合の内容

longblock signal の直後にある信号（priority signal 等）を通過するたびに、速度が 25 km/h まで低下する不具合を修正しました。

## 原因

`check_longblock_signal()` は、現在ルート上に信号が見つかった場合（line 3778）、その信号位置に `next_stop_index` をセットして即リターンしていました。

... → LongBlock C → Priority D → Priority E → end



のような配置で、C の `check_longblock_signal` が D を発見すると `next_stop_index = D` をセットして処理を終了します。その後、列車が D に差し掛かったときに D の sync_step チェックが走り、D のさらに先に longblock がある場合はステップ要求を出して失敗します。

列車はすでに `next_stop_index > route_index` の条件を満たしているため D を通過できますが、D+1 に入った瞬間に `next_stop_index == route_index` となり `tiles_left = 1` → **25 km/h** が発動します。

その後ステップが走って `next_stop_index` が更新されることで速度は回復しますが、ステップ実行前（sync_step が先に走るため）に必ず 1 フレーム以上 25 km/h が発生していました。

## 修正内容

`vehicle/simvehicle.cc` の `check_longblock_signal()` 内（line 3778 周辺）

`is_priority_signal_clear()` に適用したものと同じロジックを追加しました。次の信号が見つかった場合、その信号に対して `is_signal_clear()` を `call_by_step=true` で呼び出して cascade を展開します。cascade によって `next_stop_index` がより遠くにセットされた場合はそれを維持し、上書きしません。

```cpp
// cascade through the next signal (same logic as is_priority_signal_clear)
if(  cnv->get_route()->at(next_signal) != cnv->get_route()->back()  ) {
    sint32 dummy = restart_speed;
    is_signal_clear( next_signal, dummy, true );
}
// do not shorten next_stop_index set by cascaded signal
if(  next_crossing <= next_signal  ||  cnv->get_next_stop_index() <= next_signal + 1  ) {
    cnv->set_next_stop_index( min( next_crossing, next_signal ) );
}

