### PR TITLE
BUG FIX: clear reserved_tiles when release reservation

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -309,7 +309,7 @@ void convoi_t::unreserve_route()
  */
 void convoi_t::reserve_route()
 {
-	if(  reserved_tiles.get_count()>0  &&  anz_vehikel>0  ) {
+	if(  !is_coupled()  &&  reserved_tiles.get_count()>0  &&  anz_vehikel>0  ) {
 		// reservation is controlled by reserved_tiles
 		for(  uint32 idx = 0;  idx < reserved_tiles.get_count();  idx++  ) {
 			if(  grund_t *gr = welt->lookup( reserved_tiles[idx] )  ) {

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -309,7 +309,7 @@ void convoi_t::unreserve_route()
  */
 void convoi_t::reserve_route()
 {
-	if(  !is_coupled()  &&  reserved_tiles.get_count()>0  &&  anz_vehikel>0  ) {
+	if(  reserved_tiles.get_count()>0  &&  anz_vehikel>0  ) {
 		// reservation is controlled by reserved_tiles
 		for(  uint32 idx = 0;  idx < reserved_tiles.get_count();  idx++  ) {
 			if(  grund_t *gr = welt->lookup( reserved_tiles[idx] )  ) {

--- a/simtool.cc
+++ b/simtool.cc
@@ -1825,9 +1825,12 @@ const char *tool_clear_reservation_t::work( player_t *, koord3d pos )
 				cnv->set_next_reservation_index( cnv->front()->get_route_index() );
 				// next_coupling_index: clear so no stale coupling target remains.
 				cnv->set_next_coupling( route_t::INVALID_INDEX, 0 );
-				// next_stop_index: reset to just ahead of the front vehicle so the next
-				// can_enter_tile call triggers a fresh block reservation.
-				cnv->set_next_stop_index( cnv->front()->get_route_index() );
+				// coupling_in_progress: clear both sides so the partner convoy is not left
+				// waiting indefinitely for a coupling that will never complete.
+				cnv->unset_convoi_coupling_in_progress();
+				// next_stop_index: auto-detect from route end so the convoy can drive
+				// normally until re-routing via ROUTING_1 sets everything fresh.
+				cnv->set_next_stop_index( route_t::INVALID_INDEX );
 			}
 			else if(  s  ) {
 				s->unreserve_all();

--- a/simtool.cc
+++ b/simtool.cc
@@ -1818,6 +1818,16 @@ const char *tool_clear_reservation_t::work( player_t *, koord3d pos )
 						}
 					}
 				}
+				// Reset convoy reservation state after all schiene tiles have been freed.
+				// clear_reserved_tiles() releases any off-route tiles and wipes the vector.
+				cnv->clear_reserved_tiles();
+				// next_reservation_index: restart from the front vehicle's current position.
+				cnv->set_next_reservation_index( cnv->front()->get_route_index() );
+				// next_coupling_index: clear so no stale coupling target remains.
+				cnv->set_next_coupling( route_t::INVALID_INDEX, 0 );
+				// next_stop_index: reset to just ahead of the front vehicle so the next
+				// can_enter_tile call triggers a fresh block reservation.
+				cnv->set_next_stop_index( cnv->front()->get_route_index() );
 			}
 			else if(  s  ) {
 				s->unreserve_all();


### PR DESCRIPTION
`b`を押して予約解除した場合に、`reserved_tiles`を強制的にリリースします