### PR TITLE
BUG FIX: longblock signal reservation only treated by front vehicle

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -2916,22 +2916,30 @@ void convoi_t::vorfahren()
 void convoi_t::clear_reserved_tile_if_not_matching_route()
 {
 	if(  get_reserved_tiles().get_count()==0 || route.get_count()==0  ) {
-		// this convoy does not have reserved_tile
 		return;
 	}
-    // NEW: if reserved_tiles doesn't cover the full new route, clear and switch to next_reservation_index
-    if( get_reserved_tiles().get_count() < route.get_count() ) {
-        clear_reserved_tiles();
-        return;
-    }
-	// check the new route to the next stop is match as reserved_tiles
-	for( uint16 i=1; i<min(get_route()->get_count(),get_reserved_tiles().get_count()); i++ ) {
-		if( route.at(i) != reserved_tiles[i]  ) {
+	dbg->message("convoi_t::clear_reserved_tile_if_not_matching_route()","reserved tile from %i,%i,%i, route from %i,%i,%i, count: %i vs %i",
+		reserved_tiles[0].x, reserved_tiles[0].y, (int)reserved_tiles[0].z,
+		route.at(0).x, route.at(0).y, (int)route.at(0).z,
+		reserved_tiles.get_count(), route.get_count());
+	// reserved_tiles[i] corresponds to route[i+1]:
+	// route[0] (the departure stop) is never added to reserved_tiles by block_reserver
+	// because it starts from next_block+1 and target_rt from index 1, both skipping route[0].
+	// So reserved_tiles must cover route[1..end], i.e. at least route.get_count()-1 entries.
+	if( get_reserved_tiles().get_count() < route.get_count() - 1 ) {
+		clear_reserved_tiles();
+		return;
+	}
+	// check reserved_tiles[i] == route[i+1]
+	for( uint16 i=0; i<min(get_route()->get_count()-1, get_reserved_tiles().get_count()); i++ ) {
+		if( route.at(i+1) != get_reserved_tiles()[i]  ) {
+			dbg->warning("convoi_t::clear_reserved_tile_if_not_matching_route()","invalid reserved_tile found: %i,%i,%i vs %i,%i,%i",
+				reserved_tiles[i].x, reserved_tiles[i].y, (int)reserved_tiles[i].z,
+				route.at(i+1).x, route.at(i+1).y, (int)route.at(i+1).z);
 			clear_reserved_tiles();
 			return;
 		}
 	}
-	return;
 }
 
 
@@ -5891,6 +5899,7 @@ void convoi_t::set_next_cross_lane(bool n) {
 
 
 void convoi_t::clear_reserved_tiles(){
+	dbg->message("convoi_t::clear_reserved_tiles()","%s clear its reserved tiles",get_name());
 	if(  reserved_tiles.get_count()==0  ) {
 		// nothing to do.
 		return;

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -5893,7 +5893,7 @@ void convoi_t::clear_reserved_tiles(){
 	for(  sint32 i=route.get_count()-1;  i>=0;  i--  ) {
 		if(  reserved_tiles.is_contained(route.at(i))  ) {
 			// set next_reservation_index
-			set_next_reservation_index(i);
+			set_next_reservation_index(i+1);
 			break;
 		}
 	}

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -1641,6 +1641,7 @@ void convoi_t::step()
 			break;
 
 		case NO_ROUTE:
+			clear_reserved_tiles();
 			unset_convoi_coupling_in_progress();
 			// stuck vehicles
 			if (schedule->empty()) {
@@ -2918,6 +2919,11 @@ void convoi_t::clear_reserved_tile_if_not_matching_route()
 		// this convoy does not have reserved_tile
 		return;
 	}
+    // NEW: if reserved_tiles doesn't cover the full new route, clear and switch to next_reservation_index
+    if( get_reserved_tiles().get_count() < route.get_count() ) {
+        clear_reserved_tiles();
+        return;
+    }
 	// check the new route to the next stop is match as reserved_tiles
 	for( uint16 i=1; i<min(get_route()->get_count(),get_reserved_tiles().get_count()); i++ ) {
 		if( route.at(i) != reserved_tiles[i]  ) {

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -309,12 +309,21 @@ void convoi_t::unreserve_route()
  */
 void convoi_t::reserve_route()
 {
-	if(  reserved_tiles.get_count()>0  &&  anz_vehikel>0  ) {
+	if(  !is_coupled()  &&  reserved_tiles.get_count()>0  &&  anz_vehikel>0  ) {
 		// reservation is controlled by reserved_tiles
 		for(  uint32 idx = 0;  idx < reserved_tiles.get_count();  idx++  ) {
 			if(  grund_t *gr = welt->lookup( reserved_tiles[idx] )  ) {
 				if(  schiene_t *sch = obj_cast<schiene_t>(gr->get_weg( front()->get_waytype() ))  ) {
 					sch->reserve( self, ribi_type( reserved_tiles[max(1u,idx)-1u], reserved_tiles[min(reserved_tiles.get_count()-1u,idx+1u)] ) );
+				}
+			}
+		}
+		// only front vehicle treats reserved_tiles, other convoy-on tiles should be reserved now! 
+		for(  int idx = max(1u, back()->get_route_index()) - 1;  idx < front()->get_route_index()-1  &&  idx < (int)route.get_count();  idx++  ) {
+			if(  grund_t *gr = welt->lookup( route.at(idx) )  ) {
+				if(  schiene_t *sch = obj_cast<schiene_t>(gr->get_weg( front()->get_waytype() ))  ) {
+					unreserve_pos(route.at(idx));
+					sch->reserve( self, ribi_type( route.at(max(1u,idx)-1u), route.at(min(route.get_count()-1u,idx+1u)) ) );
 				}
 			}
 		}

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -319,7 +319,7 @@ void convoi_t::reserve_route()
 			}
 		}
 		// only front vehicle treats reserved_tiles, other convoy-on tiles should be reserved now! 
-		for(  int idx = max(1u, back()->get_route_index()) - 1;  idx < front()->get_route_index()-1  &&  idx < (int)route.get_count();  idx++  ) {
+		for(  int idx = max(1u, find_most_child_convoi()->back()->get_route_index()) - 1;  idx < front()->get_route_index()-1  &&  idx < (int)route.get_count();  idx++  ) {
 			if(  grund_t *gr = welt->lookup( route.at(idx) )  ) {
 				if(  schiene_t *sch = obj_cast<schiene_t>(gr->get_weg( front()->get_waytype() ))  ) {
 					unreserve_pos(route.at(idx));
@@ -332,7 +332,7 @@ void convoi_t::reserve_route()
 		// reservation is controlled by next_reservation_index.
 		// Start one step back so the rear car's current tile is also reserved with
 		// the correct ribi direction (individual loading only uses ribi_t::none).
-		for(  int idx = max(1u, back()->get_route_index()) - 1;  idx < next_reservation_index  &&  idx < (int)route.get_count();  idx++  ) {
+		for(  int idx = max(1u, find_most_child_convoi()->back()->get_route_index()) - 1;  idx < next_reservation_index  &&  idx < (int)route.get_count();  idx++  ) {
 			if(  grund_t *gr = welt->lookup( route.at(idx) )  ) {
 				if(  schiene_t *sch = obj_cast<schiene_t>(gr->get_weg( front()->get_waytype() ))  ) {
 					sch->reserve( self, ribi_type( route.at(max(1u,idx)-1u), route.at(min(route.get_count()-1u,idx+1u)) ) );

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -323,6 +323,7 @@ private:
 	 * This holds coordinates reserved by this convoy.
 	 * Used when reservation is triggered by longblocksignal.
 	 * @author THLeaderH
+	 * from v55_5, we add/remove tiles by front vehicle!
 	 */
 	vector_tpl<koord3d> reserved_tiles;
 

--- a/tests/automated-tests/all_tests.nut
+++ b/tests/automated-tests/all_tests.nut
@@ -27,6 +27,7 @@ include("tests/test_scenario")
 include("tests/test_sign")
 include("tests/test_start_signal")
 include("tests/test_stop_before_check_signal")
+include("tests/test_longblock_signal")
 include("tests/test_slope")
 include("tests/test_terraform")
 include("tests/test_transport")
@@ -232,6 +233,15 @@ all_tests <- [
 	test_stop_before_check_longblock_signal_convoy_stops,
 	test_stop_before_check_choose_signal_convoy_stops,
 	test_stop_before_check_false_convoy_does_not_stop,
+	test_longblock_open_no_prefix_signal,
+	test_longblock_blocked_no_prefix_signal,
+	test_longblock_open_pre_signal,
+	test_longblock_blocked_pre_signal,
+	test_longblock_open_priority_signal,
+	test_longblock_blocked_priority_signal,
+	test_longblock_blocked_priority_priority_long,
+	test_longblock_blocked_priority_pre_long,
+	test_longblock_blocked_pre_priority_long,
 	test_trees_plant_single_invalid_param,
 	test_way_tunnel_build_straight,
 	test_schedule_entry_maximum_load,

--- a/tests/automated-tests/all_tests.nut
+++ b/tests/automated-tests/all_tests.nut
@@ -28,6 +28,7 @@ include("tests/test_sign")
 include("tests/test_start_signal")
 include("tests/test_stop_before_check_signal")
 include("tests/test_longblock_signal")
+include("tests/test_sigcheck")
 include("tests/test_slope")
 include("tests/test_terraform")
 include("tests/test_transport")
@@ -239,6 +240,7 @@ all_tests <- [
 	test_longblock_blocked_pre_signal,
 	test_longblock_open_priority_signal,
 	test_longblock_blocked_priority_signal,
+	test_sigcheck,
 	test_trees_plant_single_invalid_param,
 	test_way_tunnel_build_straight,
 	test_schedule_entry_maximum_load,

--- a/tests/automated-tests/all_tests.nut
+++ b/tests/automated-tests/all_tests.nut
@@ -240,6 +240,7 @@ all_tests <- [
 	test_longblock_blocked_pre_signal,
 	test_longblock_open_priority_signal,
 	test_longblock_blocked_priority_signal,
+	test_longblock_blocked_priority_priority_long,
 	test_longblock_blocked_priority_pre_long,
 	test_longblock_blocked_pre_priority_long,
 	test_sigcheck,
@@ -270,10 +271,6 @@ all_tests <- [
 
 // Tests that are currently failing
 failing_tests <- [
-	// TC7: priority→priority→longblock chain doesn't stop at L because the
-	// first priority sees the second as "clear" and overwrites next_stop_index
-	// past the longblock.  Requires a C++ fix in is_priority_signal_clear.
-	test_longblock_blocked_priority_priority_long,
 	test_building_city_multitile_replaces_existing,
 	test_city_change_size_to_minimum,
 	test_depot_build_invalid_pos,

--- a/tests/automated-tests/all_tests.nut
+++ b/tests/automated-tests/all_tests.nut
@@ -27,8 +27,6 @@ include("tests/test_scenario")
 include("tests/test_sign")
 include("tests/test_start_signal")
 include("tests/test_stop_before_check_signal")
-include("tests/test_longblock_signal")
-include("tests/test_sigcheck")
 include("tests/test_slope")
 include("tests/test_terraform")
 include("tests/test_transport")
@@ -234,16 +232,6 @@ all_tests <- [
 	test_stop_before_check_longblock_signal_convoy_stops,
 	test_stop_before_check_choose_signal_convoy_stops,
 	test_stop_before_check_false_convoy_does_not_stop,
-	test_longblock_open_no_prefix_signal,
-	test_longblock_blocked_no_prefix_signal,
-	test_longblock_open_pre_signal,
-	test_longblock_blocked_pre_signal,
-	test_longblock_open_priority_signal,
-	test_longblock_blocked_priority_signal,
-	test_longblock_blocked_priority_priority_long,
-	test_longblock_blocked_priority_pre_long,
-	test_longblock_blocked_pre_priority_long,
-	test_sigcheck,
 	test_trees_plant_single_invalid_param,
 	test_way_tunnel_build_straight,
 	test_schedule_entry_maximum_load,

--- a/tests/automated-tests/all_tests.nut
+++ b/tests/automated-tests/all_tests.nut
@@ -240,6 +240,8 @@ all_tests <- [
 	test_longblock_blocked_pre_signal,
 	test_longblock_open_priority_signal,
 	test_longblock_blocked_priority_signal,
+	test_longblock_blocked_priority_pre_long,
+	test_longblock_blocked_pre_priority_long,
 	test_sigcheck,
 	test_trees_plant_single_invalid_param,
 	test_way_tunnel_build_straight,
@@ -268,6 +270,10 @@ all_tests <- [
 
 // Tests that are currently failing
 failing_tests <- [
+	// TC7: priority→priority→longblock chain doesn't stop at L because the
+	// first priority sees the second as "clear" and overwrites next_stop_index
+	// past the longblock.  Requires a C++ fix in is_priority_signal_clear.
+	test_longblock_blocked_priority_priority_long,
 	test_building_city_multitile_replaces_existing,
 	test_city_change_size_to_minimum,
 	test_depot_build_invalid_pos,

--- a/tests/automated-tests/all_tests.nut
+++ b/tests/automated-tests/all_tests.nut
@@ -27,6 +27,7 @@ include("tests/test_scenario")
 include("tests/test_sign")
 include("tests/test_start_signal")
 include("tests/test_stop_before_check_signal")
+include("tests/test_longblock_signal")
 include("tests/test_slope")
 include("tests/test_terraform")
 include("tests/test_transport")
@@ -232,6 +233,12 @@ all_tests <- [
 	test_stop_before_check_longblock_signal_convoy_stops,
 	test_stop_before_check_choose_signal_convoy_stops,
 	test_stop_before_check_false_convoy_does_not_stop,
+	test_longblock_open_no_prefix_signal,
+	test_longblock_blocked_no_prefix_signal,
+	test_longblock_open_pre_signal,
+	test_longblock_blocked_pre_signal,
+	test_longblock_open_priority_signal,
+	test_longblock_blocked_priority_signal,
 	test_trees_plant_single_invalid_param,
 	test_way_tunnel_build_straight,
 	test_schedule_entry_maximum_load,

--- a/tests/automated-tests/tests/test_longblock_signal.nut
+++ b/tests/automated-tests/tests/test_longblock_signal.nut
@@ -456,3 +456,203 @@ function test_longblock_blocked_priority_signal()
 	ASSERT_TRUE(stopped_at_L)
 	ASSERT_TRUE(reached_H3)
 }
+
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Helper: remove signal at y=3 (TC7-9 place a second signal there)
+// ──────────────────────────────────────────────────────────────────────────────
+function _lb_remove_y3_signal(pl)
+{
+	local sig = tile_x(10, 3, 0).find_object(mo_signal)
+	if (sig != null) {
+		command_x(tool_remover).work(pl, coord3d(10, 3, 0))
+	}
+}
+
+
+// ──────────────────────────────────────────────────────────────────────────────
+// TC7 – priority(y=2)→priority(y=3)→longblock(y=4), blocker at H2
+// Both priority signals cascade "can still go" and let the convoy through to L.
+// At L the longblock section cannot be reserved because H2 is occupied.
+// Convoy stops AT L (y=4). After removing the blocker convoy reaches H3.
+// ──────────────────────────────────────────────────────────────────────────────
+function test_longblock_blocked_priority_priority_long()
+{
+	local pl   = player_x(0)
+	local rail = way_desc_x.get_available_ways(wt_rail, st_flat)[0]
+	ASSERT_TRUE(rail != null)
+
+	local pri_desc = sign_desc_x.get_available_signs(wt_rail).filter(
+	                     @(idx, s) s.is_priority_signal())[0]
+	ASSERT_TRUE(pri_desc != null)
+
+	local sigs = _lb_build_infra(pl, rail)
+	ASSERT_EQUAL(command_x.build_sign_at(pl, coord3d(10, 2, 0), pri_desc), null)
+	ASSERT_EQUAL(command_x.build_sign_at(pl, coord3d(10, 3, 0), pri_desc), null)
+	ASSERT_TRUE(tile_x(10, 2, 0).find_object(mo_signal) != null)
+	ASSERT_TRUE(tile_x(10, 3, 0).find_object(mo_signal) != null)
+
+	debug.set_game_speed(5)
+
+	local blocker = _lb_start_blocker(pl)
+	local cnv     = _lb_start_main(pl)
+
+	local stopped_at_L = false
+	for (local i = 0; i < 6000; i++) {
+		sleep()
+		if (!cnv.is_valid()) break
+		local y = cnv.get_pos().y
+		if (y == 4 && (cnv.is_waiting() || cnv.get_speed() <= 0)) {
+			stopped_at_L = true
+			break
+		}
+		if (y > 4) break
+	}
+
+	local reached_H3 = false
+	if (stopped_at_L) {
+		_lb_destroy(pl, blocker)
+		reached_H3 = _lb_wait_until_y(cnv, 12, 8000)
+	}
+
+	print("  stopped_at_L: " + stopped_at_L)
+	print("  reached_H3:   " + reached_H3)
+
+	debug.set_game_speed(1)
+	_lb_destroy(pl, blocker)
+	_lb_destroy(pl, cnv)
+	_lb_remove_y3_signal(pl)
+	_lb_remove_infra(pl)
+	RESET_ALL_PLAYER_FUNDS()
+
+	ASSERT_TRUE(stopped_at_L)
+	ASSERT_TRUE(reached_H3)
+}
+
+
+// ──────────────────────────────────────────────────────────────────────────────
+// TC8 – priority(y=2)→pre-signal(y=3)→longblock(y=4), blocker at H2
+// Priority at y=2 "can still go" (cascades to the pre which is YELLOW because
+// L is blocked), advancing the convoy to the pre-signal at y=3.
+// The pre-signal blocks because L cannot reserve through H2.
+// Convoy stops AT the pre-signal (y=3). After removing the blocker reaches H3.
+// ──────────────────────────────────────────────────────────────────────────────
+function test_longblock_blocked_priority_pre_long()
+{
+	local pl   = player_x(0)
+	local rail = way_desc_x.get_available_ways(wt_rail, st_flat)[0]
+	ASSERT_TRUE(rail != null)
+
+	local pri_desc = sign_desc_x.get_available_signs(wt_rail).filter(
+	                     @(idx, s) s.is_priority_signal())[0]
+	local pre_desc = sign_desc_x.get_available_signs(wt_rail).filter(
+	                     @(idx, s) s.is_pre_signal())[0]
+	ASSERT_TRUE(pri_desc != null)
+	ASSERT_TRUE(pre_desc != null)
+
+	local sigs = _lb_build_infra(pl, rail)
+	ASSERT_EQUAL(command_x.build_sign_at(pl, coord3d(10, 2, 0), pri_desc), null)
+	ASSERT_EQUAL(command_x.build_sign_at(pl, coord3d(10, 3, 0), pre_desc), null)
+	ASSERT_TRUE(tile_x(10, 2, 0).find_object(mo_signal) != null)
+	ASSERT_TRUE(tile_x(10, 3, 0).find_object(mo_signal) != null)
+
+	debug.set_game_speed(5)
+
+	local blocker = _lb_start_blocker(pl)
+	local cnv     = _lb_start_main(pl)
+
+	local stopped_at_pre = false
+	for (local i = 0; i < 6000; i++) {
+		sleep()
+		if (!cnv.is_valid()) break
+		local y = cnv.get_pos().y
+		if (y == 3 && (cnv.is_waiting() || cnv.get_speed() <= 0)) {
+			stopped_at_pre = true
+			break
+		}
+		if (y > 3) break
+	}
+
+	local reached_H3 = false
+	if (stopped_at_pre) {
+		_lb_destroy(pl, blocker)
+		reached_H3 = _lb_wait_until_y(cnv, 12, 8000)
+	}
+
+	print("  stopped_at_pre: " + stopped_at_pre)
+	print("  reached_H3:     " + reached_H3)
+
+	debug.set_game_speed(1)
+	_lb_destroy(pl, blocker)
+	_lb_destroy(pl, cnv)
+	_lb_remove_y3_signal(pl)
+	_lb_remove_infra(pl)
+	RESET_ALL_PLAYER_FUNDS()
+
+	ASSERT_TRUE(stopped_at_pre)
+	ASSERT_TRUE(reached_H3)
+}
+
+
+// ──────────────────────────────────────────────────────────────────────────────
+// TC9 – pre-signal(y=2)→priority(y=3)→longblock(y=4), blocker at H2
+// Pre-signal evaluates priority which evaluates L.  L is blocked, but priority
+// "can still go" so the pre-signal sees GREEN from priority and shows GREEN.
+// The convoy proceeds through both y=2 and y=3 and stops AT L (y=4).
+// After removing the blocker convoy reaches H3.
+// ──────────────────────────────────────────────────────────────────────────────
+function test_longblock_blocked_pre_priority_long()
+{
+	local pl   = player_x(0)
+	local rail = way_desc_x.get_available_ways(wt_rail, st_flat)[0]
+	ASSERT_TRUE(rail != null)
+
+	local pre_desc = sign_desc_x.get_available_signs(wt_rail).filter(
+	                     @(idx, s) s.is_pre_signal())[0]
+	local pri_desc = sign_desc_x.get_available_signs(wt_rail).filter(
+	                     @(idx, s) s.is_priority_signal())[0]
+	ASSERT_TRUE(pre_desc != null)
+	ASSERT_TRUE(pri_desc != null)
+
+	local sigs = _lb_build_infra(pl, rail)
+	ASSERT_EQUAL(command_x.build_sign_at(pl, coord3d(10, 2, 0), pre_desc), null)
+	ASSERT_EQUAL(command_x.build_sign_at(pl, coord3d(10, 3, 0), pri_desc), null)
+	ASSERT_TRUE(tile_x(10, 2, 0).find_object(mo_signal) != null)
+	ASSERT_TRUE(tile_x(10, 3, 0).find_object(mo_signal) != null)
+
+	debug.set_game_speed(5)
+
+	local blocker = _lb_start_blocker(pl)
+	local cnv     = _lb_start_main(pl)
+
+	local stopped_at_L = false
+	for (local i = 0; i < 6000; i++) {
+		sleep()
+		if (!cnv.is_valid()) break
+		local y = cnv.get_pos().y
+		if (y == 4 && (cnv.is_waiting() || cnv.get_speed() <= 0)) {
+			stopped_at_L = true
+			break
+		}
+		if (y > 4) break
+	}
+
+	local reached_H3 = false
+	if (stopped_at_L) {
+		_lb_destroy(pl, blocker)
+		reached_H3 = _lb_wait_until_y(cnv, 12, 8000)
+	}
+
+	print("  stopped_at_L: " + stopped_at_L)
+	print("  reached_H3:   " + reached_H3)
+
+	debug.set_game_speed(1)
+	_lb_destroy(pl, blocker)
+	_lb_destroy(pl, cnv)
+	_lb_remove_y3_signal(pl)
+	_lb_remove_infra(pl)
+	RESET_ALL_PLAYER_FUNDS()
+
+	ASSERT_TRUE(stopped_at_L)
+	ASSERT_TRUE(reached_H3)
+}

--- a/tests/automated-tests/tests/test_longblock_signal.nut
+++ b/tests/automated-tests/tests/test_longblock_signal.nut
@@ -1,0 +1,445 @@
+//
+// Tests for longblock signal reservation behaviour.
+//
+// Layout (x=10, track runs south y=0→14):
+//   y= 0 : D1  – depot for main convoy
+//   y= 2 : S1  – optional signal (none / pre-signal / priority, varies per test)
+//   y= 4 : L   – longblock signal (always present)
+//   y= 6 : H1  – first stop for main convoy
+//   y= 8 : H2  – second stop; blocker convoy parks here for "blocked" tests
+//   y=10 : S2  – simple signal
+//   y=12 : H3  – third stop for main convoy (final destination)
+//   y=14 : D2  – depot for blocker convoy (approaches H2 from the south)
+//
+// Main convoy schedule : H1 → H2 → H3  (0 % min-load, departs immediately)
+// Blocker schedule     : H2 only        (200 % min-load, never departs)
+//
+// Test matrix
+//   TC1  no signal at S1, no blocker  → convoy passes L, reaches H3
+//   TC2  no signal at S1, blocker     → convoy stops AT L, after removal reaches H3
+//   TC3  pre-signal at S1, no blocker → same as TC1
+//   TC4  pre-signal at S1, blocker    → convoy stops near S1, after removal reaches H3
+//   TC5  priority  at S1, no blocker  → same as TC1 (priority defers to step)
+//   TC6  priority  at S1, blocker     → convoy stops AT L, after removal reaches H3
+//
+// Uses x=10 to avoid coordinate collisions with other test files.
+//
+
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Infrastructure helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+// Build shared track, depots, stations.  S1 tile is left empty (caller may
+// optionally place a signal there).  Returns [sig_L, sig_S2].
+function _lb_build_infra(pl, rail)
+{
+	local station_desc = building_desc_x.get_available_stations(
+	                         building_desc_x.station, wt_rail, good_desc_x.passenger)[0]
+	local depot_desc   = get_depot_by_wt(wt_rail)
+	ASSERT_TRUE(station_desc != null)
+	ASSERT_TRUE(depot_desc   != null)
+
+	ASSERT_EQUAL(command_x.build_way(pl, coord3d(10, 0, 0), coord3d(10, 14, 0), rail, true), null)
+
+	ASSERT_EQUAL(command_x.build_depot(pl, coord3d(10,  0, 0), depot_desc), null)
+	ASSERT_EQUAL(command_x.build_depot(pl, coord3d(10, 14, 0), depot_desc), null)
+
+	ASSERT_EQUAL(command_x.build_station(pl, coord3d(10,  6, 0), station_desc), null)  // H1
+	ASSERT_EQUAL(command_x.build_station(pl, coord3d(10,  8, 0), station_desc), null)  // H2
+	ASSERT_EQUAL(command_x.build_station(pl, coord3d(10, 12, 0), station_desc), null)  // H3
+
+	local lb_desc = sign_desc_x.get_available_signs(wt_rail).filter(
+	                    @(idx, s) s.is_longblock_signal())[0]
+	local sg_desc = sign_desc_x.get_available_signs(wt_rail).filter(
+	                    @(idx, s) s.is_signal())[0]
+	ASSERT_TRUE(lb_desc != null)
+	ASSERT_TRUE(sg_desc != null)
+
+	ASSERT_EQUAL(command_x.build_sign_at(pl, coord3d(10,  4, 0), lb_desc), null)  // L
+	ASSERT_EQUAL(command_x.build_sign_at(pl, coord3d(10, 10, 0), sg_desc), null)  // S2
+
+	local sig_L  = tile_x(10,  4, 0).find_object(mo_signal)
+	local sig_S2 = tile_x(10, 10, 0).find_object(mo_signal)
+	ASSERT_TRUE(sig_L  != null)
+	ASSERT_TRUE(sig_S2 != null)
+
+	return [sig_L, sig_S2]
+}
+
+function _lb_remove_infra(pl)
+{
+	// signals
+	foreach (y in [2, 4, 10]) {
+		local sig = tile_x(10, y, 0).find_object(mo_signal)
+		if (sig != null) {
+			command_x(tool_remover).work(pl, coord3d(10, y, 0))
+		}
+	}
+	// stations & depots
+	foreach (y in [0, 6, 8, 12, 14]) {
+		command_x(tool_remover).work(pl, coord3d(10, y, 0))
+	}
+	command_x(tool_remove_way).work(pl, coord3d(10, 0, 0), coord3d(10, 14, 0), "" + wt_rail)
+}
+
+// Start the main convoy (D1 → H1 → H2 → H3).
+function _lb_start_main(pl)
+{
+	local depot = depot_x(10, 0, 0)
+	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("H-Trans-Pantheress"))
+	local cnv = depot.get_convoy_list()[0]
+	depot.append_vehicle(pl, cnv, vehicle_desc_x("H-Trans-Tiger-Car"))
+	depot.append_vehicle(pl, cnv, vehicle_desc_x("H-Trans-Tiger-Car"))
+	depot.append_vehicle(pl, cnv, vehicle_desc_x("H-Trans-Pantheress-Back"))
+	cnv.change_schedule(pl, schedule_x(wt_rail, [
+		schedule_entry_x(coord3d(10,  6, 0), 0, 0),   // H1
+		schedule_entry_x(coord3d(10,  8, 0), 0, 0),   // H2
+		schedule_entry_x(coord3d(10, 12, 0), 0, 0),   // H3
+	]))
+	depot.start_all_convoys(pl)
+	sleep()
+	return cnv
+}
+
+// Start the blocker convoy (D2 → H2 at 200 % min-load, never departs).
+function _lb_start_blocker(pl)
+{
+	local depot = depot_x(10, 14, 0)
+	depot.append_vehicle(pl, convoy_x(0), vehicle_desc_x("H-Trans-Pantheress"))
+	local cnv = depot.get_convoy_list()[0]
+	depot.append_vehicle(pl, cnv, vehicle_desc_x("H-Trans-Tiger-Car"))
+	depot.append_vehicle(pl, cnv, vehicle_desc_x("H-Trans-Tiger-Car"))
+	depot.append_vehicle(pl, cnv, vehicle_desc_x("H-Trans-Pantheress-Back"))
+	cnv.change_schedule(pl, schedule_x(wt_rail, [
+		schedule_entry_x(coord3d(10, 8, 0), 200, 0),  // H2 – 200% min-load → stays forever
+	]))
+	depot.start_all_convoys(pl)
+	// Wait until blocker reaches H2
+	for (local i = 0; i < 6000 && cnv.is_valid() && cnv.get_pos().y < 8; i++) {
+		sleep()
+	}
+	return cnv
+}
+
+// Wait until cnv.get_pos().y reaches target_y (or timeout).
+function _lb_wait_until_y(cnv, target_y, max_steps)
+{
+	for (local i = 0; i < max_steps; i++) {
+		sleep()
+		if (!cnv.is_valid()) return false
+		if (cnv.get_pos().y == target_y) return true
+	}
+	return false
+}
+
+// Wait until cnv.get_pos().y exceeds target_y (or timeout).
+function _lb_wait_past_y(cnv, target_y, max_steps)
+{
+	for (local i = 0; i < max_steps; i++) {
+		sleep()
+		if (!cnv.is_valid()) return false
+		if (cnv.get_pos().y > target_y) return true
+	}
+	return false
+}
+
+// Destroy convoy safely and wait for removal.
+function _lb_destroy(pl, cnv)
+{
+	if (cnv.is_valid()) {
+		cnv.destroy(pl)
+		sleep()
+		sleep()
+	}
+}
+
+
+// ──────────────────────────────────────────────────────────────────────────────
+// TC1 – plain longblock, no blocker
+// L reserves through H1/H2 to S2; convoy reaches H3 unobstructed.
+// ──────────────────────────────────────────────────────────────────────────────
+function test_longblock_open_no_prefix_signal()
+{
+	local pl   = player_x(0)
+	local rail = way_desc_x.get_available_ways(wt_rail, st_flat)[0]
+	ASSERT_TRUE(rail != null)
+
+	local sigs = _lb_build_infra(pl, rail)
+	// No signal at S1.
+
+	debug.set_game_speed(5)
+	local cnv = _lb_start_main(pl)
+
+	// Convoy must reach H3 (y=12).
+	local reached_H3 = _lb_wait_until_y(cnv, 12, 8000)
+
+	print("  reached_H3: " + reached_H3)
+
+	debug.set_game_speed(1)
+	_lb_destroy(pl, cnv)
+	_lb_remove_infra(pl)
+	RESET_ALL_PLAYER_FUNDS()
+
+	ASSERT_TRUE(reached_H3)
+}
+
+
+// ──────────────────────────────────────────────────────────────────────────────
+// TC2 – plain longblock, blocker at H2
+// Convoy must stop AT L (y=4) while blocker holds H2.
+// After removing the blocker the convoy reaches H3.
+// ──────────────────────────────────────────────────────────────────────────────
+function test_longblock_blocked_no_prefix_signal()
+{
+	local pl   = player_x(0)
+	local rail = way_desc_x.get_available_ways(wt_rail, st_flat)[0]
+	ASSERT_TRUE(rail != null)
+
+	local sigs = _lb_build_infra(pl, rail)
+
+	debug.set_game_speed(5)
+
+	// Blocker first, then main convoy.
+	local blocker = _lb_start_blocker(pl)
+	local cnv     = _lb_start_main(pl)
+
+	// Convoy should stop at L (y=4) – the longblock signal blocks because H2 is occupied.
+	local stopped_at_L = false
+	for (local i = 0; i < 6000; i++) {
+		sleep()
+		if (!cnv.is_valid()) break
+		if (cnv.get_pos().y == 4 && (cnv.is_waiting() || cnv.get_speed() <= 0)) {
+			stopped_at_L = true
+			break
+		}
+	}
+
+	// Remove blocker and verify convoy proceeds to H3.
+	local reached_H3 = false
+	if (stopped_at_L) {
+		_lb_destroy(pl, blocker)
+		reached_H3 = _lb_wait_until_y(cnv, 12, 8000)
+	}
+
+	print("  stopped_at_L: " + stopped_at_L)
+	print("  reached_H3:   " + reached_H3)
+
+	debug.set_game_speed(1)
+	_lb_destroy(pl, blocker)
+	_lb_destroy(pl, cnv)
+	_lb_remove_infra(pl)
+	RESET_ALL_PLAYER_FUNDS()
+
+	ASSERT_TRUE(stopped_at_L)
+	ASSERT_TRUE(reached_H3)
+}
+
+
+// ──────────────────────────────────────────────────────────────────────────────
+// TC3 – pre-signal at S1, no blocker
+// Pre-signal evaluates L; convoy reaches H3 unobstructed.
+// ──────────────────────────────────────────────────────────────────────────────
+function test_longblock_open_pre_signal()
+{
+	local pl   = player_x(0)
+	local rail = way_desc_x.get_available_ways(wt_rail, st_flat)[0]
+	ASSERT_TRUE(rail != null)
+
+	local pre_desc = sign_desc_x.get_available_signs(wt_rail).filter(
+	                     @(idx, s) s.is_pre_signal())[0]
+	ASSERT_TRUE(pre_desc != null)
+
+	local sigs = _lb_build_infra(pl, rail)
+	ASSERT_EQUAL(command_x.build_sign_at(pl, coord3d(10, 2, 0), pre_desc), null)
+	local sig_S1 = tile_x(10, 2, 0).find_object(mo_signal)
+	ASSERT_TRUE(sig_S1 != null)
+
+	debug.set_game_speed(5)
+	local cnv = _lb_start_main(pl)
+
+	local reached_H3 = _lb_wait_until_y(cnv, 12, 8000)
+
+	print("  reached_H3: " + reached_H3)
+
+	debug.set_game_speed(1)
+	_lb_destroy(pl, cnv)
+	_lb_remove_infra(pl)
+	RESET_ALL_PLAYER_FUNDS()
+
+	ASSERT_TRUE(reached_H3)
+}
+
+
+// ──────────────────────────────────────────────────────────────────────────────
+// TC4 – pre-signal at S1, blocker at H2
+// Pre-signal cascades to L; because L cannot reserve through H2 the pre-signal
+// shows YELLOW and convoy stops near S1 (y ≤ 3).
+// After removing the blocker the convoy reaches H3.
+// ──────────────────────────────────────────────────────────────────────────────
+function test_longblock_blocked_pre_signal()
+{
+	local pl   = player_x(0)
+	local rail = way_desc_x.get_available_ways(wt_rail, st_flat)[0]
+	ASSERT_TRUE(rail != null)
+
+	local pre_desc = sign_desc_x.get_available_signs(wt_rail).filter(
+	                     @(idx, s) s.is_pre_signal())[0]
+	ASSERT_TRUE(pre_desc != null)
+
+	local sigs = _lb_build_infra(pl, rail)
+	ASSERT_EQUAL(command_x.build_sign_at(pl, coord3d(10, 2, 0), pre_desc), null)
+	local sig_S1 = tile_x(10, 2, 0).find_object(mo_signal)
+	ASSERT_TRUE(sig_S1 != null)
+
+	debug.set_game_speed(5)
+
+	local blocker = _lb_start_blocker(pl)
+	local cnv     = _lb_start_main(pl)
+
+	// Convoy should be held near S1 (y <= 3) because pre-signal returns YELLOW/RED.
+	local stopped_near_S1 = false
+	for (local i = 0; i < 6000; i++) {
+		sleep()
+		if (!cnv.is_valid()) break
+		local pos = cnv.get_pos()
+		if (pos.y <= 3 && (cnv.is_waiting() || cnv.get_speed() <= 0)) {
+			stopped_near_S1 = true
+			break
+		}
+	}
+
+	// Remove blocker; convoy should now proceed all the way to H3.
+	local reached_H3 = false
+	if (stopped_near_S1) {
+		_lb_destroy(pl, blocker)
+		reached_H3 = _lb_wait_until_y(cnv, 12, 8000)
+	}
+
+	print("  stopped_near_S1: " + stopped_near_S1)
+	print("  reached_H3:      " + reached_H3)
+
+	debug.set_game_speed(1)
+	_lb_destroy(pl, blocker)
+	_lb_destroy(pl, cnv)
+	_lb_remove_infra(pl)
+	RESET_ALL_PLAYER_FUNDS()
+
+	ASSERT_TRUE(stopped_near_S1)
+	ASSERT_TRUE(reached_H3)
+}
+
+
+// ──────────────────────────────────────────────────────────────────────────────
+// TC5 – priority signal at S1, no blocker
+// Priority cannot evaluate L in sync_step; it defers and evaluates in step().
+// The convoy is briefly held at S1 (WAITING_FOR_CLEARANCE for one step) while
+// the longblock is checked, then proceeds and reaches H3.
+// ──────────────────────────────────────────────────────────────────────────────
+function test_longblock_open_priority_signal()
+{
+	local pl   = player_x(0)
+	local rail = way_desc_x.get_available_ways(wt_rail, st_flat)[0]
+	ASSERT_TRUE(rail != null)
+
+	local pri_desc = sign_desc_x.get_available_signs(wt_rail).filter(
+	                     @(idx, s) s.is_priority_signal())[0]
+	ASSERT_TRUE(pri_desc != null)
+
+	local sigs = _lb_build_infra(pl, rail)
+	ASSERT_EQUAL(command_x.build_sign_at(pl, coord3d(10, 2, 0), pri_desc), null)
+	local sig_S1 = tile_x(10, 2, 0).find_object(mo_signal)
+	ASSERT_TRUE(sig_S1 != null)
+
+	debug.set_game_speed(5)
+	local cnv = _lb_start_main(pl)
+
+	// The convoy should pass S1 (briefly waiting) and then L, then reach H3.
+	// We observe a brief wait near S1 (y <= 3) before the convoy proceeds.
+	local waited_at_S1 = false
+	local reached_H3   = false
+
+	for (local i = 0; i < 8000; i++) {
+		sleep()
+		if (!cnv.is_valid()) break
+		local pos = cnv.get_pos()
+		if (pos.y <= 3 && cnv.is_waiting()) {
+			waited_at_S1 = true
+		}
+		if (pos.y == 12) {
+			reached_H3 = true
+			break
+		}
+	}
+
+	print("  waited_at_S1: " + waited_at_S1)
+	print("  reached_H3:   " + reached_H3)
+
+	debug.set_game_speed(1)
+	_lb_destroy(pl, cnv)
+	_lb_remove_infra(pl)
+	RESET_ALL_PLAYER_FUNDS()
+
+	ASSERT_TRUE(waited_at_S1)
+	ASSERT_TRUE(reached_H3)
+}
+
+
+// ──────────────────────────────────────────────────────────────────────────────
+// TC6 – priority signal at S1, blocker at H2
+// Priority "can still go" with longblock: reserves S1→L, convoy proceeds to L.
+// At L the longblock section (L→S2) cannot be reserved because H2 is occupied,
+// so the convoy stops AT L (y=4).
+// After removing the blocker check_longblock_signal succeeds, convoy reaches H3.
+// ──────────────────────────────────────────────────────────────────────────────
+function test_longblock_blocked_priority_signal()
+{
+	local pl   = player_x(0)
+	local rail = way_desc_x.get_available_ways(wt_rail, st_flat)[0]
+	ASSERT_TRUE(rail != null)
+
+	local pri_desc = sign_desc_x.get_available_signs(wt_rail).filter(
+	                     @(idx, s) s.is_priority_signal())[0]
+	ASSERT_TRUE(pri_desc != null)
+
+	local sigs = _lb_build_infra(pl, rail)
+	ASSERT_EQUAL(command_x.build_sign_at(pl, coord3d(10, 2, 0), pri_desc), null)
+	local sig_S1 = tile_x(10, 2, 0).find_object(mo_signal)
+	ASSERT_TRUE(sig_S1 != null)
+
+	debug.set_game_speed(5)
+
+	local blocker = _lb_start_blocker(pl)
+	local cnv     = _lb_start_main(pl)
+
+	// Convoy should stop AT L (y=4).  Priority passes S1 ("can still go") but
+	// the longblock at L cannot reserve through the occupied H2.
+	local stopped_at_L = false
+	for (local i = 0; i < 6000; i++) {
+		sleep()
+		if (!cnv.is_valid()) break
+		if (cnv.get_pos().y == 4 && (cnv.is_waiting() || cnv.get_speed() <= 0)) {
+			stopped_at_L = true
+			break
+		}
+	}
+
+	// Remove blocker; check_longblock_signal now succeeds, convoy proceeds to H3.
+	local reached_H3 = false
+	if (stopped_at_L) {
+		_lb_destroy(pl, blocker)
+		reached_H3 = _lb_wait_until_y(cnv, 12, 8000)
+	}
+
+	print("  stopped_at_L: " + stopped_at_L)
+	print("  reached_H3:   " + reached_H3)
+
+	debug.set_game_speed(1)
+	_lb_destroy(pl, blocker)
+	_lb_destroy(pl, cnv)
+	_lb_remove_infra(pl)
+	RESET_ALL_PLAYER_FUNDS()
+
+	ASSERT_TRUE(stopped_at_L)
+	ASSERT_TRUE(reached_H3)
+}

--- a/tests/automated-tests/tests/test_longblock_signal.nut
+++ b/tests/automated-tests/tests/test_longblock_signal.nut
@@ -111,12 +111,16 @@ function _lb_start_blocker(pl)
 	depot.append_vehicle(pl, cnv, vehicle_desc_x("H-Trans-Tiger-Car"))
 	depot.append_vehicle(pl, cnv, vehicle_desc_x("H-Trans-Tiger-Car"))
 	depot.append_vehicle(pl, cnv, vehicle_desc_x("H-Trans-Pantheress-Back"))
+	// Two entries required (schedule validation rejects single-entry schedules).
+	// H2 at 200% min-load keeps the blocker parked there permanently;
+	// H3 is the "return" entry but is never reached because the convoy never departs H2.
 	cnv.change_schedule(pl, schedule_x(wt_rail, [
-		schedule_entry_x(coord3d(10, 8, 0), 200, 0),  // H2 – 200% min-load → stays forever
+		schedule_entry_x(coord3d(10,  8, 0), 200, 0),  // H2 – 200% min-load → stays forever
+		schedule_entry_x(coord3d(10, 12, 0), 200, 0),  // H3 – backup entry (never reached)
 	]))
 	depot.start_all_convoys(pl)
-	// Wait until blocker reaches H2
-	for (local i = 0; i < 6000 && cnv.is_valid() && cnv.get_pos().y < 8; i++) {
+	// Blocker travels north: y decreases from 14 → 8.  Wait until it reaches H2.
+	for (local i = 0; i < 6000 && cnv.is_valid() && cnv.get_pos().y > 8; i++) {
 		sleep()
 	}
 	return cnv
@@ -401,27 +405,36 @@ function test_longblock_blocked_priority_signal()
 	local pri_desc = sign_desc_x.get_available_signs(wt_rail).filter(
 	                     @(idx, s) s.is_priority_signal())[0]
 	ASSERT_TRUE(pri_desc != null)
+	print("  pri_desc ok: " + pri_desc.get_name())
 
 	local sigs = _lb_build_infra(pl, rail)
+	print("  infra built")
 	ASSERT_EQUAL(command_x.build_sign_at(pl, coord3d(10, 2, 0), pri_desc), null)
 	local sig_S1 = tile_x(10, 2, 0).find_object(mo_signal)
 	ASSERT_TRUE(sig_S1 != null)
+	print("  S1 placed")
 
 	debug.set_game_speed(5)
 
 	local blocker = _lb_start_blocker(pl)
+	print("  blocker at y=" + blocker.get_pos().y)
 	local cnv     = _lb_start_main(pl)
+	print("  main started at y=" + cnv.get_pos().y)
 
 	// Convoy should stop AT L (y=4).  Priority passes S1 ("can still go") but
 	// the longblock at L cannot reserve through the occupied H2.
 	local stopped_at_L = false
+	local last_y = -1
 	for (local i = 0; i < 6000; i++) {
 		sleep()
-		if (!cnv.is_valid()) break
-		if (cnv.get_pos().y == 4 && (cnv.is_waiting() || cnv.get_speed() <= 0)) {
+		if (!cnv.is_valid()) { print("  cnv invalid at step " + i); break }
+		local y = cnv.get_pos().y
+		if (y != last_y) { print("  cnv y=" + y + " waiting=" + cnv.is_waiting()); last_y = y }
+		if (y == 4 && (cnv.is_waiting() || cnv.get_speed() <= 0)) {
 			stopped_at_L = true
 			break
 		}
+		if (y > 4) break  // convoy passed L already
 	}
 
 	// Remove blocker; check_longblock_signal now succeeds, convoy proceeds to H3.

--- a/tests/automated-tests/tests/test_sigcheck.nut
+++ b/tests/automated-tests/tests/test_sigcheck.nut
@@ -1,0 +1,8 @@
+function test_sigcheck()
+{
+    local signs = sign_desc_x.get_available_signs(wt_rail)
+    foreach(idx, s in signs) {
+        print("  SIGN " + s.get_name() + " pri=" + s.is_priority_signal() + " pre=" + s.is_pre_signal() + " lb=" + s.is_longblock_signal())
+    }
+    ASSERT_TRUE(true)
+}

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -4142,9 +4142,6 @@ bool rail_vehicle_t::is_priority_signal_clear(signal_t *sig, uint16 next_block, 
 			// ok, the next signal is clear
 			sig->set_state( roadsign_t::STATE_GREEN );
 			// Only shorten next_stop_index when a crossing requires an earlier stop.
-			// get_next_stop_index() returns n+1 (set_next_stop_index stores n+1),
-			// so set_next_stop_index(get_next_stop_index()) would shift by +1 again —
-			// losing the stop position a child priority signal set for a longblock.
 			if(  next_crossing < cnv->get_next_stop_index() - 1  ) {
 				cnv->set_next_stop_index( next_crossing );
 			}

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -4146,14 +4146,18 @@ bool rail_vehicle_t::is_priority_signal_clear(signal_t *sig, uint16 next_block, 
 	uint16 next_signal, next_crossing;
 
 	if(  block_reserver( cnv->get_route(), next_block+1, next_signal, next_crossing, 0, true, false )  ) {
-		if(  next_signal == route_t::INVALID_INDEX  ||  cnv->get_route()->at(next_signal) == cnv->get_route()->back()  ||  is_signal_clear( next_signal, restart_speed, call_by_step )  ) {
+		if(  next_signal == route_t::INVALID_INDEX  ||  cnv->get_route()->at(next_signal) == cnv->get_route()->back()  ) {
 			// ok, end of route => we can go
 			sig->set_state( roadsign_t::STATE_GREEN );
 			// do not shorten next_stop_index set by recursive call (e.g. longblock signal)
 			// unless a crossing requires stopping before the next signal
-			if(  next_crossing <= next_signal  ||  cnv->get_next_stop_index() <= next_signal + 1  ) {
-				cnv->set_next_stop_index( min( next_signal, next_crossing ) );
-			}
+			cnv->set_next_stop_index( min( next_signal, next_crossing ) );
+			return true;
+		}
+		if(  is_signal_clear( next_signal, restart_speed, call_by_step )  ) {
+			// ok, the next signal is clear
+			sig->set_state( roadsign_t::STATE_GREEN );
+			cnv->set_next_stop_index( min(cnv->get_next_stop_index(), next_crossing) );
 			return true;
 		}
 
@@ -4782,10 +4786,6 @@ void rail_vehicle_t::leave_tile()
 						sig->set_state(  roadsign_t::STATE_RED );
 					}
 				}
-				if(  cnv  ) {
-					// If reservation is controlled by next_reservation_index, this does nothing.
-					cnv->get_most_parent_convoi()->unreserve_pos(get_pos());
-				}
 				if (gr->has_two_ways()) {
 					// we may need to reserve the other way as well
 					if (schiene_t* sch1 = dynamic_cast<schiene_t*>(gr->get_weg_nr(gr->get_weg_nr(0) == sch0))) {
@@ -4809,6 +4809,10 @@ void rail_vehicle_t::leave_tile()
 						sig->set_state(  roadsign_t::STATE_RED );
 					}
 				}
+			}
+			if(  cnv  ) {
+				// If reservation is controlled by next_reservation_index, this does nothing.
+				cnv->get_most_parent_convoi()->unreserve_pos(get_pos());
 			}
 		}
 	}

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -4174,6 +4174,7 @@ bool rail_vehicle_t::is_priority_signal_clear(signal_t *sig, uint16 next_block, 
 		// when we reached here, the way after the last signal is not free though the way before is => we can still go
 		if(  cnv->get_next_reservation_index()<=next_signal+1  ) {
 			// only show third aspect on last signal of cascade
+			cnv->set_next_stop_index(next_signal);
 			sig->set_state( roadsign_t::STATE_YELLOW );
 		}
 		else {

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -4158,7 +4158,13 @@ bool rail_vehicle_t::is_priority_signal_clear(signal_t *sig, uint16 next_block, 
 		if(  is_signal_clear( next_signal, restart_speed, call_by_step )  ) {
 			// ok, the next signal is clear
 			sig->set_state( roadsign_t::STATE_GREEN );
-			cnv->set_next_stop_index( min(cnv->get_next_stop_index(), next_crossing) );
+			// Only shorten next_stop_index when a crossing requires an earlier stop.
+			// get_next_stop_index() returns n+1 (set_next_stop_index stores n+1),
+			// so set_next_stop_index(get_next_stop_index()) would shift by +1 again —
+			// losing the stop position a child priority signal set for a longblock.
+			if(  next_crossing < cnv->get_next_stop_index() - 1  ) {
+				cnv->set_next_stop_index( next_crossing );
+			}
 			return true;
 		}
 

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -3780,21 +3780,21 @@ bool rail_vehicle_t::check_longblock_signal(signal_t *sig, uint16 next_block, si
 		return true;
 	}
 
-	// now we have to maintain reservation with reserved_tiles, that is slower than using next_reservation_index
-	// copy all tiles that are already reserved
-	bool add_pos = false;
-	vector_tpl<koord3d> tiles_convoy_on;
-	for(  uint16 i=0;  i<cnv->get_vehicle_count();  i++  ) {
-		tiles_convoy_on.append_unique(cnv->get_vehikel(i)->get_pos());
-	}
-	for(  uint16 i=0;  i<next_block+1  &&  i<cnv->get_route()->get_count();  i++  ) {
-		if(  !add_pos  &&  tiles_convoy_on.is_contained(cnv->get_route()->at(i))  ) {
-			add_pos = true;
-		}
-		if(  add_pos  ) {
-			cnv->reserve_pos(cnv->get_route()->at(i));
-		}
-	}
+	// // now we have to maintain reservation with reserved_tiles, that is slower than using next_reservation_index
+	// // copy all tiles that are already reserved
+	// bool add_pos = false;
+	// vector_tpl<koord3d> tiles_convoy_on;
+	// for(  uint16 i=0;  i<cnv->get_vehicle_count();  i++  ) {
+	// 	tiles_convoy_on.append_unique(cnv->get_vehikel(i)->get_pos());
+	// }
+	// for(  uint16 i=0;  i<next_block+1  &&  i<cnv->get_route()->get_count();  i++  ) {
+	// 	if(  !add_pos  &&  tiles_convoy_on.is_contained(cnv->get_route()->at(i))  ) {
+	// 		add_pos = true;
+	// 	}
+	// 	if(  add_pos  ) {
+	// 		cnv->reserve_pos(cnv->get_route()->at(i));
+	// 	}
+	// }
 
 	// now we can use the route search array
 	// (route until end is already reserved at this point!)
@@ -4460,7 +4460,10 @@ bool rail_vehicle_t::can_enter_tile(const grund_t *gr, sint32 &restart_speed, ui
 			return cnv->get_next_stop_index()>route_index;
 		}
 		// next check for signal
-		if(  sch1->has_signal()  &&  cnv->get_reserved_tiles().get_count()<=3  ) {
+		// The <=3 guard was removed: when a priority signal chains to a longblock
+		// signal, reserved_tiles may be large while next_stop_index still points
+		// to a real signal that must be checked.
+		if(  sch1->has_signal()  ) {
 			if(  !is_signal_clear( next_block, restart_speed )  ) {
 				// only return false, if we are directly in front of the signal
 				return cnv->get_next_stop_index()>route_index;
@@ -4786,6 +4789,10 @@ void rail_vehicle_t::leave_tile()
 					if(sig) {
 						sig->set_state(  roadsign_t::STATE_RED );
 					}
+				}
+				if(  cnv  ) {
+					// for treat reservation safely
+					cnv->get_most_parent_convoi()->unreserve_pos(get_pos());
 				}
 				if (gr->has_two_ways()) {
 					// we may need to reserve the other way as well

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -4170,7 +4170,22 @@ bool rail_vehicle_t::is_priority_signal_clear(signal_t *sig, uint16 next_block, 
 			restart_speed = -1;
 
 			return false;
-		} 
+		}
+		// If the next signal is a longblock or choose type and returned false, the convoy must
+		// stop at this priority signal so the next signal can be properly evaluated later.
+		// The "can still go" shortcut must not be used for these signal types, because:
+		// - longblock needs the convoy to be waiting (or call_by_step) before check_longblock_signal runs
+		// - allowing pass-through leaves the section after the longblock unreserved
+		if(  next_signal < cnv->get_route()->get_count()  ) {
+			grund_t *gr_next = welt->lookup(cnv->get_route()->at(next_signal));
+			signal_t *next_sig = gr_next ? gr_next->find<signal_t>() : NULL;
+			if(  next_sig  &&  (next_sig->get_desc()->is_longblock_signal() || next_sig->get_desc()->is_choose_sign())  ) {
+				block_reserver( cnv->get_route(), next_block+1, next_signal, next_crossing, 0, false, false );
+				sig->set_state( roadsign_t::STATE_RED );
+				restart_speed = 0;
+				return false;
+			}
+		}
 		// when we reached here, the way after the last signal is not free though the way before is => we can still go
 		if(  cnv->get_next_stop_index()<=next_signal+1  ) {
 			// only show third aspect on last signal of cascade

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -4171,30 +4171,29 @@ bool rail_vehicle_t::is_priority_signal_clear(signal_t *sig, uint16 next_block, 
 
 			return false;
 		}
-		// If the next signal is a longblock or choose type and returned false, the convoy must
-		// stop at this priority signal so the next signal can be properly evaluated later.
-		// The "can still go" shortcut must not be used for these signal types, because:
-		// - longblock needs the convoy to be waiting (or call_by_step) before check_longblock_signal runs
-		// - allowing pass-through leaves the section after the longblock unreserved
-		if(  next_signal < cnv->get_route()->get_count()  ) {
-			grund_t *gr_next = welt->lookup(cnv->get_route()->at(next_signal));
-			signal_t *next_sig = gr_next ? gr_next->find<signal_t>() : NULL;
-			if(  next_sig  &&  (next_sig->get_desc()->is_longblock_signal() || next_sig->get_desc()->is_choose_sign())  ) {
-				block_reserver( cnv->get_route(), next_block+1, next_signal, next_crossing, 0, false, false );
-				sig->set_state( roadsign_t::STATE_RED );
-				restart_speed = 0;
-				return false;
-			}
-		}
 		// when we reached here, the way after the last signal is not free though the way before is => we can still go
-		if(  cnv->get_next_stop_index()<=next_signal+1  ) {
+		if(  cnv->get_next_reservation_index()<=next_signal+1  ) {
 			// only show third aspect on last signal of cascade
 			sig->set_state( roadsign_t::STATE_YELLOW );
 		}
 		else {
 			sig->set_state( roadsign_t::STATE_GREEN );
 		}
-		cnv->set_next_stop_index( min( next_signal, next_crossing ) );
+
+		// For longblock/choose: set next_stop_index one past the signal so that next_block
+		// equals the signal's route index in can_enter_tile, causing sch1->has_signal() to
+		// fire.  This forces is_signal_clear() → check_longblock_signal() to be called when
+		// the convoy tries to leave the longblock tile, instead of falling through to the
+		// generic "signal passed" block_reserver which bypasses target_rt reservation.
+		uint16 adjusted_stop = next_signal;
+		if(  next_signal < cnv->get_route()->get_count()  ) {
+			grund_t *gr_ns = welt->lookup( cnv->get_route()->at(next_signal) );
+			signal_t *ns   = gr_ns ? gr_ns->find<signal_t>() : NULL;
+			if(  ns  &&  (ns->get_desc()->is_longblock_signal() || ns->get_desc()->is_choose_sign())  ) {
+				adjusted_stop = next_signal + 1;
+			}
+		}
+		cnv->set_next_stop_index( min( adjusted_stop, next_crossing ) );
 
 		return true;
 	}

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -4181,20 +4181,20 @@ bool rail_vehicle_t::is_priority_signal_clear(signal_t *sig, uint16 next_block, 
 			sig->set_state( roadsign_t::STATE_GREEN );
 		}
 
-		// For longblock/choose: set next_stop_index one past the signal so that next_block
-		// equals the signal's route index in can_enter_tile, causing sch1->has_signal() to
-		// fire.  This forces is_signal_clear() → check_longblock_signal() to be called when
-		// the convoy tries to leave the longblock tile, instead of falling through to the
-		// generic "signal passed" block_reserver which bypasses target_rt reservation.
-		uint16 adjusted_stop = next_signal;
-		if(  next_signal < cnv->get_route()->get_count()  ) {
-			grund_t *gr_ns = welt->lookup( cnv->get_route()->at(next_signal) );
-			signal_t *ns   = gr_ns ? gr_ns->find<signal_t>() : NULL;
-			if(  ns  &&  (ns->get_desc()->is_longblock_signal() || ns->get_desc()->is_choose_sign())  ) {
-				adjusted_stop = next_signal + 1;
-			}
-		}
-		cnv->set_next_stop_index( min( adjusted_stop, next_crossing ) );
+		// // For longblock/choose: set next_stop_index one past the signal so that next_block
+		// // equals the signal's route index in can_enter_tile, causing sch1->has_signal() to
+		// // fire.  This forces is_signal_clear() → check_longblock_signal() to be called when
+		// // the convoy tries to leave the longblock tile, instead of falling through to the
+		// // generic "signal passed" block_reserver which bypasses target_rt reservation.
+		// uint16 adjusted_stop = next_signal;
+		// if(  next_signal < cnv->get_route()->get_count()  ) {
+		// 	grund_t *gr_ns = welt->lookup( cnv->get_route()->at(next_signal) );
+		// 	signal_t *ns   = gr_ns ? gr_ns->find<signal_t>() : NULL;
+		// 	if(  ns  &&  (ns->get_desc()->is_longblock_signal() || ns->get_desc()->is_choose_sign())  ) {
+		// 		adjusted_stop = next_signal + 1;
+		// 	}
+		// }
+		// cnv->set_next_stop_index( min( adjusted_stop, next_crossing ) );
 
 		return true;
 	}

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -3775,6 +3775,7 @@ bool rail_vehicle_t::check_longblock_signal(signal_t *sig, uint16 next_block, si
 	if(  next_signal != route_t::INVALID_INDEX  ) {
 		// success, and there is a signal before end of route => finished
 		sig->set_state( roadsign_t::STATE_GREEN );
+		cnv->clear_reserved_tiles();
 		cnv->set_next_stop_index( min( next_crossing, next_signal ) );
 		return true;
 	}

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -3779,23 +3779,6 @@ bool rail_vehicle_t::check_longblock_signal(signal_t *sig, uint16 next_block, si
 		cnv->set_next_stop_index( min( next_crossing, next_signal ) );
 		return true;
 	}
-
-	// // now we have to maintain reservation with reserved_tiles, that is slower than using next_reservation_index
-	// // copy all tiles that are already reserved
-	// bool add_pos = false;
-	// vector_tpl<koord3d> tiles_convoy_on;
-	// for(  uint16 i=0;  i<cnv->get_vehicle_count();  i++  ) {
-	// 	tiles_convoy_on.append_unique(cnv->get_vehikel(i)->get_pos());
-	// }
-	// for(  uint16 i=0;  i<next_block+1  &&  i<cnv->get_route()->get_count();  i++  ) {
-	// 	if(  !add_pos  &&  tiles_convoy_on.is_contained(cnv->get_route()->at(i))  ) {
-	// 		add_pos = true;
-	// 	}
-	// 	if(  add_pos  ) {
-	// 		cnv->reserve_pos(cnv->get_route()->at(i));
-	// 	}
-	// }
-
 	// now we can use the route search array
 	// (route until end is already reserved at this point!)
 	schedule_t* schedule = cnv->get_schedule();
@@ -4186,22 +4169,6 @@ bool rail_vehicle_t::is_priority_signal_clear(signal_t *sig, uint16 next_block, 
 		else {
 			sig->set_state( roadsign_t::STATE_GREEN );
 		}
-
-		// // For longblock/choose: set next_stop_index one past the signal so that next_block
-		// // equals the signal's route index in can_enter_tile, causing sch1->has_signal() to
-		// // fire.  This forces is_signal_clear() → check_longblock_signal() to be called when
-		// // the convoy tries to leave the longblock tile, instead of falling through to the
-		// // generic "signal passed" block_reserver which bypasses target_rt reservation.
-		// uint16 adjusted_stop = next_signal;
-		// if(  next_signal < cnv->get_route()->get_count()  ) {
-		// 	grund_t *gr_ns = welt->lookup( cnv->get_route()->at(next_signal) );
-		// 	signal_t *ns   = gr_ns ? gr_ns->find<signal_t>() : NULL;
-		// 	if(  ns  &&  (ns->get_desc()->is_longblock_signal() || ns->get_desc()->is_choose_sign())  ) {
-		// 		adjusted_stop = next_signal + 1;
-		// 	}
-		// }
-		// cnv->set_next_stop_index( min( adjusted_stop, next_crossing ) );
-
 		return true;
 	}
 
@@ -4481,9 +4448,6 @@ bool rail_vehicle_t::can_enter_tile(const grund_t *gr, sint32 &restart_speed, ui
 			return cnv->get_next_stop_index()>route_index;
 		}
 		// next check for signal
-		// The <=3 guard was removed: when a priority signal chains to a longblock
-		// signal, reserved_tiles may be large while next_stop_index still points
-		// to a real signal that must be checked.
 		if(  sch1->has_signal()  ) {
 			if(  !is_signal_clear( next_block, restart_speed )  ) {
 				// only return false, if we are directly in front of the signal

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -4541,10 +4541,6 @@ bool rail_vehicle_t::block_reserver(const route_t *route, uint16 start_index, ui
 			if(  !sch1->reserve( cnv->self, ribi_type( route->at(max(1u,i)-1u), route->at(min(route->get_count()-1u,i+1u)) ) )  ) {
 				success = false;
 			}
-			else if(  use_vector  ){
-				// use reserved_tiles instead of next_reservation_index to hold reservations.
-				cnv->reserve_pos(pos);
-			}
 			if (gr->has_two_ways()) {
 				// we may need to reserve the other way as well
 				if (schiene_t* sch0 = dynamic_cast<schiene_t*>(gr->get_weg_nr(gr->get_weg_nr(0) == sch1))) {
@@ -4553,6 +4549,10 @@ bool rail_vehicle_t::block_reserver(const route_t *route, uint16 start_index, ui
 						success = false;
 					}
 				}
+			}
+			if(  success  &&  use_vector  ){
+				// use reserved_tiles instead of next_reservation_index to hold reservations.
+				cnv->reserve_pos(pos);
 			}
 			if(next_crossing_index==route_t::INVALID_INDEX  &&  gr->get_crossing()) {
 				next_crossing_index = i;


### PR DESCRIPTION
`reserved_tiles`を先頭車両のみが操作することとしました。また、次の駅より手前に信号がある場合に不要な`reserved_tiles`を持たないようにしました