### PR TITLE
BUG FIX: city info window from overflowing screen when city has many factories

### DIFF
--- a/gui/city_info.cc
+++ b/gui/city_info.cc
@@ -21,6 +21,7 @@
 #include "minimap.h"
 #include "components/gui_button_to_chart.h"
 #include "components/gui_image.h"
+#include "components/gui_scrollpane.h"
 
 #include "../display/simgraph.h"
 
@@ -288,9 +289,9 @@ void city_info_t::init()
 	gui_label_buf_t *lb_pax = container_factories.new_component<gui_label_buf_t>();
 	lb_pax->buf().printf(translator::translate("Connected Factories"));
 	lb_pax->update();
-	container_factories.add_component(&all_factories);
+	container_factories.new_component<gui_scrollpane_t>(&all_factories);
 	all_factories.set_table_layout(7,0);
-	all_factories.set_margin(scr_size(0,0), scr_size(0,D_V_SPACE));
+	all_factories.set_margin(scr_size(0,0), scr_size(D_H_SPACE,D_V_SPACE));
 	const vector_tpl<stadt_t::factory_entry_t> & fab_list = city->get_target_factories_for_pax().get_entries();
 	if(!fab_list.empty()){
 		FOR(vector_tpl<stadt_t::factory_entry_t>, const& e, fab_list) {


### PR DESCRIPTION
## 問題

工場が多く接続されている都市の都市詳細ウインドウが縦長になり、ゲームウインドウをはみ出ることがある。

## 原因

「Factories」タブ内の `all_factories`（`gui_aligned_container_t`）に工場エントリをスクロールなしで直接追加していた。
`gui_tab_panel_t::get_min_size()` は全タブの最小サイズの最大値を取るため、工場数が多いほどウインドウ全体の最小高が増加し、ディスプレイ高を超える場合があった。

## 修正内容

- `all_factories` を `gui_scrollpane_t` でラップ
  - スクロールペインの最小高はスクロールバーの高さのみとなるため、工場数に関係なくウインドウの最小高が一定（年・月タブの最小高）になる
  - 工場数が多い場合はスクロールバーが表示され、リスト全体を閲覧可能
- `all_factories` の右マージンに `D_H_SPACE` を追加し、ポストマークとスクロールバーが視覚的に重なるのを防止