### PR TITLE
BUG FIX: crash when using cargo_queue_t::clear many times

### DIFF
--- a/simhalt.cc
+++ b/simhalt.cc
@@ -452,6 +452,7 @@ struct haltestelle_t::cargo_queue_t {
 			cargos.clear();
 			zwischenziel_index.clear();
 			ziel_index.clear();
+			fresh_index.clear();
 		}
 
 		// Sets all zwischenziels of the waiting items in the storage


### PR DESCRIPTION
`TOOL_EXTINGUISH_WAITING_GOODS`を複数回使用するとクラッシュする不具合を修正しました