### PR TITLE
Show depot name in minimap

### DIFF
--- a/gui/depot_picker.cc
+++ b/gui/depot_picker.cc
@@ -5,6 +5,7 @@
 
 #include "depot_picker.h"
 #include "gui_theme.h"
+#include "minimap.h"
 
 #include "../player/simplay.h"
 #include "../vehicle/simvehicle.h"
@@ -268,6 +269,7 @@ bool depot_picker_t::action_triggered(gui_action_creator_t *comp, value_t)
 void depot_picker_t::fill_list()
 {
 	scrolly.clear_elements();
+	vector_tpl<koord> positions;
 
 	FOR(slist_tpl<depot_t*>, const depot, depot_t::get_depot_list()) {
 		if (depot->get_owner() != owner || !depot->can_accept_waytype(wt)) {
@@ -280,6 +282,7 @@ void depot_picker_t::fill_list()
 				continue;
 			}
 		}
+		positions.append(depot->get_pos().get_2d());
 		if (cnv.is_bound()) {
 			scrolly.new_component<depot_picker_item_t>(depot, cnv, teleport);
 		}
@@ -289,4 +292,16 @@ void depot_picker_t::fill_list()
 	}
 	scrolly.sort(0);
 	scrolly.set_size(scrolly.get_size());
+
+	if (minimap_t *mm = minimap_t::get_instance()) {
+		mm->set_highlighted_depots(positions);
+	}
+}
+
+
+depot_picker_t::~depot_picker_t()
+{
+	if (minimap_t *mm = minimap_t::get_instance()) {
+		mm->clear_highlighted_depots();
+	}
 }

--- a/gui/depot_picker.h
+++ b/gui/depot_picker.h
@@ -93,6 +93,7 @@ public:
 	depot_picker_t(convoihandle_t cnv, bool teleport);
 	/// Open picker to teleport all convoys of a line to a chosen depot
 	depot_picker_t(linehandle_t line, waytype_t wt, player_t *owner);
+	~depot_picker_t();
 
 	bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
 	bool has_min_sizer() const OVERRIDE { return true; }

--- a/gui/minimap.cc
+++ b/gui/minimap.cc
@@ -1883,13 +1883,16 @@ void minimap_t::draw(scr_coord pos)
 
 	if(  mode & MAP_DEPOT  ) {
 		FOR(  slist_tpl<depot_t*>,  const d,  depot_t::get_depot_list()  ) {
-			if(  d->get_owner() == world->get_active_player()  ) {
-				scr_coord depot_pos = map_to_screen_coord( d->get_pos().get_2d() );
-				depot_pos = depot_pos + pos;
-				// offset of one to avoid
-				static uint8 depot_typ_to_color[19]={ COL_ORANGE, COL_YELLOW, COL_RED, 0, 0, 0, 0, 0, 0, COL_PURPLE, COL_DARK_RED, COL_DARK_ORANGE, 0, 0, 0, 0, 0, 0, COL_LIGHT_RED };
-				display_filled_circle_rgb( depot_pos.x, depot_pos.y, 4, color_idx_to_rgb(depot_typ_to_color[d->get_typ() - obj_t::bahndepot]) );
-				display_circle_rgb( depot_pos.x, depot_pos.y, 4, color_idx_to_rgb(COL_BLACK) );
+			scr_coord depot_pos = map_to_screen_coord( d->get_pos().get_2d() );
+			depot_pos = depot_pos + pos;
+			// offset of one to avoid
+			const bool has_filter = !highlighted_depot_positions.empty();
+			const bool highlighted = !has_filter || highlighted_depot_positions.is_contained(d->get_pos().get_2d());
+			const sint16 r = highlighted ? 4 : 2;
+			display_filled_circle_rgb( depot_pos.x, depot_pos.y, r, color_idx_to_rgb(d->get_owner()->get_player_color1()+4) );
+			display_circle_rgb( depot_pos.x, depot_pos.y, r, color_idx_to_rgb(COL_BLACK) );
+			if(  highlighted && has_filter  ) {
+				display_circle_rgb( depot_pos.x, depot_pos.y, r + 3, color_idx_to_rgb(COL_WHITE) );
 			}
 		}
 	}
@@ -2029,6 +2032,40 @@ void minimap_t::draw(scr_coord pos)
 			scr_coord p = map_to_screen_coord( stadt->get_pos() );
 			p += pos;
 			display_proportional_clip_rgb( p.x, p.y, name, ALIGN_LEFT, col, true );
+		}
+	}
+
+	// draw depot names on top so they are not erased by vehicles
+	if(  mode & MAP_DEPOT  ) {
+		const bool has_filter = !highlighted_depot_positions.empty();
+		FOR(  slist_tpl<depot_t*>,  const d,  depot_t::get_depot_list()  ) {
+			if(  has_filter && !highlighted_depot_positions.is_contained(d->get_pos().get_2d())  ) {
+				continue;
+			}
+			scr_coord p = map_to_screen_coord( d->get_pos().get_2d() );
+			p += pos;
+
+			// resolve waytype icon
+			const skin_desc_t *wt_skin = NULL;
+			switch(  d->get_waytype()  ) {
+				case track_wt:        wt_skin = skinverwaltung_t::zughaltsymbol;          break;
+				case water_wt:        wt_skin = skinverwaltung_t::schiffshaltsymbol;      break;
+				case road_wt:         wt_skin = skinverwaltung_t::autohaltsymbol;         break;
+				case air_wt:          wt_skin = skinverwaltung_t::airhaltsymbol;          break;
+				case monorail_wt:     wt_skin = skinverwaltung_t::monorailhaltsymbol;     break;
+				case tram_wt:         wt_skin = skinverwaltung_t::tramhaltsymbol;         break;
+				case maglev_wt:       wt_skin = skinverwaltung_t::maglevhaltsymbol;       break;
+				case narrowgauge_wt:  wt_skin = skinverwaltung_t::narrowgaugehaltsymbol;  break;
+				default: break;
+			}
+			const image_id icon_img = (wt_skin ? wt_skin->get_image_id(0) : IMG_EMPTY);
+			scr_coord_val icon_xoff = 0, icon_yoff = 0, icon_xw = 12, icon_yw = 12;
+			if(  icon_img != IMG_EMPTY  ) {
+				display_get_image_offset(icon_img, &icon_xoff, &icon_yoff, &icon_xw, &icon_yw);
+				display_color_img(icon_img, p.x + 6 - icon_xoff, p.y - icon_yoff - icon_yw / 2, d->get_owner()->get_player_nr(), false, true);
+			}
+			const scr_coord_val name_x = p.x + 6 + (icon_img != IMG_EMPTY ? icon_xw + 2 : 0);
+			display_proportional_clip_rgb( name_x, p.y - LINESPACE / 2, d->get_name(), ALIGN_LEFT, color_idx_to_rgb(COL_WHITE), true );
 		}
 	}
 }

--- a/gui/minimap.h
+++ b/gui/minimap.h
@@ -184,6 +184,8 @@ private:
 	vector_tpl<halthandle_t> route_search_transfer_halts;
 	halthandle_t route_search_from_halt, route_search_dest_halt;
 
+	vector_tpl<koord> highlighted_depot_positions;
+
 public:
 	scr_coord map_to_screen_coord(const koord &k) const;
 
@@ -291,6 +293,12 @@ public:
 
 	void add_route_halt(halthandle_t halt) { route_search_highlighted_halts.append_unique(halt); }
 	void add_transfer_halt(halthandle_t halt) { route_search_transfer_halts.append_unique(halt); }
+
+	void set_highlighted_depots(const vector_tpl<koord> &positions) {
+		highlighted_depot_positions.clear();
+		for (koord const& k : positions) { highlighted_depot_positions.append(k); }
+	}
+	void clear_highlighted_depots() { highlighted_depot_positions.clear(); }
 	void set_from_dest_halt(halthandle_t from_halt, halthandle_t dest_halt) {
 		if (  from_halt.is_bound() && dest_halt.is_bound()  ) {
 			route_search_from_halt = from_halt;


### PR DESCRIPTION
地図上に車庫名を表示します
これに伴い、以下の変更が発生しています
- 地図で「車庫を表示」時、車庫名を表示
- 車庫名を全社分表示し、車庫の〇をラインカラーに変更
- 上記に伴い、`waytype`の見分け方を〇の色からアイコンに変更し、〇[アイコン][車庫名]に表示方法を変更
- 車庫転送ウィンドウ表示時、選択肢に挙がった車庫を白円で強調表示
