### PR TITLE
Fix crash when displaying vehicle overlay during route calculation

### DIFF
--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -1968,7 +1968,8 @@ void vehicle_t::display_after(int xpos, int ypos, bool is_global) const
 			// nothing to show
 			return;
 		}
-		grund_t const* const gr = cnv->get_route()?welt->lookup(cnv->get_route()->back()):NULL;
+		const route_t* const route = cnv->get_route();
+		grund_t const* const gr = route->get_count() > 0 ? welt->lookup(route->back()) : NULL;
 		const float conversion_ratio = (float)world()->get_settings().get_spacing_shift_divisor()/world()->ticks_per_world_month;
 
 		


### PR DESCRIPTION
## 概要

経路計算中の画面更新で、空になっている経路の末尾を参照してクラッシュする問題を修正します。

## 原因

`route_t::calc_route()` は経路探索開始時に既存の経路をクリアします。探索中の `INT_CHECK()` から画面更新が実行されると、`vehicle_t::display_overlay()` が空の経路に対して `back()` を呼び、範囲外アクセスが発生していました。

## 修正内容

- 経路に要素がある場合のみ `back()` と `welt->lookup()` を呼ぶように変更
- 経路が空の場合は終点の地面を `NULL` として既存の表示処理を継続

## 確認

- `make -j8` 成功
- `git diff --check` 成功