### PR TITLE
BUG FIX: fix two GUI bugs in convoy detail window

### DIFF
--- a/gui/components/gui_combobox.cc
+++ b/gui/components/gui_combobox.cc
@@ -359,7 +359,9 @@ void gui_combobox_t::set_size(scr_size size)
 	closed_size = size;
 	gui_component_t::set_size( size );
 
-	droplist.request_size(scr_size(this->size.w, droplist.get_size().h));
+	if(  droplist.get_size().w != this->size.w  ) {
+		droplist.request_size(scr_size(this->size.w, droplist.get_size().h));
+	}
 
 	textinp.set_size( scr_size( size.w - bt_prev.get_size().w - bt_next.get_size().w - D_H_SPACE, closed_size.h ) );
 	set_pos(get_pos());

--- a/gui/convoi_info_t.cc
+++ b/gui/convoi_info_t.cc
@@ -495,9 +495,10 @@ void convoi_info_t::draw(scr_coord pos, scr_size size)
 	route_show_button.pressed = is_route_show;
 	route_show_button.enable();
 
+	// update layout before rendering so upper section width matches current window size
+	set_windowsize(size);
 	// all gui stuff set => display it
 	gui_frame_t::draw(pos, size);
-	set_windowsize(size);
 }
 
 


### PR DESCRIPTION
## 概要

車両詳細ウィンドウの不具合を2点修正します。

## 修正内容

### 1. 会社選択コンボボックスのスクロール位置がリセットされる問題

車両を譲渡する際、会社を選択するコンボボックスのドロップリストを開いてスクロールしようとすると、毎フレームスクロール位置が先頭に戻ってしまい、正しく選択できない問題を修正しました。

**原因：** `gui_combobox_t::set_size()` 内で、ドロップリストの幅が変わっていないにもかかわらず毎フレーム `droplist.request_size()` を呼んでいた。`request_size()` は内部で `show_focused()` を呼び出しており、これがスクロール位置を選択中アイテムへ強制的に戻していた。

**修正：** ドロップリストの幅が実際に変化した場合のみ `request_size()` を呼ぶよう変更。

### 2. ウィンドウのリサイズ中に上部セクションの幅がちらつく問題

ウィンドウ右下のリサイズハンドルをドラッグすると、タブより上のセクション（速度バーなど）の幅が正しく追従せずにちらつく問題を修正しました。

**原因：** `convoi_info_t::draw()` の末尾で `gui_frame_t::draw()` の**後に** `set_windowsize()` を呼んでいた。そのため、レイアウトの再計算が常に1フレーム遅れており、描画は常に「前フレームのウィンドウサイズ」に基づいたレイアウトで行われていた。

**修正：** `set_windowsize()` を `gui_frame_t::draw()` より**前**に移動し、描画前にレイアウトを最新のウィンドウサイズで更新するよう変更。