### PR TITLE
BUG FIX: fix stray track reservations when route changes during operation

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -1392,7 +1392,7 @@ bool convoi_t::drive_to()
 			}
 		}
 
-		// unreserve old route before replacing to avoid stray reservations when rerouted
+		// unreserve old route before replacing; required for cache-hit path where calc_route() (which also unreserves) is skipped
 		unreserve_route();
 
 		if(  !cached_calc_route( start, ziel, &route, schedule->get_current_entry().is_pass_stop() )  ) {
@@ -1654,6 +1654,7 @@ void convoi_t::step()
 		case NO_ROUTE:
 			clear_reserved_tiles();
 			unset_convoi_coupling_in_progress();
+			unreserve_route();
 			// stuck vehicles
 			if (schedule->empty()) {
 				// no entries => no route ...

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -1392,6 +1392,9 @@ bool convoi_t::drive_to()
 			}
 		}
 
+		// unreserve old route before replacing to avoid stray reservations when rerouted
+		unreserve_route();
+
 		if(  !cached_calc_route( start, ziel, &route, schedule->get_current_entry().is_pass_stop() )  ) {
 			if(  state != NO_ROUTE  ) {
 				state = NO_ROUTE;


### PR DESCRIPTION
## 概要

鉄道の運行中に経路が変わった際、もとの線路の予約が解除されずに残ってしまう問題を修正します。経路探索キャッシュのオン・オフにかかわらず発生しますが、キャッシュがオンの場合に特に顕在化しやすい状態でした。

## 原因

`suche_neue_route()` が呼ばれると（信号遮断・線路変更・その他の経路再計算要求時）、`state = ROUTING_1` がセットされるだけで、既存の線路予約は解除されません。

その後 `drive_to()` が呼ばれ、`cached_calc_route()` によって `route` メンバが新しい経路で上書きされます。しかし、`block_reserver` によって確保された古い経路の**前方予約済み線路**（列車先頭より前方のタイル）は誰にも解除されず、そのまま残り続けます。

経路探索キャッシュがオンの場合、過去に使った経路がそのままキャッシュから返されるため、A* と比べて現在の経路との乖離が大きくなりやすく、症状が顕在化しやすい状態でした。

## 修正内容

`drive_to()` 内で `cached_calc_route()` が `route` を置き換える直前に `unreserve_route()` を呼ぶよう変更しました。これにより、古い経路の前方予約がすべて解除されます。その後、列車が走行を再開すると `block_reserver` が新しい経路に対して正しく再予約します。
