### PR TITLE
Change depot Start button to owner switch button when viewing other player's depot

### DIFF
--- a/gui/depot_frame.cc
+++ b/gui/depot_frame.cc
@@ -1500,20 +1500,7 @@ void depot_frame_t::update_data()
 	}
 	
 	
-	// update the description of start/move_to_parent_convoy button
-	// if this convoy is child convoy, start button is changed to "move to parent convoy" button.
-	if(  !is_shown_convoy_coupled  ) {
-		if( is_teleport_to_another_depot ){
-			bt_start.set_text("Teleport to Depot");
-			bt_start.set_tooltip("Teleport this convoy to another depot(defined in schedule)");
-		} else {
-			bt_start.set_text("Start");
-			bt_start.set_tooltip("Start the selected vehicle(s)");
-		}
-	} else {
-		bt_start.set_tooltip("Move to Parent Convoy");
-		bt_start.set_text("Move to Parent Convoy");
-	}
+	// start button text is updated every frame in draw()
 
 	const vehicle_desc_t *veh = NULL;
 
@@ -2147,7 +2134,9 @@ bool depot_frame_t::action_triggered( gui_action_creator_t *comp, value_t p)
 
 	if(  comp != NULL  ) { // message from outside!
 		if(  comp == &bt_start  ) {
-			if(  cnv.is_bound()  ) {
+			if(  depot->get_owner() != welt->get_active_player()  ) {
+				welt->switch_active_player(depot->get_owner()->get_player_nr(), false);
+			} else if(  cnv.is_bound()  ) {
 				// Move to Parent Convoy (Not Start Button!)
 				if(  is_shown_convoy_coupled  ) {
 					for( uint32 i=0; i<depot->get_convoy_list().get_count(); i++ ) {
@@ -2491,6 +2480,10 @@ bool depot_frame_t::infowin_event(const event_t *ev)
 {
 	// enable disable button actions
 	if(  ev->ev_class < INFOWIN  &&  (depot == NULL  ||  welt->get_active_player() != depot->get_owner()) ) {
+		// allow click events through so bt_start can switch to the depot owner
+		if(  ev->ev_class == EVENT_CLICK  ||  ev->ev_class == EVENT_RELEASE  ||  ev->ev_class == EVENT_REPEAT  ) {
+			return gui_frame_t::infowin_event(ev);
+		}
 		return false;
 	}
 
@@ -2545,11 +2538,27 @@ void depot_frame_t::draw(scr_coord pos, scr_size size)
 	const bool action_allowed = welt->get_active_player() == depot->get_owner();
 	convoihandle_t cnv = depot->get_convoi(icnv);
 
+	if(  !action_allowed  ) {
+		bt_start.set_text(depot->get_owner()->get_name());
+		bt_start.set_tooltip("move to the owner");
+	} else if(  !is_shown_convoy_coupled  ) {
+		if(  is_teleport_to_another_depot  ) {
+			bt_start.set_text("Teleport to Depot");
+			bt_start.set_tooltip("Teleport this convoy to another depot(defined in schedule)");
+		} else {
+			bt_start.set_text("Start");
+			bt_start.set_tooltip("Start the selected vehicle(s)");
+		}
+	} else {
+		bt_start.set_text("Move to Parent Convoy");
+		bt_start.set_tooltip("Move to Parent Convoy");
+	}
+
 	bt_new_line.enable( action_allowed );
 	bt_change_line.enable( action_allowed );
 	bt_copy_convoi.enable( action_allowed );
 	bt_apply_line.enable( action_allowed );
-	bt_start.enable( action_allowed  &&  cnv!=depot->get_replacement_seed() );	
+	bt_start.enable( !action_allowed  ||  cnv!=depot->get_replacement_seed() );
 	bt_schedule.enable( action_allowed );
 	bt_destroy.enable( action_allowed );
 	bt_sell.enable( action_allowed );

--- a/gui/depot_frame.cc
+++ b/gui/depot_frame.cc
@@ -704,6 +704,7 @@ DBG_DEBUG("depot_frame_t::depot_frame_t()","get_max_convoi_length()=%i",depot->g
 	gui_frame_t::set_windowsize(size);
 	set_resizemode( diagonal_resize );
 
+	last_action_allowed = (welt->get_active_player() == depot->get_owner());
 	depot->clear_command_pending();
 }
 
@@ -1500,7 +1501,25 @@ void depot_frame_t::update_data()
 	}
 	
 	
-	// start button text is updated every frame in draw()
+	// update start button text based on current active player and convoy state
+	{
+		const bool action_allowed = welt->get_active_player() == depot->get_owner();
+		if(  !action_allowed  ) {
+			bt_start.set_text(depot->get_owner()->get_name());
+			bt_start.set_tooltip("move to the owner");
+		} else if(  !is_shown_convoy_coupled  ) {
+			if(  is_teleport_to_another_depot  ) {
+				bt_start.set_text("Teleport to Depot");
+				bt_start.set_tooltip("Teleport this convoy to another depot(defined in schedule)");
+			} else {
+				bt_start.set_text("Start");
+				bt_start.set_tooltip("Start the selected vehicle(s)");
+			}
+		} else {
+			bt_start.set_text("Move to Parent Convoy");
+			bt_start.set_tooltip("Move to Parent Convoy");
+		}
+	}
 
 	const vehicle_desc_t *veh = NULL;
 
@@ -2539,20 +2558,9 @@ void depot_frame_t::draw(scr_coord pos, scr_size size)
 	const bool action_allowed = welt->get_active_player() == depot->get_owner();
 	convoihandle_t cnv = depot->get_convoi(icnv);
 
-	if(  !action_allowed  ) {
-		bt_start.set_text(depot->get_owner()->get_name());
-		bt_start.set_tooltip("move to the owner");
-	} else if(  !is_shown_convoy_coupled  ) {
-		if(  is_teleport_to_another_depot  ) {
-			bt_start.set_text("Teleport to Depot");
-			bt_start.set_tooltip("Teleport this convoy to another depot(defined in schedule)");
-		} else {
-			bt_start.set_text("Start");
-			bt_start.set_tooltip("Start the selected vehicle(s)");
-		}
-	} else {
-		bt_start.set_text("Move to Parent Convoy");
-		bt_start.set_tooltip("Move to Parent Convoy");
+	if(  action_allowed != last_action_allowed  ) {
+		last_action_allowed = action_allowed;
+		update_data();
 	}
 
 	bt_new_line.enable( action_allowed );
@@ -2572,7 +2580,20 @@ void depot_frame_t::draw(scr_coord pos, scr_size size)
 	bt_remove_all_vehicles.enable( action_allowed );
 
 	bt_paste_convoi.enable( action_allowed );
-	
+	bt_allow_invalid_convoy.enable( action_allowed );
+
+	if(  !action_allowed  ) {
+		bt_uncouple.disable();
+		bt_reverse.disable();
+		child_convoi_selector.disable();
+		vehicle_filter.disable();
+		sort_by.disable();
+	}
+	else {
+		vehicle_filter.enable();
+		sort_by.enable();
+	}
+
 	bt_replacement_seed.set_text(cnv==depot->get_replacement_seed() ? "Unregister replacement" : "Replacement seed");
 
 	// check for data inconsistencies (can happen with withdraw-all and vehicle in depot)

--- a/gui/depot_frame.cc
+++ b/gui/depot_frame.cc
@@ -2556,12 +2556,9 @@ bool depot_frame_t::infowin_event(const event_t *ev)
 void depot_frame_t::draw(scr_coord pos, scr_size size)
 {
 	const bool action_allowed = welt->get_active_player() == depot->get_owner();
+	const bool player_changed = (action_allowed != last_action_allowed);
+	last_action_allowed = action_allowed;
 	convoihandle_t cnv = depot->get_convoi(icnv);
-
-	if(  action_allowed != last_action_allowed  ) {
-		last_action_allowed = action_allowed;
-		update_data();
-	}
 
 	bt_new_line.enable( action_allowed );
 	bt_change_line.enable( action_allowed );
@@ -2596,9 +2593,11 @@ void depot_frame_t::draw(scr_coord pos, scr_size size)
 
 	bt_replacement_seed.set_text(cnv==depot->get_replacement_seed() ? "Unregister replacement" : "Replacement seed");
 
-	// check for data inconsistencies (can happen with withdraw-all and vehicle in depot)
-	if(  !cnv.is_bound()  &&  !convoi_pics.empty()  ) {
-		icnv=0;
+	// check for data inconsistencies or active-player change
+	if(  player_changed  ||  (!cnv.is_bound()  &&  !convoi_pics.empty())  ) {
+		if(  !cnv.is_bound()  &&  !convoi_pics.empty()  ) {
+			icnv = 0;
+		}
 		update_data();
 		cnv = depot->get_convoi(icnv);
 	}

--- a/gui/depot_frame.cc
+++ b/gui/depot_frame.cc
@@ -2480,8 +2480,9 @@ bool depot_frame_t::infowin_event(const event_t *ev)
 {
 	// enable disable button actions
 	if(  ev->ev_class < INFOWIN  &&  (depot == NULL  ||  welt->get_active_player() != depot->get_owner()) ) {
-		// allow click events through so bt_start can switch to the depot owner
-		if(  ev->ev_class == EVENT_CLICK  ||  ev->ev_class == EVENT_RELEASE  ||  ev->ev_class == EVENT_REPEAT  ) {
+		// allow clicks on bt_start only, so the player can switch to the depot owner
+		if(  (IS_LEFTCLICK(ev)  ||  IS_LEFTRELEASE(ev)  ||  IS_LEFTREPEAT(ev))
+		     &&  bt_start.getroffen(ev->cx, ev->cy - D_TITLEBAR_HEIGHT)  ) {
 			return gui_frame_t::infowin_event(ev);
 		}
 		return false;
@@ -2568,6 +2569,7 @@ void depot_frame_t::draw(scr_coord pos, scr_size size)
 	bt_veh_action.enable( action_allowed );
 	bt_sell_all.enable( action_allowed );
 	line_button.enable( action_allowed );
+	bt_remove_all_vehicles.enable( action_allowed );
 
 	bt_paste_convoi.enable( action_allowed );
 	

--- a/gui/depot_frame.h
+++ b/gui/depot_frame.h
@@ -123,6 +123,8 @@ private:
 	bool is_shown_convoy_coupled;
 	// When this flag is true, this convoy will be teleported to another depot set in schedule.
 	bool is_teleport_to_another_depot;
+	// cached value of (active_player == depot_owner) from the previous draw() call; used to detect player switches
+	bool last_action_allowed;
 
 	button_t bt_obsolete;
 	button_t bt_show_all;


### PR DESCRIPTION
## 概要

編成詳細ウインドウの「スケジュール」ボタンと同様に、他社の車庫を開いたとき「スタート」ボタンをその車庫の保有会社に切り替えるボタンに変更します。

## 変更内容

- 他社の車庫を表示中、「スタート」ボタンのラベルをその車庫のオーナー会社名に変更し、ツールチップを "move to the owner" に設定する
- ボタンをクリックすると `switch_active_player` によりそのオーナー会社に切り替わる
- 自社の車庫に戻ると、ボタンは通常の「スタート」／「Teleport to Depot」／「Move to Parent Convoy」に戻る

## 実装の詳細

- ボタンテキストの更新を `update_data()` から `draw()` に移動し、アクティブプレイヤーの切替に即座に追従するようにした
- `infowin_event` の他社ブロック処理に例外を追加し、クリック・リリース・リピートイベントのみ通過させることでボタンを押せるようにした
- `bt_start` の `enable` 条件を修正し、他社の車庫でもグレーアウトしないようにした
