### PR TITLE
BUG FIX: fix finance chart margin curve exceeding drawing area

### DIFF
--- a/gui/components/gui_chart.cc
+++ b/gui/components/gui_chart.cc
@@ -202,8 +202,9 @@ void gui_chart_t::draw(scr_coord offset)
 				}
 				else if(  c.type==PERCENT  ) {
 					display_tmp = tmp*0.01;
-					tmp /= 100;  // 0..100
-					y_off = (long)((double)tmp * chart_size.h / 100.0);
+					tmp /= 100;
+					if(  tmp > 100  ) { tmp = 100; }
+					y_off = (long)(tmp/scale);
 				}
 				else if(  c.type!=0  ) {
 					display_tmp = tmp*0.01;
@@ -309,11 +310,24 @@ void gui_chart_t::calc_gui_chart_values(sint64 *baseline, double *scale, char *c
 						max_suffix = c.suffix;
 					}
 				}
-				else if(  c.type==2 || !env_t::show_yen ) {
+				else if(  c.type==2  ) {
+					tmp /= 100;
+					if (min > tmp) {
+						min = tmp;
+						precision = c.precision;
+						min_suffix = c.suffix;
+					}
+					if (max < 100) {
+						max = 100;
+						precision = c.precision;
+						max_suffix = c.suffix;
+					}
+				}
+				else if(  !env_t::show_yen  ) {
 					tmp /= 100;
 					precision = 0;
 					if (min > tmp) {
-						min = tmp ;
+						min = tmp;
 						precision = c.precision;
 						min_suffix = c.suffix;
 					}


### PR DESCRIPTION
## Summary

- `gui_chart_t` の `PERCENT` 型カーブが描画範囲を超えて表示されるバグを修正
- 利益率が100%を超える場合、または負の利益率が存在する場合に発生
- Y軸上限を100%固定とし、100%超の値はグラフ上端にクランプして表示

## Root cause

`draw()` 内の `PERCENT` 型カーブの `y_off` は固定スケール
(`chart_size.h / 100.0`) で計算されていた一方、`baseline` は
`calc_gui_chart_values()` でデータの実際のmin/maxから動的に計算されており、
2つのスケールが一致しないため描画位置がずれていた。

## Changes

- `draw()`: `PERCENT` 型の `y_off` を固定スケールから動的 `scale` に変更し、
  100%超の値を100にクランプ
- `calc_gui_chart_values()`: `PERCENT` (type==2) を `MONEY` (!show_yen) と
  分離し、`max` を常に100以上に固定することでY軸ラベル上限を100%とする
