### PR TITLE
tool_build_tunnel_t and tool_build_bridge_t use called_from_move flag

### DIFF
--- a/simmenu.cc
+++ b/simmenu.cc
@@ -1444,6 +1444,9 @@ const char *two_click_tool_t::move(player_t *player, uint16 buttonstate, koord3d
 		} else if(tool_build_tunnel_t* tt = dynamic_cast<tool_build_tunnel_t*>(this)) {
 			// This is tool_build_tunnel_t. The mode selection window should not be called.
 			tt->init( player, true );
+		} else if(tool_build_wayobj_t* two = dynamic_cast<tool_build_wayobj_t*>(this)) {
+			// This is tool_build_wayobj_t. The mode selection window should not be called.
+			two->init( player, true );
 		} else {
 			init( player );
 		}

--- a/simmenu.cc
+++ b/simmenu.cc
@@ -1438,6 +1438,12 @@ const char *two_click_tool_t::move(player_t *player, uint16 buttonstate, koord3d
 		if(tool_build_way_t* t = dynamic_cast<tool_build_way_t*>(this)) {
 			// This is tool_build_way_t. The mode selection window should not be called.
 			t->init( player, true );
+		} else if(tool_build_bridge_t* tb = dynamic_cast<tool_build_bridge_t*>(this)) {
+			// This is tool_build_bridge_t. The mode selection window should not be called.
+			tb->init( player, true );
+		} else if(tool_build_tunnel_t* tt = dynamic_cast<tool_build_tunnel_t*>(this)) {
+			// This is tool_build_tunnel_t. The mode selection window should not be called.
+			tt->init( player, true );
 		} else {
 			init( player );
 		}

--- a/simtool.cc
+++ b/simtool.cc
@@ -4288,11 +4288,11 @@ bool tool_build_wayobj_t::is_selected() const
 	return (selected  &&  selected->build==build  &&  selected->get_desc() == get_desc());
 }
 
-bool tool_build_wayobj_t::init( player_t *player )
+bool tool_build_wayobj_t::init( player_t *player, bool called_from_move )
 {
 	two_click_tool_t::init( player );
 
-	if (is_ctrl_pressed()  &&  can_use_gui()) {
+	if (  !called_from_move  &&  is_ctrl_pressed()  &&  can_use_gui()  ) {
 		create_win(new wayobj_spacing_frame_t(player, this), w_info, (ptrdiff_t)this);
 	}
 

--- a/simtool.cc
+++ b/simtool.cc
@@ -3337,7 +3337,7 @@ waytype_t tool_build_bridge_t::get_waytype() const
 }
 
 
-bool tool_build_bridge_t::init( player_t *player )
+bool tool_build_bridge_t::init( player_t *player, bool called_from_move )
 {
 	two_click_tool_t::init( player );
 	// now get current desc
@@ -3345,7 +3345,7 @@ bool tool_build_bridge_t::init( player_t *player )
 	if(  desc  &&  !desc->is_available(welt->get_timeline_year_month())  &&  player!=NULL  &&  player!=welt->get_public_player()  ) {
 		return false;
 	}
-	if (is_ctrl_pressed()  &&  can_use_gui()  ) {
+	if (  !called_from_move  &&  is_ctrl_pressed()  &&  can_use_gui()  ) {
 		create_win(new overtaking_mode_frame_t(player, this), w_info, (ptrdiff_t)this);
 	}
 	return desc!=NULL;
@@ -3629,7 +3629,7 @@ waytype_t tool_build_tunnel_t::get_waytype() const
 }
 
 
-bool tool_build_tunnel_t::init( player_t *player )
+bool tool_build_tunnel_t::init( player_t *player, bool called_from_move )
 {
 	two_click_tool_t::init( player );
 	// now get current desc
@@ -3637,7 +3637,7 @@ bool tool_build_tunnel_t::init( player_t *player )
 	if(  desc  &&  !desc->is_available(welt->get_timeline_year_month())  &&  player!=NULL  &&  player!=welt->get_public_player()  ) {
 		return false;
 	}
-	if (is_ctrl_pressed()  &&  can_use_gui()  ) {
+	if (  !called_from_move  &&  is_ctrl_pressed()  &&  can_use_gui()  ) {
 		create_win(new overtaking_mode_frame_t(player, this), w_info, (ptrdiff_t)this);
 	}
 	return desc!=NULL;

--- a/simtool.h
+++ b/simtool.h
@@ -474,7 +474,8 @@ public:
 	tool_build_wayobj_t(uint16 const id = TOOL_BUILD_WAYOBJ | GENERAL_TOOL, bool b = true) : two_click_tool_t(id), build(b) {}
 	char const* get_tooltip(player_t const*) const OVERRIDE;
 	bool is_selected() const OVERRIDE;
-	bool init(player_t*) OVERRIDE;
+	bool init(player_t* player) OVERRIDE { return init(player, false); }
+	bool init(player_t*,bool called_from_move);
 	bool exit(player_t*) OVERRIDE;
 	void rdwr_custom_data(memory_rw_t *packet) OVERRIDE;
 	void draw_after(scr_coord, bool dirty) const OVERRIDE;

--- a/simtool.h
+++ b/simtool.h
@@ -386,7 +386,8 @@ public:
 	waytype_t get_waytype() const OVERRIDE;
 	bool remove_preview_necessary() const OVERRIDE { return !is_first_click(); }
 	void rdwr_custom_data(memory_rw_t*) OVERRIDE;
-	bool init(player_t*) OVERRIDE;
+	bool init(player_t* player) OVERRIDE { return init(player, false); }
+	bool init(player_t*,bool called_from_move);
 	bool exit(player_t*) OVERRIDE;
 	void draw_after(scr_coord, bool dirty) const OVERRIDE;
 	void set_overtaking_mode(overtaking_mode_t ov) { overtaking_mode = ov; }
@@ -422,7 +423,8 @@ public:
 	waytype_t get_waytype() const OVERRIDE;
 	bool remove_preview_necessary() const OVERRIDE { return !is_first_click(); }
 	void rdwr_custom_data(memory_rw_t*) OVERRIDE;
-	bool init(player_t*) OVERRIDE;
+	bool init(player_t* player) OVERRIDE { return init(player, false); }
+	bool init(player_t*,bool called_from_move);
 	bool exit(player_t*) OVERRIDE;
 	void draw_after(scr_coord, bool dirty) const OVERRIDE;
 	void set_overtaking_mode(overtaking_mode_t ov) { overtaking_mode = ov; }


### PR DESCRIPTION
`tool_build_tunnel_t`および`tool_build_bridge_t`においても`init()`において`called_from_move`を使用することで、トンネルポータルのみ建設時等の`ctrl`キーを押しながらの動作時に追い越し設定ウィンドウが表示される不具合を修正します