### PR TITLE
sync reverse_base_offset

### DIFF
--- a/dataobj/environment.cc
+++ b/dataobj/environment.cc
@@ -713,6 +713,3 @@ sint8 env_t::driveleft_base_offsets[8][2];
 // the reading method is in setting_t, and these parameters are used in vehicle_t.
 sint8 env_t::overtaking_base_offsets[8][2];
 
-// Graphical offsets for reverseing vehicles
-// the reading method is in setting_t, and these parameters are used in vehicle_t.
-sint8 env_t::reverse_base_offsets[8][3];

--- a/dataobj/environment.h
+++ b/dataobj/environment.h
@@ -571,17 +571,6 @@ public:
 	// overtaking offset
 	static sint8 overtaking_base_offsets[8][2];
 
-	// Graphical offsets for reverseing vehicles
-	// [directions][offsets]
-	// directions:{"south", "west", "southwest", "southeast", "north", "east", "northeast", "northwest"}
-	// offsets   :{x_offset,y_offset,length_offset}
-	// these parameters are written in simuconf.tab, such as:
-	// 	reverse_base_offset_east = 0, 0, 18
-	// 	reverse_base_offset_west = 0, 2, 14 
-	//
-	// Write the 8 directions in characters and the amount of offset in numbers with 3 components.
-	// the reading method is in setting_t, and these parameters are used in vehicle_t.
-	static sint8 reverse_base_offsets[8][3];
 	// define reversible waytype
 	static bool reversible_waytype(waytype_t w) {
 		return	w!=waytype_t::invalid_wt&&

--- a/dataobj/settings.cc
+++ b/dataobj/settings.cc
@@ -1102,6 +1102,37 @@ void settings_t::rdwr(loadsave_t *file)
 		if (file->is_version_atleast(124, 4)||file->get_OTRP_version()>=54) {
 			file->rdwr_long(cst_kw_per_credit);
 		}
+		if(  file->get_OTRP_version() >= 56  ) {
+			// network clients must use the server's values; others always use simuconf.tab
+			// (parse_simuconf has already set the field, so non-clients just skip reading)
+			const bool use_local = !env_t::networkmode  ||  env_t::server;
+			if(  use_local  ) {
+				// write local simuconf.tab values so the server can sync them to clients
+				// on load, skip reading so the parse_simuconf values remain
+				if(  file->is_saving()  ) {
+					for(uint8 d = 0; d < 8; d++) {
+						for(uint8 i = 0; i < 3; i++) {
+							file->rdwr_byte(reverse_base_offsets[d][i]);
+						}
+					}
+				} else {
+					// skip the 24 bytes in the stream
+					for(uint8 d = 0; d < 8; d++) {
+						for(uint8 i = 0; i < 3; i++) {
+							sint8 dummy;
+							file->rdwr_byte(dummy);
+						}
+					}
+				}
+			} else {
+				for(uint8 d = 0; d < 8; d++) {
+					for(uint8 i = 0; i < 3; i++) {
+						file->rdwr_byte(reverse_base_offsets[d][i]);
+					}
+				}
+			}
+		}
+		// v<56: values were never saved; parse_simuconf already set them from simuconf.tab
 		// otherwise the default values of the last one will be used
 	}
 	// sometimes broken savegames could have no legal direction for take off ...
@@ -1214,12 +1245,12 @@ void settings_t::parse_simuconf( tabfile_t& simuconf, sint16& disp_width, sint16
 		vector_tpl<int> temp_offset = contents.get_ints(buf);
 		if (temp_offset.get_count()>=3) {
 			for(uint8 i=0; i<3; i++) {
-				env_t::reverse_base_offsets[d_idx][i] = temp_offset[i];
+				reverse_base_offsets[d_idx][i] = temp_offset[i];
 			}
 		} else {
 			for(uint8 i=0; i<3; i++) {
-				env_t::reverse_base_offsets[d_idx][i] = 0;
-			}			
+				reverse_base_offsets[d_idx][i] = 0;
+			}
 		}
 	}
 	// setting default reverse or not when next direction is opposite

--- a/dataobj/settings.cc
+++ b/dataobj/settings.cc
@@ -338,6 +338,7 @@ settings_t::settings_t() :
 	base_waiting_ticks_for_ship_convoi = 60000;
 	base_waiting_ticks_for_air_convoi = 200000;
 
+	MEMZERON(reverse_base_offsets, 8);
 	default_reverse=false;
 	allow_unload_longer_convoy=false;
 	allow_higher_flight = true;

--- a/dataobj/settings.h
+++ b/dataobj/settings.h
@@ -384,6 +384,10 @@ private:
 	// can unload cargo even if stop length is too short
 	bool allow_unload_longer_convoy;
 
+	// Graphical and step offsets for reversing vehicles
+	// [direction][offset]: direction order matches ribi_t::dir, offsets are {x, y, length_steps}
+	sint8 reverse_base_offsets[8][3];
+
 public:
 	/* the big cost section */
 	sint32 maint_building; // normal building
@@ -770,6 +774,8 @@ public:
 	bool is_default_reverse() const {return default_reverse;}
 	// allow unload longer convoy
 	bool is_allow_unload_longer_convoy() const { return allow_unload_longer_convoy; }
+	// get reverse base offsets for a given direction
+	const sint8* get_reverse_base_offsets(uint8 dir) const { return reverse_base_offsets[dir]; }
 
 	bool is_using_route_cache() const { return use_route_cache; }
 };

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -1079,15 +1079,16 @@ void vehicle_t::get_screen_offset( int &xoff, int &yoff, const sint16 raster_wid
 	}
 	// Add offset when the vehicle is reversed.
 	sint32 steps_delta;
-	steps_delta = raster_width*(VEHICLE_STEPS_PER_TILE / 2 - get_desc()->get_length_in_steps() + env_t::reverse_base_offsets[dir][2]);
+	const sint8* rbo = welt->get_settings().get_reverse_base_offsets(dir);
+	steps_delta = raster_width*(VEHICLE_STEPS_PER_TILE / 2 - get_desc()->get_length_in_steps() + rbo[2]);
 	if(dx && dy) {
 		steps_delta &= 0xFFFFFC00;
 	}
 	else {
 		steps_delta = (steps_delta*diagonal_multiplier)>>10;
 	}
-	xoff += ((steps_delta*dx) >> 10) + tile_raster_scale_x(env_t::reverse_base_offsets[dir][0],raster_width);
-	yoff += ((steps_delta*dy) >> 10) + tile_raster_scale_y(env_t::reverse_base_offsets[dir][1],raster_width);
+	xoff += ((steps_delta*dx) >> 10) + tile_raster_scale_x(rbo[0],raster_width);
+	yoff += ((steps_delta*dy) >> 10) + tile_raster_scale_y(rbo[1],raster_width);
 }
 
 
@@ -4760,7 +4761,7 @@ bool rail_vehicle_t::can_couple(const route_t* route, uint16 start_index, uint16
 			cnv->set_convoi_coupling_in_progress(coupling_target);
 			coupling_index = i;
 			// if the target vehicle overlaps another tile, fix index and steps
-			c_step -= ((coupling_target_ribi&dir)==0) ? env_t::reverse_base_offsets[ribi_t::get_dir(coupling_target_ribi)][2] + VEHICLE_STEPS_PER_TILE / 2 : 0;
+			c_step -= ((coupling_target_ribi&dir)==0) ? welt->get_settings().get_reverse_base_offsets(ribi_t::get_dir(coupling_target_ribi))[2] + VEHICLE_STEPS_PER_TILE / 2 : 0;
 			while(c_step<0&&coupling_index>0) {
 				coupling_index--;
 				grund_t* gr_coupling = welt->lookup(route->at(coupling_index));


### PR DESCRIPTION
`reverse_base_offset`は現在`env_t`に保存されていますが、`rail_vehicle_t`において`coupling_index`等の計算に使用する値であるため、サーバーと同期する必要があります。そこで、本データをセーブデータにも記載することとします。
ただし、そのままでは`simuconf.tab`を弄ってもセーブデータに反映されなくなるため、ゲームロード時は原則`simuconf.tab`で定義された値を使用し、ネットワークモードの時のみ同期する形とします（セーブデータの互換性のため、セーブ時には常にこの値を記録します）