### PR TITLE
always ask password even when public player unlocked

### DIFF
--- a/network/network_cmd_ingame.cc
+++ b/network/network_cmd_ingame.cc
@@ -578,10 +578,6 @@ bool nwc_auth_player_t::execute(karte_t *welt)
 				}
 			}
 			else if (player_nr < PLAYER_UNOWNED) {
-				// players with public service player access always pass password checks
-				if(  info.is_player_unlocked(1)  ) {
-					info.unlock_player(player_nr);
-				}
 				// check password
 				else if (welt->get_player(player_nr)->access_password_hash() == hash) {
 

--- a/network/network_cmd_ingame.cc
+++ b/network/network_cmd_ingame.cc
@@ -579,7 +579,7 @@ bool nwc_auth_player_t::execute(karte_t *welt)
 			}
 			else if (player_nr < PLAYER_UNOWNED) {
 				// check password
-				else if (welt->get_player(player_nr)->access_password_hash() == hash) {
+				if (welt->get_player(player_nr)->access_password_hash() == hash) {
 
 					dbg->message("nwc_auth_player_t::execute","unlock plnr = %d at our_client_id = %d", player_nr, our_client_id);
 


### PR DESCRIPTION
ネットワークモードにおいて、公共事業が鍵がかかっていない場合に、他のパスワードが掛かっているプレイヤーを操作してもパスワード認証要求がされない不具合を修正しました。
※これにより、パスワードのかかっているプレイヤーをサーバー管理者等が操作する場合は、原則として`nettool`によるパスワード解除操作が必要になります。