### PR TITLE
halt on the slopetile

### DIFF
--- a/bauer/hausbauer.cc
+++ b/bauer/hausbauer.cc
@@ -610,19 +610,32 @@ gebaeude_t *hausbauer_t::build_station_extension_depot(player_t *player, koord3d
 
 		int layout = built_layout & 9;
 
+		// Height of each edge of the current tile relative to the tile's base z.
+		// For flat tiles all z_delta values are 0, so behaviour is unchanged.
+		// For slope tiles the primary lookup is at the correct edge height, and
+		// the fallback also catches slope-stop neighbours one level below.
+		const slope_t::type cur_slope = welt->lookup( pos )->get_weg_hang();
+		const int z_delta_far = (layout & 1)
+		    ? max( corner_ne(cur_slope), corner_se(cur_slope) )   // EW: east edge
+		    : max( corner_sw(cur_slope), corner_se(cur_slope) );  // NS: south edge
+		const int z_delta_near = (layout & 1)
+		    ? max( corner_nw(cur_slope), corner_sw(cur_slope) )   // EW: west edge
+		    : max( corner_nw(cur_slope), corner_ne(cur_slope) );  // NS: north edge
+
 		// detect if we are connected at far (north/west) end
 		sint8 offset = welt->lookup( pos )->get_weg_yoff()/TILE_HEIGHT_STEP;
-		koord3d checkpos = pos+koord3d( (layout & 1 ? koord::east : koord::south), offset);
+		koord3d checkpos = pos+koord3d( (layout & 1 ? koord::east : koord::south), offset+z_delta_far);
 		grund_t * gr = welt->lookup( checkpos );
 
 		if(!gr) {
-			// check whether bridge end tile
-			grund_t * gr_tmp = welt->lookup( pos+koord3d( (layout & 1 ? koord::east : koord::south),offset - 1) );
-			if(gr_tmp && gr_tmp->get_weg_yoff()/TILE_HEIGHT_STEP == 1) {
+			// Bridge end tile or downslope continuation one level below the edge.
+			grund_t * gr_tmp = welt->lookup( pos+koord3d( (layout & 1 ? koord::east : koord::south), offset+z_delta_far-1) );
+			if(gr_tmp && (gr_tmp->get_weg_yoff()/TILE_HEIGHT_STEP == 1
+			              || (z_delta_far == 0 && slope_t::is_single( gr_tmp->get_weg_hang() )))) {
 				gr = gr_tmp;
 			}
 			else {
-				gr_tmp = welt->lookup( pos+koord3d( (layout & 1 ? koord::east : koord::south),offset - 2) );
+				gr_tmp = welt->lookup( pos+koord3d( (layout & 1 ? koord::east : koord::south), offset+z_delta_far-2) );
 				if(gr_tmp && gr_tmp->get_weg_yoff()/TILE_HEIGHT_STEP == 2) {
 					gr = gr_tmp;
 				}
@@ -648,11 +661,18 @@ gebaeude_t *hausbauer_t::build_station_extension_depot(player_t *player, koord3d
 				corner_layout &= ~2; // clear near bit
 				const koord xy = gb->get_tile()->get_offset();
 				uint8 layoutbase = gb->get_tile()->get_layout();
-				if(  layoutbase>=16  ) {
+				if(  layoutbase>=48  &&  gb->get_tile()->get_desc()->get_all_layouts()>48  ) {
+					// slope stop neighbour - preserve slope offset bits
+					if(  (layoutbase & 1) == (layout & 1)  ) {
+						const uint8 slope_p = layoutbase & 0xF0;
+						layoutbase = slope_p | ((layoutbase & 0x0F) & 0x0b);
+					}
+				}
+				else if(  layoutbase>=16  ) {
 					if(  (layoutbase & 0x30) == 0x10  ) {
 						// vertical diagonal. 010->000, 011->001
 						layoutbase &= ~2;
-					} 
+					}
 					else if(  (layoutbase & 6) != 6  ) {
 						// horizontal diagonal. 011->001, 101->001
 						layoutbase &= ~6;
@@ -668,15 +688,16 @@ gebaeude_t *hausbauer_t::build_station_extension_depot(player_t *player, koord3d
 		}
 
 		// detect if near (south/east) end
-		gr = welt->lookup( pos+koord3d( (layout & 1 ? koord::west : koord::north), offset) );
+		gr = welt->lookup( pos+koord3d( (layout & 1 ? koord::west : koord::north), offset+z_delta_near) );
 		if(!gr) {
-			// check whether bridge end tile
-			grund_t * gr_tmp = welt->lookup( pos+koord3d( (layout & 1 ? koord::west : koord::north),offset - 1) );
-			if(gr_tmp && gr_tmp->get_weg_yoff()/TILE_HEIGHT_STEP == 1) {
+			// Bridge end tile or downslope continuation one level below the edge.
+			grund_t * gr_tmp = welt->lookup( pos+koord3d( (layout & 1 ? koord::west : koord::north), offset+z_delta_near-1) );
+			if(gr_tmp && (gr_tmp->get_weg_yoff()/TILE_HEIGHT_STEP == 1
+			              || (z_delta_near == 0 && slope_t::is_single( gr_tmp->get_weg_hang() )))) {
 				gr = gr_tmp;
 			}
 			else {
-				gr_tmp = welt->lookup( pos+koord3d( (layout & 1 ? koord::west : koord::north),offset - 2) );
+				gr_tmp = welt->lookup( pos+koord3d( (layout & 1 ? koord::west : koord::north), offset+z_delta_near-2) );
 				if(gr_tmp && gr_tmp->get_weg_yoff()/TILE_HEIGHT_STEP == 2) {
 					gr = gr_tmp;
 				}
@@ -688,11 +709,18 @@ gebaeude_t *hausbauer_t::build_station_extension_depot(player_t *player, koord3d
 				corner_layout &= ~4; // clear far bit
 				const koord xy = gb->get_tile()->get_offset();
 				uint8 layoutbase = gb->get_tile()->get_layout();
-				if(  layoutbase>=16  ) {
+				if(  layoutbase>=48  &&  gb->get_tile()->get_desc()->get_all_layouts()>48  ) {
+					// slope stop neighbour - preserve slope offset bits
+					if(  (layoutbase & 1) == (layout & 1)  ) {
+						const uint8 slope_p = layoutbase & 0xF0;
+						layoutbase = slope_p | ((layoutbase & 0x0F) & 0x0d);
+					}
+				}
+				else if(  layoutbase>=16  ) {
 					if(  (layoutbase & 0x30) == 0x10  ) {
 						// vertical diagonal. 100->000, 101->001
 						layoutbase &= ~4;
-					} 
+					}
 					else if(  (layoutbase & 6) != 6  ) {
 						// horizontal diagonal. 010->000, 100->100
 						layoutbase &= ~6;
@@ -735,17 +763,28 @@ gebaeude_t* hausbauer_t::build_station_on_diagonal_way(player_t* player, koord3d
 	
 	// calculate neighbour_diagonal_stops
 	const sint8 offset = bd->get_hoehe()+bd->get_weg_yoff()/TILE_HEIGHT_STEP;
+	// Per-direction edge heights relative to the tile base (NESW order matching koord::nesw[]).
+	// For flat tiles all values are 0. For slope tiles the neighbour must be looked up at
+	// offset + z_delta[i] so that uphill and downhill connections are found correctly.
+	const slope_t::type diag_slope = bd->get_weg_hang();
+	const int z_delta[4] = {
+		max( corner_nw(diag_slope), corner_ne(diag_slope) ),  // N (i=0)
+		max( corner_ne(diag_slope), corner_se(diag_slope) ),  // E (i=1)
+		max( corner_sw(diag_slope), corner_se(diag_slope) ),  // S (i=2)
+		max( corner_nw(diag_slope), corner_sw(diag_slope) )   // W (i=3)
+	};
 	grund_t *gr;
 	gebaeude_t* neighbour_diagonal_stops[] = {NULL, NULL, NULL, NULL};
 	const koord pos_2d = bd->get_pos().get_2d();
 	for(  unsigned i=0;  i<4;  i++  ) {
 		// oriented buildings here - get neighbouring layouts
-		gr = world()->lookup(koord3d(pos_2d+koord::nesw[i],offset));
+		gr = world()->lookup(koord3d(pos_2d+koord::nesw[i], offset+z_delta[i]));
 		if(  !gr  ) {
-			// check whether bridge end tile
-			grund_t * gr_off1 = world()->lookup(koord3d(pos_2d+koord::nesw[i],offset-1));
-			grund_t * gr_off2 = world()->lookup(koord3d(pos_2d+koord::nesw[i],offset-2));
-			if(gr_off1 && gr_off1->get_weg_yoff()/TILE_HEIGHT_STEP == 1) {
+			// Bridge end tile or downslope continuation one level below the edge.
+			grund_t * gr_off1 = world()->lookup(koord3d(pos_2d+koord::nesw[i], offset+z_delta[i]-1));
+			grund_t * gr_off2 = world()->lookup(koord3d(pos_2d+koord::nesw[i], offset+z_delta[i]-2));
+			if(gr_off1 && (gr_off1->get_weg_yoff()/TILE_HEIGHT_STEP == 1
+			               || (z_delta[i] == 0 && slope_t::is_single( gr_off1->get_weg_hang() )))) {
 				gr = gr_off1;
 			}
 			else if(gr_off2 && gr_off2->get_weg_yoff()/TILE_HEIGHT_STEP == 2) {
@@ -807,6 +846,172 @@ gebaeude_t* hausbauer_t::build_station_on_diagonal_way(player_t* player, koord3d
 	
 	const uint8 layout = diagonal_direction_bits | front_back_bit | (corner_bits << 1) | way_connection_dir_bits;
 	return build_station_extension_depot_with_complete_layout_bits(player, pos, layout, desc, &halt);
+}
+
+
+gebaeude_t* hausbauer_t::build_station_on_slope_way(player_t* player, koord3d pos, int built_layout, const building_desc_t* desc, halthandle_t halt)
+{
+	uint8 corner_layout = 6; // assume single building (for more than 4 layouts)
+
+	// Slope of the current tile: needed for both neighbor lookup and slope-image offset.
+	const slope_t::type slope = welt->lookup( pos )->get_weg_hang();
+
+	// adjust layout of neighbouring buildings (same logic as build_station_extension_depot)
+	if(  desc->is_transport_building()  &&  desc->get_all_layouts()>1  ) {
+
+		int layout = built_layout & 9;
+
+		sint8 offset = welt->lookup( pos )->get_weg_yoff()/TILE_HEIGHT_STEP;
+
+		// Height of each edge of the current slope tile relative to the tile's base z.
+		// For NS way (layout bit 0 == 0): far block checks south edge, near block checks north edge.
+		// For EW way (layout bit 0 == 1): far block checks east  edge, near block checks west  edge.
+		// corner_xx macros return 0..2 (single slope = 1, double = 2).
+		const int z_delta_far = (layout & 1)
+		    ? max( corner_ne(slope), corner_se(slope) )   // EW: east edge
+		    : max( corner_sw(slope), corner_se(slope) );  // NS: south edge
+		const int z_delta_near = (layout & 1)
+		    ? max( corner_nw(slope), corner_sw(slope) )   // EW: west edge
+		    : max( corner_nw(slope), corner_ne(slope) );  // NS: north edge
+
+		// detect far (north/west) end neighbor
+		koord3d checkpos = pos+koord3d( (layout & 1 ? koord::east : koord::south), offset+z_delta_far);
+		grund_t *gr = welt->lookup( checkpos );
+		if(  !gr  ) {
+			// One level below the edge: bridge end (elevated way) or downslope continuation.
+			grund_t *gr_tmp = welt->lookup( pos+koord3d( (layout & 1 ? koord::east : koord::south), offset+z_delta_far-1) );
+			if(  gr_tmp  &&  (gr_tmp->get_weg_yoff()/TILE_HEIGHT_STEP == 1
+			                  ||  (z_delta_far == 0  &&  slope_t::is_single( gr_tmp->get_weg_hang() )))  ) {
+				gr = gr_tmp;
+			}
+			else {
+				gr_tmp = welt->lookup( pos+koord3d( (layout & 1 ? koord::east : koord::south), offset+z_delta_far-2) );
+				if(  gr_tmp  &&  gr_tmp->get_weg_yoff()/TILE_HEIGHT_STEP == 2  ) {
+					gr = gr_tmp;
+				}
+			}
+		}
+		if(  gr  ) {
+			gebaeude_t *gb = gr->find<gebaeude_t>();
+			if(  gb==NULL  ) {
+				const planquadrat_t *pl = welt->access( checkpos.get_2d() );
+				if(  pl  ) {
+					for(  uint8 i=0;  i<pl->get_boden_count();  i++  ) {
+						gr = pl->get_boden_bei(i);
+						if(  gr->is_halt()  &&  gr->get_halt().is_bound()  ) {
+							break;
+						}
+					}
+				}
+				gb = gr->find<gebaeude_t>();
+			}
+			if(  gb  &&  gb->get_tile()->get_desc()->is_transport_building()  ) {
+				corner_layout &= ~2; // clear near bit
+				const koord xy = gb->get_tile()->get_offset();
+				uint8 layoutbase = gb->get_tile()->get_layout();
+				if(  layoutbase>=48  &&  gb->get_tile()->get_desc()->get_all_layouts()>48  ) {
+					// slope stop neighbour - preserve slope offset bits
+					if(  (layoutbase & 1) == (layout & 1)  ) {
+						const uint8 slope_p = layoutbase & 0xF0;
+						layoutbase = slope_p | ((layoutbase & 0x0F) & 0x0b);
+					}
+				}
+				else if(  layoutbase>=16  ) {
+					if(  (layoutbase & 0x30) == 0x10  ) {
+						layoutbase &= ~2;
+					}
+					else if(  (layoutbase & 6) != 6  ) {
+						layoutbase &= ~6;
+					}
+				}
+				else if(  gb->get_tile()->get_desc()->get_all_layouts()>4  ) {
+					if(  (layoutbase & 1) == (layout & 1)  ) {
+						layoutbase &= 0x0b;
+					}
+				}
+				gb->set_tile( gb->get_tile()->get_desc()->get_tile(layoutbase, xy.x, xy.y), false );
+			}
+		}
+
+		// detect near (south/east) end neighbor
+		gr = welt->lookup( pos+koord3d( (layout & 1 ? koord::west : koord::north), offset+z_delta_near) );
+		if(  !gr  ) {
+			// One level below the edge: bridge end (elevated way) or downslope continuation.
+			grund_t *gr_tmp = welt->lookup( pos+koord3d( (layout & 1 ? koord::west : koord::north), offset+z_delta_near-1) );
+			if(  gr_tmp  &&  (gr_tmp->get_weg_yoff()/TILE_HEIGHT_STEP == 1
+			                  ||  (z_delta_near == 0  &&  slope_t::is_single( gr_tmp->get_weg_hang() )))  ) {
+				gr = gr_tmp;
+			}
+			else {
+				gr_tmp = welt->lookup( pos+koord3d( (layout & 1 ? koord::west : koord::north), offset+z_delta_near-2) );
+				if(  gr_tmp  &&  gr_tmp->get_weg_yoff()/TILE_HEIGHT_STEP == 2  ) {
+					gr = gr_tmp;
+				}
+			}
+		}
+		if(  gr  ) {
+			gebaeude_t *gb = gr->find<gebaeude_t>();
+			if(  gb  &&  gb->get_tile()->get_desc()->is_transport_building()  ) {
+				corner_layout &= ~4; // clear far bit
+				const koord xy = gb->get_tile()->get_offset();
+				uint8 layoutbase = gb->get_tile()->get_layout();
+				if(  layoutbase>=48  &&  gb->get_tile()->get_desc()->get_all_layouts()>48  ) {
+					// slope stop neighbour - preserve slope offset bits
+					if(  (layoutbase & 1) == (layout & 1)  ) {
+						const uint8 slope_p = layoutbase & 0xF0;
+						layoutbase = slope_p | ((layoutbase & 0x0F) & 0x0d);
+					}
+				}
+				else if(  layoutbase>=16  ) {
+					if(  (layoutbase & 0x30) == 0x10  ) {
+						layoutbase &= ~4;
+					}
+					else if(  (layoutbase & 6) != 6  ) {
+						layoutbase &= ~6;
+					}
+				}
+				else if(  gb->get_tile()->get_desc()->get_all_layouts()>4  ) {
+					if(  (layoutbase & 1) == (layout & 1)  ) {
+						layoutbase &= 0x0d;
+					}
+				}
+				gb->set_tile( gb->get_tile()->get_desc()->get_tile(layoutbase, xy.x, xy.y), false );
+			}
+		}
+	}
+
+	// apply corner bits to the flat part of the layout
+	// use min(48, all_layouts) so the modulo stays within the flat image range
+	const int flat_count = min( 48, (int)desc->get_all_layouts() );
+	if(  flat_count > 4  ) {
+		built_layout = (corner_layout | (built_layout & 9)) % flat_count;
+	}
+
+	// determine slope image offset:
+	//   N or W single-height  => +48
+	//   S or E single-height  => +64
+	//   N or W double-height  => +80
+	//   S or E double-height  => +96
+	int slope_offset = 0;
+	if(  slope == slope_t::north  ||  slope == slope_t::west  ) {
+		slope_offset = 48;
+	}
+	else if(  slope == slope_t::south  ||  slope == slope_t::east  ) {
+		slope_offset = 64;
+	}
+	else if(  slope == (slope_t::type)(slope_t::north*2)  ||  slope == (slope_t::type)(slope_t::west*2)  ) {
+		slope_offset = 80;
+	}
+	else if(  slope == (slope_t::type)(slope_t::south*2)  ||  slope == (slope_t::type)(slope_t::east*2)  ) {
+		slope_offset = 96;
+	}
+
+	// use slope image only when the descriptor defines one for this layout
+	if(  slope_offset > 0  &&  built_layout + slope_offset < (int)desc->get_all_layouts()  ) {
+		built_layout += slope_offset;
+	}
+
+	return build_station_extension_depot_with_complete_layout_bits( player, pos, built_layout, desc, &halt );
 }
 
 

--- a/bauer/hausbauer.cc
+++ b/bauer/hausbauer.cc
@@ -610,53 +610,43 @@ gebaeude_t *hausbauer_t::build_station_extension_depot(player_t *player, koord3d
 
 		int layout = built_layout & 9;
 
-		// Height of each edge of the current tile relative to the tile's base z.
-		// For flat tiles all z_delta values are 0, so behaviour is unchanged.
-		// For slope tiles the primary lookup is at the correct edge height, and
-		// the fallback also catches slope-stop neighbours one level below.
-		const slope_t::type cur_slope = welt->lookup( pos )->get_weg_hang();
-		const int z_delta_far = (layout & 1)
-		    ? max( corner_ne(cur_slope), corner_se(cur_slope) )   // EW: east edge
-		    : max( corner_sw(cur_slope), corner_se(cur_slope) );  // NS: south edge
-		const int z_delta_near = (layout & 1)
-		    ? max( corner_nw(cur_slope), corner_sw(cur_slope) )   // EW: west edge
-		    : max( corner_nw(cur_slope), corner_ne(cur_slope) );  // NS: north edge
+		const grund_t* const this_gr = welt->lookup( pos );
 
-		// detect if we are connected at far (north/west) end
-		sint8 offset = welt->lookup( pos )->get_weg_yoff()/TILE_HEIGHT_STEP;
-		koord3d checkpos = pos+koord3d( (layout & 1 ? koord::east : koord::south), offset+z_delta_far);
-		grund_t * gr = welt->lookup( checkpos );
+		// Determine the two axis directions for this stop orientation.
+		// NS (layout bit 0 == 0): far = south, near = north.
+		// EW (layout bit 0 == 1): far = east,  near = west.
+		const ribi_t::ribi dir_far  = (layout & 1) ? ribi_t::east  : ribi_t::south;
+		const ribi_t::ribi dir_near = (layout & 1) ? ribi_t::west  : ribi_t::north;
 
-		if(!gr) {
-			// Bridge end tile or downslope continuation one level below the edge.
-			grund_t * gr_tmp = welt->lookup( pos+koord3d( (layout & 1 ? koord::east : koord::south), offset+z_delta_far-1) );
-			if(gr_tmp && (gr_tmp->get_weg_yoff()/TILE_HEIGHT_STEP == 1
-			              || (z_delta_far == 0 && slope_t::is_single( gr_tmp->get_weg_hang() )))) {
-				gr = gr_tmp;
-			}
-			else {
-				gr_tmp = welt->lookup( pos+koord3d( (layout & 1 ? koord::east : koord::south), offset+z_delta_far-2) );
-				if(gr_tmp && gr_tmp->get_weg_yoff()/TILE_HEIGHT_STEP == 2) {
-					gr = gr_tmp;
+		// Find a connected stop neighbour in direction dir.
+		// get_neighbour() handles all height transitions (single/double slope, bridge,
+		// tunnel) via get_vmove(), so no manual z-delta computation is needed.
+		// Falls back to the same-height tile that owns a halt (for adjacent extensions
+		// that are not directly way-connected).
+		auto find_nb = [&]( ribi_t::ribi dir ) -> grund_t* {
+			grund_t* nb = nullptr;
+			for(  int w = 0;  w < 2  &&  !nb;  w++  ) {
+				const weg_t* weg = this_gr->get_weg_nr( w );
+				if(  weg  ) {
+					this_gr->get_neighbour( nb, weg->get_waytype(), dir );
 				}
 			}
-		}
-
-		if(gr) {
-			gebaeude_t* gb = gr->find<gebaeude_t>();
-			if(gb==NULL) {
-				// no building on same level, check other levels
-				const planquadrat_t *pl = welt->access(checkpos.get_2d());
-				if (pl) {
-					for(  uint8 i=0;  i<pl->get_boden_count();  i++  ) {
-						gr = pl->get_boden_bei(i);
-						if(gr->is_halt() && gr->get_halt().is_bound() ) {
-							break;
-						}
+			if(  !nb  ) {
+				// Same-height tile with a halt (stop extension without direct way link).
+				const planquadrat_t* pl = welt->access( pos.get_2d() + koord(dir) );
+				if(  pl  ) {
+					grund_t* same_z = pl->get_boden_in_hoehe( pos.z );
+					if(  same_z  &&  same_z->get_halt().is_bound()  ) {
+						nb = same_z;
 					}
 				}
-				gb = gr->find<gebaeude_t>();
 			}
+			return nb;
+		};
+
+		// detect if we are connected at far (south/east) end
+		if(  grund_t* gr = find_nb( dir_far )  ) {
+			gebaeude_t* gb = gr->find<gebaeude_t>();
 			if(  gb  &&  gb->get_tile()->get_desc()->is_transport_building()  ) {
 				corner_layout &= ~2; // clear near bit
 				const koord xy = gb->get_tile()->get_offset();
@@ -679,7 +669,7 @@ gebaeude_t *hausbauer_t::build_station_extension_depot(player_t *player, koord3d
 					}
 				}
 				else if(  gb->get_tile()->get_desc()->get_all_layouts()>4  ) {
-					if((layoutbase & 1) == (layout & 1)) {
+					if(  (layoutbase & 1) == (layout & 1)  ) {
 						layoutbase &= 0xb; // clear near bit on neighbour
 					}
 				}
@@ -687,25 +677,10 @@ gebaeude_t *hausbauer_t::build_station_extension_depot(player_t *player, koord3d
 			}
 		}
 
-		// detect if near (south/east) end
-		gr = welt->lookup( pos+koord3d( (layout & 1 ? koord::west : koord::north), offset+z_delta_near) );
-		if(!gr) {
-			// Bridge end tile or downslope continuation one level below the edge.
-			grund_t * gr_tmp = welt->lookup( pos+koord3d( (layout & 1 ? koord::west : koord::north), offset+z_delta_near-1) );
-			if(gr_tmp && (gr_tmp->get_weg_yoff()/TILE_HEIGHT_STEP == 1
-			              || (z_delta_near == 0 && slope_t::is_single( gr_tmp->get_weg_hang() )))) {
-				gr = gr_tmp;
-			}
-			else {
-				gr_tmp = welt->lookup( pos+koord3d( (layout & 1 ? koord::west : koord::north), offset+z_delta_near-2) );
-				if(gr_tmp && gr_tmp->get_weg_yoff()/TILE_HEIGHT_STEP == 2) {
-					gr = gr_tmp;
-				}
-			}
-		}
-		if(gr) {
+		// detect if we are connected at near (north/west) end
+		if(  grund_t* gr = find_nb( dir_near )  ) {
 			gebaeude_t* gb = gr->find<gebaeude_t>();
-			if(gb  &&  gb->get_tile()->get_desc()->is_transport_building()) {
+			if(  gb  &&  gb->get_tile()->get_desc()->is_transport_building()  ) {
 				corner_layout &= ~4; // clear far bit
 				const koord xy = gb->get_tile()->get_offset();
 				uint8 layoutbase = gb->get_tile()->get_layout();
@@ -726,8 +701,8 @@ gebaeude_t *hausbauer_t::build_station_extension_depot(player_t *player, koord3d
 						layoutbase &= ~6;
 					}
 				}
-				else if(gb->get_tile()->get_desc()->get_all_layouts()>4) {
-					if((layoutbase & 1) == (layout & 1)) {
+				else if(  gb->get_tile()->get_desc()->get_all_layouts()>4  ) {
+					if(  (layoutbase & 1) == (layout & 1)  ) {
 						layoutbase &= 0xd; // clear far bit on neighbour
 					}
 				}
@@ -762,33 +737,28 @@ gebaeude_t* hausbauer_t::build_station_on_diagonal_way(player_t* player, koord3d
 	const uint16 way_connection_dir_bits = way_connection & ribi_t::west ? 1 : 0;
 	
 	// calculate neighbour_diagonal_stops
-	const sint8 offset = bd->get_hoehe()+bd->get_weg_yoff()/TILE_HEIGHT_STEP;
-	// Per-direction edge heights relative to the tile base (NESW order matching koord::nesw[]).
-	// For flat tiles all values are 0. For slope tiles the neighbour must be looked up at
-	// offset + z_delta[i] so that uphill and downhill connections are found correctly.
-	const slope_t::type diag_slope = bd->get_weg_hang();
-	const int z_delta[4] = {
-		max( corner_nw(diag_slope), corner_ne(diag_slope) ),  // N (i=0)
-		max( corner_ne(diag_slope), corner_se(diag_slope) ),  // E (i=1)
-		max( corner_sw(diag_slope), corner_se(diag_slope) ),  // S (i=2)
-		max( corner_nw(diag_slope), corner_sw(diag_slope) )   // W (i=3)
-	};
+	// Use get_neighbour() so that slope/bridge height transitions are handled correctly.
 	grund_t *gr;
 	gebaeude_t* neighbour_diagonal_stops[] = {NULL, NULL, NULL, NULL};
 	const koord pos_2d = bd->get_pos().get_2d();
 	for(  unsigned i=0;  i<4;  i++  ) {
-		// oriented buildings here - get neighbouring layouts
-		gr = world()->lookup(koord3d(pos_2d+koord::nesw[i], offset+z_delta[i]));
-		if(  !gr  ) {
-			// Bridge end tile or downslope continuation one level below the edge.
-			grund_t * gr_off1 = world()->lookup(koord3d(pos_2d+koord::nesw[i], offset+z_delta[i]-1));
-			grund_t * gr_off2 = world()->lookup(koord3d(pos_2d+koord::nesw[i], offset+z_delta[i]-2));
-			if(gr_off1 && (gr_off1->get_weg_yoff()/TILE_HEIGHT_STEP == 1
-			               || (z_delta[i] == 0 && slope_t::is_single( gr_off1->get_weg_hang() )))) {
-				gr = gr_off1;
+		// Find connected neighbour via each way on this tile.
+		const ribi_t::ribi dir = ribi_t::nesw[i];
+		gr = nullptr;
+		for(  int w = 0;  w < 2  &&  !gr;  w++  ) {
+			const weg_t* weg = bd->get_weg_nr( w );
+			if(  weg  ) {
+				bd->get_neighbour( gr, weg->get_waytype(), dir );
 			}
-			else if(gr_off2 && gr_off2->get_weg_yoff()/TILE_HEIGHT_STEP == 2) {
-				gr = gr_off2;
+		}
+		if(  !gr  ) {
+			// Same-height tile with a halt (for extensions not directly way-connected).
+			const planquadrat_t* pl = world()->access( pos_2d + koord::nesw[i] );
+			if(  pl  ) {
+				grund_t* same_z = pl->get_boden_in_hoehe( bd->get_hoehe() );
+				if(  same_z  &&  same_z->get_halt().is_bound()  ) {
+					gr = same_z;
+				}
 			}
 		}
 		if(  !gr  ||  !gr->get_halt().is_bound()  ) {
@@ -861,50 +831,35 @@ gebaeude_t* hausbauer_t::build_station_on_slope_way(player_t* player, koord3d po
 
 		int layout = built_layout & 9;
 
-		sint8 offset = welt->lookup( pos )->get_weg_yoff()/TILE_HEIGHT_STEP;
+		const grund_t* const this_gr = welt->lookup( pos );
 
-		// Height of each edge of the current slope tile relative to the tile's base z.
-		// For NS way (layout bit 0 == 0): far block checks south edge, near block checks north edge.
-		// For EW way (layout bit 0 == 1): far block checks east  edge, near block checks west  edge.
-		// corner_xx macros return 0..2 (single slope = 1, double = 2).
-		const int z_delta_far = (layout & 1)
-		    ? max( corner_ne(slope), corner_se(slope) )   // EW: east edge
-		    : max( corner_sw(slope), corner_se(slope) );  // NS: south edge
-		const int z_delta_near = (layout & 1)
-		    ? max( corner_nw(slope), corner_sw(slope) )   // EW: west edge
-		    : max( corner_nw(slope), corner_ne(slope) );  // NS: north edge
+		const ribi_t::ribi dir_far  = (layout & 1) ? ribi_t::east  : ribi_t::south;
+		const ribi_t::ribi dir_near = (layout & 1) ? ribi_t::west  : ribi_t::north;
 
-		// detect far (north/west) end neighbor
-		koord3d checkpos = pos+koord3d( (layout & 1 ? koord::east : koord::south), offset+z_delta_far);
-		grund_t *gr = welt->lookup( checkpos );
-		if(  !gr  ) {
-			// One level below the edge: bridge end (elevated way) or downslope continuation.
-			grund_t *gr_tmp = welt->lookup( pos+koord3d( (layout & 1 ? koord::east : koord::south), offset+z_delta_far-1) );
-			if(  gr_tmp  &&  (gr_tmp->get_weg_yoff()/TILE_HEIGHT_STEP == 1
-			                  ||  (z_delta_far == 0  &&  slope_t::is_single( gr_tmp->get_weg_hang() )))  ) {
-				gr = gr_tmp;
-			}
-			else {
-				gr_tmp = welt->lookup( pos+koord3d( (layout & 1 ? koord::east : koord::south), offset+z_delta_far-2) );
-				if(  gr_tmp  &&  gr_tmp->get_weg_yoff()/TILE_HEIGHT_STEP == 2  ) {
-					gr = gr_tmp;
+		// get_neighbour() resolves the correct height via get_vmove() for slopes and bridges.
+		auto find_nb = [&]( ribi_t::ribi dir ) -> grund_t* {
+			grund_t* nb = nullptr;
+			for(  int w = 0;  w < 2  &&  !nb;  w++  ) {
+				const weg_t* weg = this_gr->get_weg_nr( w );
+				if(  weg  ) {
+					this_gr->get_neighbour( nb, weg->get_waytype(), dir );
 				}
 			}
-		}
-		if(  gr  ) {
-			gebaeude_t *gb = gr->find<gebaeude_t>();
-			if(  gb==NULL  ) {
-				const planquadrat_t *pl = welt->access( checkpos.get_2d() );
+			if(  !nb  ) {
+				const planquadrat_t* pl = welt->access( pos.get_2d() + koord(dir) );
 				if(  pl  ) {
-					for(  uint8 i=0;  i<pl->get_boden_count();  i++  ) {
-						gr = pl->get_boden_bei(i);
-						if(  gr->is_halt()  &&  gr->get_halt().is_bound()  ) {
-							break;
-						}
+					grund_t* same_z = pl->get_boden_in_hoehe( pos.z );
+					if(  same_z  &&  same_z->get_halt().is_bound()  ) {
+						nb = same_z;
 					}
 				}
-				gb = gr->find<gebaeude_t>();
 			}
+			return nb;
+		};
+
+		// detect far (south/east) end neighbor
+		if(  grund_t* gr = find_nb( dir_far )  ) {
+			gebaeude_t *gb = gr->find<gebaeude_t>();
 			if(  gb  &&  gb->get_tile()->get_desc()->is_transport_building()  ) {
 				corner_layout &= ~2; // clear near bit
 				const koord xy = gb->get_tile()->get_offset();
@@ -933,23 +888,8 @@ gebaeude_t* hausbauer_t::build_station_on_slope_way(player_t* player, koord3d po
 			}
 		}
 
-		// detect near (south/east) end neighbor
-		gr = welt->lookup( pos+koord3d( (layout & 1 ? koord::west : koord::north), offset+z_delta_near) );
-		if(  !gr  ) {
-			// One level below the edge: bridge end (elevated way) or downslope continuation.
-			grund_t *gr_tmp = welt->lookup( pos+koord3d( (layout & 1 ? koord::west : koord::north), offset+z_delta_near-1) );
-			if(  gr_tmp  &&  (gr_tmp->get_weg_yoff()/TILE_HEIGHT_STEP == 1
-			                  ||  (z_delta_near == 0  &&  slope_t::is_single( gr_tmp->get_weg_hang() )))  ) {
-				gr = gr_tmp;
-			}
-			else {
-				gr_tmp = welt->lookup( pos+koord3d( (layout & 1 ? koord::west : koord::north), offset+z_delta_near-2) );
-				if(  gr_tmp  &&  gr_tmp->get_weg_yoff()/TILE_HEIGHT_STEP == 2  ) {
-					gr = gr_tmp;
-				}
-			}
-		}
-		if(  gr  ) {
+		// detect near (north/west) end neighbor
+		if(  grund_t* gr = find_nb( dir_near )  ) {
 			gebaeude_t *gb = gr->find<gebaeude_t>();
 			if(  gb  &&  gb->get_tile()->get_desc()->is_transport_building()  ) {
 				corner_layout &= ~4; // clear far bit

--- a/bauer/hausbauer.cc
+++ b/bauer/hausbauer.cc
@@ -987,11 +987,12 @@ gebaeude_t* hausbauer_t::build_station_on_slope_way(player_t* player, koord3d po
 		built_layout = (corner_layout | (built_layout & 9)) % flat_count;
 	}
 
-	// determine slope image offset:
-	//   N or W single-height  => +48
-	//   S or E single-height  => +64
-	//   N or W double-height  => +80
-	//   S or E double-height  => +96
+	// Determine slope image offset.
+	// Layout structure: 0-47 flat, 48-63 N/W single, 64-79 S/E single,
+	//                   80-95 N/W double, 96-111 S/E double.
+	// An 80-layout pakset has single-slope images only; double-slope tiles
+	// fall back to the same N/W or S/E single image group.
+	// A 132-layout pakset has dedicated double-slope images.
 	int slope_offset = 0;
 	if(  slope == slope_t::north  ||  slope == slope_t::west  ) {
 		slope_offset = 48;
@@ -1000,10 +1001,11 @@ gebaeude_t* hausbauer_t::build_station_on_slope_way(player_t* player, koord3d po
 		slope_offset = 64;
 	}
 	else if(  slope == (slope_t::type)(slope_t::north*2)  ||  slope == (slope_t::type)(slope_t::west*2)  ) {
-		slope_offset = 80;
+		// Use double-height images if present, otherwise fall back to single-height.
+		slope_offset = (built_layout + 80 < (int)desc->get_all_layouts()) ? 80 : 48;
 	}
 	else if(  slope == (slope_t::type)(slope_t::south*2)  ||  slope == (slope_t::type)(slope_t::east*2)  ) {
-		slope_offset = 96;
+		slope_offset = (built_layout + 96 < (int)desc->get_all_layouts()) ? 96 : 64;
 	}
 
 	// use slope image only when the descriptor defines one for this layout

--- a/bauer/hausbauer.h
+++ b/bauer/hausbauer.h
@@ -156,6 +156,11 @@ public:
 	// desc has to have 48 layouts.
 	static gebaeude_t* build_station_on_diagonal_way(player_t* player, koord3d pos, const building_desc_t* desc, const ribi_t::ribi way_connection, halthandle_t halt);
 
+	// Build a stop on a sloped way tile.
+	// Slope image offsets per flat pattern: N/W single=+48, S/E single=+64, N/W double=+80, S/E double=+96.
+	// If the descriptor does not have slope images the flat layout is used unchanged.
+	static gebaeude_t* build_station_on_slope_way(player_t* player, koord3d pos, int layout, const building_desc_t* desc, halthandle_t halt);
+
 	/// @returns house list of type @p typ
 	static const vector_tpl<const building_desc_t *> *get_list(building_desc_t::btype typ);
 

--- a/bauer/wegbauer.cc
+++ b/bauer/wegbauer.cc
@@ -486,8 +486,8 @@ bool way_builder_t::check_building( const grund_t *to, const koord dir ) const
 		if(  layouts==4  ) {
 			return  r == ribi_t::layout_to_ribi[layout];
 		}
-		if(  layout<16  ) {
-			// straight way tile
+		if(  layout<16  ||  (layouts > 48 && layout >= 48)  ) {
+			// straight way tile (layout>=48 with layouts>48 is a slope stop, also straight)
 			return ribi_t::is_straight( r | ribi_t::doubles(ribi_t::layout_to_ribi[layout&1]) );
 		}
 		// diagonal way tile

--- a/descriptor/reader/building_reader.cc
+++ b/descriptor/reader/building_reader.cc
@@ -191,8 +191,9 @@ void building_reader_t::register_obj(obj_desc_t *&data)
 	// after this point all building_desc_t's have type in building_desc_t::btype
 
 	// allowed layouts are 1,2,4,8,16,48 where 8,16,48 is reserved for stations
+	const bool is_slope_and_diagonal_supporting_station = (desc->type == building_desc_t::generic_stop &&  (desc->layouts == 80 || desc->layouts == 132));
 	const bool is_diagonal_supporting_station = (desc->type == building_desc_t::generic_stop &&  desc->layouts == 48);
-	if(  !is_diagonal_supporting_station  ) {
+	if(  !is_diagonal_supporting_station && !is_slope_and_diagonal_supporting_station  ) {
 		uint8 l = desc->type == building_desc_t::generic_stop ? 16 : 4;
 		while (l > 0) {
 			if ((desc->layouts & l) != 0  &&  (desc->layouts != l)) {

--- a/descriptor/reader/building_reader.cc
+++ b/descriptor/reader/building_reader.cc
@@ -191,7 +191,7 @@ void building_reader_t::register_obj(obj_desc_t *&data)
 	// after this point all building_desc_t's have type in building_desc_t::btype
 
 	// allowed layouts are 1,2,4,8,16,48 where 8,16,48 is reserved for stations
-	const bool is_slope_and_diagonal_supporting_station = (desc->type == building_desc_t::generic_stop &&  (desc->layouts == 80 || desc->layouts == 132));
+	const bool is_slope_and_diagonal_supporting_station = (desc->type == building_desc_t::generic_stop &&  (desc->layouts == 80 || desc->layouts == 112));
 	const bool is_diagonal_supporting_station = (desc->type == building_desc_t::generic_stop &&  desc->layouts == 48);
 	if(  !is_diagonal_supporting_station && !is_slope_and_diagonal_supporting_station  ) {
 		uint8 l = desc->type == building_desc_t::generic_stop ? 16 : 4;

--- a/obj/gebaeude.cc
+++ b/obj/gebaeude.cc
@@ -1112,59 +1112,53 @@ void gebaeude_t::cleanup(player_t *player)
 
 	// may need to update next buildings, in the case of start, middle, end buildings
 	// realign surrounding buildings...
-	const uint32 layout = tile->get_layout();
 
-	// Slope stops (layout >= 48 with slope images) use a straight-way direction table
-	// (index 0) and store NS/EW in bit 0 of the flat part, which is also bit 0 of layout.
-	// Using (layout & 0x30) >> 4 for slope layouts would give indices 3-6, out of bounds.
-	const bool is_slope_stop = (layout >= 48 && tile->get_desc()->get_all_layouts() > 48);
-	const uint32 dir_type_idx = is_slope_stop ? 0u : (layout & 0x30u) >> 4;
-
-	// [straight/vertical/horizontal][layout&1][index_to_lookup]
-	const koord directions_to_lookup[3][2][2] = {
-		{{koord::south, koord::north}, {koord::east, koord::west}},
-		{{koord::north, koord::east}, {koord::west, koord::south}},
-		{{koord::south, koord::east}, {koord::west, koord::north}}
-	};
+	// Which end-cap bit to restore on a neighbour reached from direction dir,
+	// given the neighbour's layout type (straight=0, vertical diag=1, horizontal diag=2).
 	const ribi_t::ribi bit_4_turn_on_dir[3] = {
 		ribi_t::southeast, // straight
 		ribi_t::northwest, // vertical diagonal
-		ribi_t::southwest // horizontal diagonal
+		ribi_t::southwest  // horizontal diagonal
 	};
 
-	// check adjacent tiles and turn on the connection bit.
-	const sint8 offset = this_gr->get_weg_yoff()/TILE_HEIGHT_STEP;
-	const slope_t::type cur_slope = this_gr->get_weg_hang();
-	// WORKAROUND: station extensions have somehow inverted layout bits.
-	const bool is_generic_ext = tile->get_desc()->get_type() == building_desc_t::generic_extension;
-	for(  uint8 i=0;  i<2;  i++  ) {
-		const koord dir = directions_to_lookup[dir_type_idx][(layout&1)^is_generic_ext][i];
-		// Height of this tile's edge in direction dir, relative to tile base z.
-		const int z_delta_dir = (dir == koord::south) ? max( corner_sw(cur_slope), corner_se(cur_slope) )
-		                      : (dir == koord::north) ? max( corner_nw(cur_slope), corner_ne(cur_slope) )
-		                      : (dir == koord::east)  ? max( corner_ne(cur_slope), corner_se(cur_slope) )
-		                      : /* west */              max( corner_nw(cur_slope), corner_sw(cur_slope) );
-		grund_t* gr = welt->lookup(get_pos() + koord3d(dir, offset + z_delta_dir));
-		if(!gr) {
-			// Bridge end tile or downslope continuation one level below the edge.
-			grund_t * gr_tmp = welt->lookup(get_pos() + koord3d(dir, offset + z_delta_dir - 1));
-			if(gr_tmp && (gr_tmp->get_weg_yoff()/TILE_HEIGHT_STEP == 1
-			              || (z_delta_dir == 0 && slope_t::is_single( gr_tmp->get_weg_hang() )))) {
-				gr = gr_tmp;
+	// Walk every way on this tile. For each connected direction, find the neighbouring
+	// stop via get_neighbour() and restore its end-cap bit.
+	// get_neighbour() resolves the correct height for slopes and bridges via get_vmove(),
+	// handling single slopes, double slopes, and all combinations correctly.
+	for(  int w = 0;  w < 2;  w++  ) {
+		const weg_t* weg = this_gr->get_weg_nr( w );
+		if(  !weg  ) { continue; }
+		const ribi_t::ribi way_ribi = weg->get_ribi_unmasked();
+		for(  uint8 i = 0;  i < 4;  i++  ) {
+			const ribi_t::ribi dir = ribi_t::nesw[i];
+			if(  !(way_ribi & dir)  ) { continue; }
+
+			grund_t* gr = nullptr;
+			this_gr->get_neighbour( gr, weg->get_waytype(), dir );
+			if(  !gr  ) {
+				// Same-height tile with a halt (stop extension without direct way link).
+				const planquadrat_t* pl = welt->access( get_pos().get_2d() + koord(dir) );
+				if(  pl  ) {
+					grund_t* same_z = pl->get_boden_in_hoehe( get_pos().z );
+					if(  same_z  &&  same_z->get_halt().is_bound()  ) {
+						gr = same_z;
+					}
+				}
 			}
+
+			gebaeude_t* gb = gr ? gr->find<gebaeude_t>() : NULL;
+			if(  !gb  ||  gb->get_tile()->get_desc()->get_all_layouts() <= 4u  ) {
+				continue;
+			}
+			const koord xy = gb->get_tile()->get_offset();
+			uint8 layoutbase = gb->get_tile()->get_layout();
+			// Slope stop neighbours use the straight-way rule (index 0) for bit selection.
+			const uint32 nb_idx = (layoutbase >= 48 && gb->get_tile()->get_desc()->get_all_layouts() > 48)
+			                    ? 0u : (layoutbase & 0x30u) >> 4;
+			const bool bit_4_turn_on = (dir & bit_4_turn_on_dir[nb_idx]) > 0;
+			layoutbase |= bit_4_turn_on ? 4u : 2u; // restore end-cap bit on neighbour
+			gb->set_tile( gb->get_tile()->get_desc()->get_tile(layoutbase, xy.x, xy.y), false );
 		}
-		gebaeude_t* gb = gr ? gr->find<gebaeude_t>() : NULL;
-		if(  !gb  ||  gb->get_tile()->get_desc()->get_all_layouts()<=4u  ) {
-			continue;
-		}
-		const koord xy = gb->get_tile()->get_offset();
-		uint8 layoutbase = gb->get_tile()->get_layout();
-		// Slope stop neighbours also use the straight-way rule for bit selection.
-		const uint32 nb_idx = (layoutbase >= 48 && gb->get_tile()->get_desc()->get_all_layouts() > 48)
-		                    ? 0u : (layoutbase & 0x30u) >> 4;
-		const bool bit_4_turn_on = (ribi_type(dir) & bit_4_turn_on_dir[nb_idx]) > 0;
-		layoutbase |= bit_4_turn_on ? 4u : 2u; // set end-cap bit on neighbour
-		gb->set_tile( gb->get_tile()->get_desc()->get_tile(layoutbase, xy.x, xy.y), false );
 	}
 	mark_images_dirty();
 }

--- a/obj/gebaeude.cc
+++ b/obj/gebaeude.cc
@@ -154,6 +154,24 @@ void gebaeude_t::rotate90()
 			// eight layout city building
 			layout = (layout & 4) + ((layout+3) & 3);
 		}
+		else if(  layout>=48  &&  building_desc->get_all_layouts()>48  ) {
+			// slope stop layout: rotate90 cycles N->E->S->W->N
+			// Layout = slope_group (upper nibble, one of 48/64/80/96) + flat_part (lower nibble).
+			// When way is NS (bit0=0) the slope group shifts by ±16 following the rotate90 cycle.
+			// When way is EW (bit0=1) the slope group is unchanged (rotating EW->NS keeps the slope).
+			// The flat part rotates via the same table used for straight stations.
+			static const uint8 layout_rotate[16] = { 1, 8, 5, 10, 3, 12, 7, 14, 9, 0, 13, 2, 11, 4, 15, 6 };
+			const uint8 slope_group = layout & 0xF0;
+			const uint8 flat_part   = layout & 0x0F;
+			const int   flat_count  = min( 48, (int)building_desc->get_all_layouts() );
+			const uint8 new_flat    = layout_rotate[flat_part] % flat_count;
+			// for NS-way (bit0=0): swap between N/W group and S/E group (add or subtract 16)
+			// for EW-way (bit0=1): slope group is unchanged
+			const uint8 new_group = (flat_part & 1)
+				? slope_group
+				: (uint8)(slope_group + ((slope_group & 0x10) ? 16 : -16));
+			layout = new_group + new_flat;
+		}
 		else if(  layout>=16  ) {
 			// diagonal tile layout for stations
 			// construct the rotated layout
@@ -1095,7 +1113,13 @@ void gebaeude_t::cleanup(player_t *player)
 	// may need to update next buildings, in the case of start, middle, end buildings
 	// realign surrounding buildings...
 	const uint32 layout = tile->get_layout();
-	
+
+	// Slope stops (layout >= 48 with slope images) use a straight-way direction table
+	// (index 0) and store NS/EW in bit 0 of the flat part, which is also bit 0 of layout.
+	// Using (layout & 0x30) >> 4 for slope layouts would give indices 3-6, out of bounds.
+	const bool is_slope_stop = (layout >= 48 && tile->get_desc()->get_all_layouts() > 48);
+	const uint32 dir_type_idx = is_slope_stop ? 0u : (layout & 0x30u) >> 4;
+
 	// [straight/vertical/horizontal][layout&1][index_to_lookup]
 	const koord directions_to_lookup[3][2][2] = {
 		{{koord::south, koord::north}, {koord::east, koord::west}},
@@ -1107,18 +1131,25 @@ void gebaeude_t::cleanup(player_t *player)
 		ribi_t::northwest, // vertical diagonal
 		ribi_t::southwest // horizontal diagonal
 	};
-	
+
 	// check adjacent tiles and turn on the connection bit.
 	const sint8 offset = this_gr->get_weg_yoff()/TILE_HEIGHT_STEP;
+	const slope_t::type cur_slope = this_gr->get_weg_hang();
 	// WORKAROUND: station extensions have somehow inverted layout bits.
 	const bool is_generic_ext = tile->get_desc()->get_type() == building_desc_t::generic_extension;
 	for(  uint8 i=0;  i<2;  i++  ) {
-		const koord dir = directions_to_lookup[(layout&0x30)>>4][(layout&1)^is_generic_ext][i];
-		grund_t* gr = welt->lookup(get_pos() + koord3d(dir, offset));
+		const koord dir = directions_to_lookup[dir_type_idx][(layout&1)^is_generic_ext][i];
+		// Height of this tile's edge in direction dir, relative to tile base z.
+		const int z_delta_dir = (dir == koord::south) ? max( corner_sw(cur_slope), corner_se(cur_slope) )
+		                      : (dir == koord::north) ? max( corner_nw(cur_slope), corner_ne(cur_slope) )
+		                      : (dir == koord::east)  ? max( corner_ne(cur_slope), corner_se(cur_slope) )
+		                      : /* west */              max( corner_nw(cur_slope), corner_sw(cur_slope) );
+		grund_t* gr = welt->lookup(get_pos() + koord3d(dir, offset + z_delta_dir));
 		if(!gr) {
-			// check whether bridge end tile
-			grund_t * gr_tmp = welt->lookup(get_pos() + koord3d(dir, offset - 1));
-			if(gr_tmp && gr_tmp->get_weg_yoff()/TILE_HEIGHT_STEP == 1) {
+			// Bridge end tile or downslope continuation one level below the edge.
+			grund_t * gr_tmp = welt->lookup(get_pos() + koord3d(dir, offset + z_delta_dir - 1));
+			if(gr_tmp && (gr_tmp->get_weg_yoff()/TILE_HEIGHT_STEP == 1
+			              || (z_delta_dir == 0 && slope_t::is_single( gr_tmp->get_weg_hang() )))) {
 				gr = gr_tmp;
 			}
 		}
@@ -1128,8 +1159,11 @@ void gebaeude_t::cleanup(player_t *player)
 		}
 		const koord xy = gb->get_tile()->get_offset();
 		uint8 layoutbase = gb->get_tile()->get_layout();
-		const bool bit_4_turn_on = (ribi_type(dir) & bit_4_turn_on_dir[(layoutbase&0x30)>>4]) > 0;
-		layoutbase |= bit_4_turn_on ? 4u : 2u; // set far bit on neighbour
+		// Slope stop neighbours also use the straight-way rule for bit selection.
+		const uint32 nb_idx = (layoutbase >= 48 && gb->get_tile()->get_desc()->get_all_layouts() > 48)
+		                    ? 0u : (layoutbase & 0x30u) >> 4;
+		const bool bit_4_turn_on = (ribi_type(dir) & bit_4_turn_on_dir[nb_idx]) > 0;
+		layoutbase |= bit_4_turn_on ? 4u : 2u; // set end-cap bit on neighbour
 		gb->set_tile( gb->get_tile()->get_desc()->get_tile(layoutbase, xy.x, xy.y), false );
 	}
 	mark_images_dirty();

--- a/simtool.cc
+++ b/simtool.cc
@@ -5392,6 +5392,11 @@ DBG_MESSAGE("tool_station_aux()", "building %s on square %d,%d for waytype %x", 
 		}
 	}
 
+	// Slope tiles require a descriptor with slope images (all_layouts > 48).
+	if(  bd->get_weg_hang() != slope_t::flat  &&  desc->get_all_layouts() <= 48  ) {
+		return "Stops on slope require a slope-capable descriptor!";
+	}
+
 	// seems everything ok, lets build
 	bool neu = !halt.is_bound();
 

--- a/simtool.cc
+++ b/simtool.cc
@@ -5355,6 +5355,12 @@ DBG_MESSAGE("tool_station_aux()", "building %s on square %d,%d for waytype %x", 
 		layout &= (desc->get_all_layouts()-1);
 	}
 
+	// Slope tiles require a descriptor with slope images (all_layouts > 48).
+	// Check BEFORE removing the existing building to avoid corrupting the halt.
+	if(  bd->get_weg_hang() != slope_t::flat  &&  desc->get_all_layouts() <= 48  ) {
+		return "Stops on slope require a slope-capable descriptor!";
+	}
+
 	halthandle_t old_halt = bd->get_halt();
 	sint64 old_cost = 0;
 	bool recalc_schedule = false;
@@ -5392,11 +5398,6 @@ DBG_MESSAGE("tool_station_aux()", "building %s on square %d,%d for waytype %x", 
 		}
 	}
 
-	// Slope tiles require a descriptor with slope images (all_layouts > 48).
-	if(  bd->get_weg_hang() != slope_t::flat  &&  desc->get_all_layouts() <= 48  ) {
-		return "Stops on slope require a slope-capable descriptor!";
-	}
-
 	// seems everything ok, lets build
 	bool neu = !halt.is_bound();
 
@@ -5409,7 +5410,7 @@ DBG_MESSAGE("tool_station_aux()", "building %s on square %d,%d for waytype %x", 
 	if(  bd->get_weg_hang() != slope_t::flat  ) {
 		hausbauer_t::build_station_on_slope_way(halt_player, bd->get_pos(), layout, desc, halt);
 	}
-	else if(  desc->get_all_layouts()==48  &&  !ribi_t::is_straight(ribi)  ) {
+	else if(  desc->get_all_layouts()>=48  &&  !ribi_t::is_straight(ribi)  ) {
 		hausbauer_t::build_station_on_diagonal_way(halt_player, bd->get_pos(), desc, ribi, halt);
 	}
 	else {

--- a/simtool.cc
+++ b/simtool.cc
@@ -5174,8 +5174,7 @@ DBG_MESSAGE("tool_station_aux()", "building %s on square %d,%d for waytype %x", 
 	// get valid ground
 	grund_t *bd = tool_intern_koord_to_weg_grund(player, welt, pos, wegtype);
 
-	if(  !bd  ||  bd->get_weg_hang()!=slope_t::flat  ) {
-		// only flat tiles, only one stop per map square
+	if(  !bd  ) {
 		return "No suitable way on the ground!";
 	}
 
@@ -5196,7 +5195,38 @@ DBG_MESSAGE("tool_station_aux()", "building %s on square %d,%d for waytype %x", 
 	// find out orientation ...
 	uint32 layout = 0;
 	ribi_t::ribi ribi=ribi_t::none;
-	if(  desc->get_all_layouts()==48  ) {
+	
+	if(  desc->get_all_layouts()==132  ) {
+		// through station supporting diagonal
+		if(  bd->has_two_ways()  ) {
+			// a crossing or maybe just a tram track on a road ...
+			ribi = bd->get_weg_nr(0)->get_ribi_unmasked()  |  bd->get_weg_nr(1)->get_ribi_unmasked();
+		}
+		else if(  bd->hat_wege()  ) {
+			ribi = bd->get_weg_nr(0)->get_ribi_unmasked();
+		}
+		if(  !ribi_t::is_straight(ribi)  &&  !ribi_t::is_twoway(ribi)  ) {
+			// cannot build here ...
+			return p_error;
+		}
+		layout = (ribi & ribi_t::northsouth)? 0 : 1; // discarded when the way is diagonal
+	}
+	else if(  desc->get_all_layouts()==80  ) {
+		// through station supporting diagonal
+		if(  bd->has_two_ways()  ) {
+			// a crossing or maybe just a tram track on a road ...
+			ribi = bd->get_weg_nr(0)->get_ribi_unmasked()  |  bd->get_weg_nr(1)->get_ribi_unmasked();
+		}
+		else if(  bd->hat_wege()  ) {
+			ribi = bd->get_weg_nr(0)->get_ribi_unmasked();
+		}
+		if(  !ribi_t::is_straight(ribi)  &&  !ribi_t::is_twoway(ribi)  ) {
+			// cannot build here ...
+			return p_error;
+		}
+		layout = (ribi & ribi_t::northsouth)? 0 : 1; // discarded when the way is diagonal
+	}
+	else if(  desc->get_all_layouts()==48  ) {
 		// through station supporting diagonal
 		if(  bd->has_two_ways()  ) {
 			// a crossing or maybe just a tram track on a road ...
@@ -5371,7 +5401,10 @@ DBG_MESSAGE("tool_station_aux()", "building %s on square %d,%d for waytype %x", 
 		}
 		halt = haltestelle_t::create(k, player);
 	}
-	if(  desc->get_all_layouts()==48  &&  !ribi_t::is_straight(ribi)  ) {
+	if(  bd->get_weg_hang() != slope_t::flat  ) {
+		hausbauer_t::build_station_on_slope_way(halt_player, bd->get_pos(), layout, desc, halt);
+	}
+	else if(  desc->get_all_layouts()==48  &&  !ribi_t::is_straight(ribi)  ) {
 		hausbauer_t::build_station_on_diagonal_way(halt_player, bd->get_pos(), desc, ribi, halt);
 	}
 	else {

--- a/simtool.cc
+++ b/simtool.cc
@@ -5196,7 +5196,7 @@ DBG_MESSAGE("tool_station_aux()", "building %s on square %d,%d for waytype %x", 
 	uint32 layout = 0;
 	ribi_t::ribi ribi=ribi_t::none;
 	
-	if(  desc->get_all_layouts()==132  ) {
+	if(  desc->get_all_layouts()==112  ) {
 		// through station supporting diagonal
 		if(  bd->has_two_ways()  ) {
 			// a crossing or maybe just a tram track on a road ...


### PR DESCRIPTION
勾配タイル上に停留所を設置できます。
書式は、終端・中間の区別は地平の直線タイルと同様で、
西・北向きの緩坂はインデックスを+48
東・南向きの緩坂はインデックスを+64
西・北向きの急坂はインデックスを+80
東・南向きの急坂はインデックスを+96
してください（インデックスは斜めタイルの続き番号となります）。
dimsは
坂が1種類のみの場合は80
坂が2種類の場合は112
を指定すると坂画像ありのアドオンとして読み込まれます。