### PR TITLE
Add Squirrel API to create players

### DIFF
--- a/script/api/api_world.cc
+++ b/script/api/api_world.cc
@@ -68,6 +68,23 @@ bool world_remove_player(karte_t *welt, player_t *player)
 }
 
 
+bool world_create_player(karte_t *welt, sint32 player_nr, sint32 player_type)
+{
+	if (player_nr < 2  ||  player_nr >= PLAYER_UNOWNED  ||
+	    player_type < player_t::HUMAN  ||  player_type >= player_t::MAX_AI) {
+		return false;
+	}
+	// First test whether this player slot and type can be created.
+	bool ok = welt->change_player_tool(karte_t::new_player, (uint8)player_nr, (uint16)player_type, true /*unlocked*/, false /*exec*/);
+	if (!ok) {
+		return false;
+	}
+	// This will not have an immediate effect in network games.
+	welt->call_change_player_tool(karte_t::new_player, (uint8)player_nr, (uint16)player_type, true /*scripted*/);
+	return true;
+}
+
+
 uint32 world_generate_goods(karte_t *welt, koord from, koord to, const goods_desc_t *desc, uint32 count)
 {
 	if (count == 0 || count >= 1<<23) {
@@ -271,6 +288,25 @@ void export_world(HSQUIRRELVM vm, bool scenario)
 	STATIC register_method(vm, &karte_t::get_season, "get_season");
 
 	if (scenario) {
+		/**
+		* Creates a player company in an unused player slot.
+		*
+		* Player numbers 0 and 1 are reserved for the default human and public
+		* players. Valid new player numbers are 2 through 14.
+		*
+		* Player types are 1 = human, 2 = goods AI, 3 = passenger AI, and
+		* 4 = scripted AI.
+		*
+		* In network games, there will be a delay between the call to this
+		* function and creation of the player.
+		*
+		* @param player_nr unused player number
+		* @param player_type player type to create
+		* @ingroup scen_only
+		* @returns whether the creation request was accepted
+		*/
+		STATIC register_method(vm, &world_create_player, "create_player", true);
+
 		/**
 		* Removes player company: removes all assets. Use with care.
 		*

--- a/script/api/changelog.h
+++ b/script/api/changelog.h
@@ -9,6 +9,7 @@
  *
  * @section api-trunk Current trunk
  *
+ * - Added @ref world::create_player to create player companies (scenario only)
  * - Added @ref command_x::grid_lower, @ref command_x::grid_raise
  * - Added @ref settings::has_double_slopes, @ref settings::get_way_height_clearance
  * - Added @ref tile_x::is_crossing

--- a/script/api/squirrel_types_scenario.awk
+++ b/script/api/squirrel_types_scenario.awk
@@ -403,6 +403,7 @@ BEGIN {
 	export_types_scenario["world::is_coord_valid"] = "bool(coord)"
 	export_types_scenario["world::find_nearest_city"] = "city_x(coord)"
 	export_types_scenario["world::get_season"] = "integer()"
+	export_types_scenario["world::create_player"] = "bool(integer, integer)"
 	export_types_scenario["world::remove_player"] = "bool(player_x)"
 	export_types_scenario["world::generate_goods"] = "integer(coord, coord, good_desc_x, integer)"
 	export_types_scenario["integer::get_player"] = "player_x()"

--- a/tests/automated-tests/all_tests.nut
+++ b/tests/automated-tests/all_tests.nut
@@ -137,6 +137,7 @@ all_tests <- [
 	test_label,
 	test_player_cash,
 	test_player_isactive,
+	test_player_create,
 	test_player_headquarters,
 	test_player_name,
 	test_player_lines,

--- a/tests/automated-tests/tests/test_player.nut
+++ b/tests/automated-tests/tests/test_player.nut
@@ -64,6 +64,53 @@ function test_player_isactive()
 }
 
 
+function test_player_create()
+{
+	local human = player_x(2)
+	local goods_ai = player_x(3)
+	local passenger_ai = player_x(4)
+	local scripted_ai = player_x(5)
+	local invalid_type = player_x(6)
+	local last_slot = player_x(14)
+
+	ASSERT_FALSE(human.is_valid())
+	ASSERT_FALSE(goods_ai.is_valid())
+	ASSERT_FALSE(passenger_ai.is_valid())
+	ASSERT_FALSE(scripted_ai.is_valid())
+	ASSERT_FALSE(invalid_type.is_valid())
+	ASSERT_FALSE(last_slot.is_valid())
+
+	ASSERT_TRUE(world.create_player(2, 1))
+	ASSERT_TRUE(human.is_valid())
+	ASSERT_EQUAL(human.get_type(), 1)
+
+	ASSERT_TRUE(world.create_player(3, 2))
+	ASSERT_TRUE(goods_ai.is_valid())
+	ASSERT_EQUAL(goods_ai.get_type(), 2)
+
+	ASSERT_TRUE(world.create_player(4, 3))
+	ASSERT_TRUE(passenger_ai.is_valid())
+	ASSERT_EQUAL(passenger_ai.get_type(), 3)
+
+	ASSERT_TRUE(world.create_player(5, 4))
+	ASSERT_TRUE(scripted_ai.is_valid())
+	ASSERT_EQUAL(scripted_ai.get_type(), 4)
+
+	ASSERT_TRUE(world.create_player(14, 1))
+	ASSERT_TRUE(last_slot.is_valid())
+	ASSERT_EQUAL(last_slot.get_type(), 1)
+
+	ASSERT_FALSE(world.create_player(2, 1))
+	ASSERT_FALSE(world.create_player(-1, 1))
+	ASSERT_FALSE(world.create_player(0, 1))
+	ASSERT_FALSE(world.create_player(1, 1))
+	ASSERT_FALSE(world.create_player(15, 1))
+	ASSERT_FALSE(world.create_player(6, 0))
+	ASSERT_FALSE(world.create_player(6, 5))
+	ASSERT_FALSE(invalid_type.is_valid())
+}
+
+
 function test_player_headquarters()
 {
 	local pl = player_x(0)
@@ -128,4 +175,3 @@ function test_player_lines()
 	// clean up
 	RESET_ALL_PLAYER_FUNDS()
 }
-


### PR DESCRIPTION
## 概要

Scenario Squirrel API に `world.create_player(player_nr, player_type)` を追加します。

- player number 2〜14 の未使用 slot に player を作成
- type 1〜4（human / goods AI / passenger AI / scripted AI）に対応
- 無効な slot、使用済み slot、無効な type は `false`
- 既存の `world.remove_player` と同じ network-safe な player change 経路を使用
- network game では作成要求の反映が遅延することを API docs に記載

## テスト

- `test_player_create`
  - 全4 player type の作成と `get_type()`
  - 最初・最後の有効 slot
  - 重複、予約 slot、範囲外 slot、無効 type の拒否
- `test_player_isactive`
- `test_player_cash`
- `test_sign_signal_when_player_removed`

ローカルで上記テストおよびビルドが成功しています。
