### PR TITLE
Add MCP screen capture tool

### DIFF
--- a/display/simgraph.h
+++ b/display/simgraph.h
@@ -14,6 +14,7 @@
 #include "simimg.h"
 #include "scr_coord.h"
 
+#include <string>
 
 #if COLOUR_DEPTH != 0
 
@@ -370,6 +371,8 @@ void display_pop_clip_wh(CLIP_NUM_DEF0);
 
 
 bool display_snapshot( const scr_rect &area );
+/// Capture a screen area as PNG data without writing a screenshot file.
+bool display_snapshot_png(const scr_rect &area, std::string &png_data);
 
 #if COLOUR_DEPTH != 0
 extern uint8 display_day_lights[  LIGHT_COUNT * 3];

--- a/display/simgraph0.cc
+++ b/display/simgraph0.cc
@@ -114,6 +114,11 @@ bool display_snapshot(const scr_rect &)
 	return false;
 }
 
+bool display_snapshot_png(const scr_rect &, std::string &)
+{
+	return false;
+}
+
 void display_get_image_offset(image_id image, scr_coord_val *xoff, scr_coord_val *yoff, scr_coord_val *xw, scr_coord_val *yw)
 {
 	if(  image < 2  ) {

--- a/display/simgraph16.cc
+++ b/display/simgraph16.cc
@@ -5822,28 +5822,18 @@ void simgraph_resize(scr_size new_window_size)
 /**
  * Take Screenshot
  */
-bool display_snapshot( const scr_rect &area )
+static raw_image_t *capture_snapshot(const scr_rect &area)
 {
-	if (access(SCREENSHOT_PATH_X, W_OK) == -1) {
-		return false; // directory not accessible
-	}
-
-	static int number = 0;
-	char filename[80];
-
-	// find the first not used screenshot image
-	do {
-		sprintf(filename, SCREENSHOT_PATH_X "simscr%02d.png", number++);
-	} while (access(filename, W_OK) != -1);
-
-	// now save the screenshot
 	scr_rect clipped_area = area;
 	clipped_area.clip(scr_rect(0, 0, disp_actual_width, disp_height));
+	if (clipped_area.w <= 0 || clipped_area.h <= 0) {
+		return NULL;
+	}
 
-	raw_image_t img(clipped_area.w, clipped_area.h, raw_image_t::FMT_RGB888);
+	raw_image_t *img = new raw_image_t(clipped_area.w, clipped_area.h, raw_image_t::FMT_RGB888);
 
 	for (scr_coord_val y = 0; y < clipped_area.h; ++y) {
-		uint8 *dst = img.access_pixel(0, y);
+		uint8 *dst = img->access_pixel(0, y);
 		const PIXVAL *row = textur + (clipped_area.x + 0) + (clipped_area.y + y) * disp_width;
 
 		for (scr_coord_val x = 0; x < clipped_area.w; ++x) {
@@ -5861,5 +5851,44 @@ bool display_snapshot( const scr_rect &area )
 		}
 	}
 
-	return img.write_png(filename);
+	return img;
+}
+
+
+bool display_snapshot_png(const scr_rect &area, std::string &png_data)
+{
+	raw_image_t *img = capture_snapshot(area);
+	if (img == NULL) {
+		png_data.clear();
+		return false;
+	}
+
+	const bool ok = img->write_png(png_data);
+	delete img;
+	return ok;
+}
+
+
+bool display_snapshot(const scr_rect &area)
+{
+	if (access(SCREENSHOT_PATH_X, W_OK) == -1) {
+		return false; // directory not accessible
+	}
+
+	static int number = 0;
+	char filename[80];
+
+	// find the first not used screenshot image
+	do {
+		sprintf(filename, SCREENSHOT_PATH_X "simscr%02d.png", number++);
+	} while (access(filename, W_OK) != -1);
+
+	raw_image_t *img = capture_snapshot(area);
+	if (img == NULL) {
+		return false;
+	}
+
+	const bool ok = img->write_png(filename);
+	delete img;
+	return ok;
 }

--- a/io/raw_image.h
+++ b/io/raw_image.h
@@ -11,6 +11,7 @@
 
 #include <cassert>
 #include <stdio.h>
+#include <string>
 
 
 /**
@@ -72,6 +73,8 @@ public:
 
 	/// @returns true on success
 	bool write_png(const char *filename) const;
+	/// Write a PNG image to memory.
+	bool write_png(std::string &data) const;
 	bool write_bmp(const char *filename) const;
 	bool write_ppm(const char *filename) const;
 

--- a/io/raw_image_png.cc
+++ b/io/raw_image_png.cc
@@ -19,6 +19,47 @@
 
 static std::string filename_;
 
+static bool write_png_content(const raw_image_t &image, png_structp png_ptr, png_infop info_ptr)
+{
+	int color_type;
+
+	switch (image.get_format()) {
+	case raw_image_t::FMT_RGBA8888: color_type = PNG_COLOR_TYPE_RGBA; break;
+	case raw_image_t::FMT_RGB888:   color_type = PNG_COLOR_TYPE_RGB;  break;
+	case raw_image_t::FMT_GRAY8:    color_type = PNG_COLOR_TYPE_GRAY; break;
+	default:
+		dbg->error("raw_image_t::write_png", "Unsupported source format for writing png");
+		return false;
+	}
+
+#if PNG_LIBPNG_VER_MAJOR<=1  &&  PNG_LIBPNG_VER_MINOR<5
+	png_set_compression_level(png_ptr, Z_BEST_COMPRESSION);
+#endif
+
+	png_set_IHDR(png_ptr, info_ptr, image.get_width(), image.get_height(), 8,
+		color_type, PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_DEFAULT,
+		PNG_FILTER_TYPE_DEFAULT);
+	png_write_info(png_ptr, info_ptr);
+
+	for (uint32 y = 0; y < image.get_height(); ++y) {
+		const uint8 *row = image.access_pixel(0, y);
+		png_write_row(png_ptr, const_cast<png_bytep>(row));
+	}
+
+	png_write_end(png_ptr, info_ptr);
+	return true;
+}
+
+static void write_png_to_string(png_structp png_ptr, png_bytep data, png_size_t length)
+{
+	std::string *output = static_cast<std::string *>(png_get_io_ptr(png_ptr));
+	output->append(reinterpret_cast<const char *>(data), length);
+}
+
+static void flush_png_string(png_structp)
+{
+}
+
 
 bool raw_image_t::read_png_data(FILE *file)
 {
@@ -219,49 +260,43 @@ bool raw_image_t::write_png(const char *file_name) const
 	// assign file
 	png_init_io(png_ptr, fp);
 
-#if PNG_LIBPNG_VER_MAJOR<=1  &&  PNG_LIBPNG_VER_MINOR<5
-	/* set the zlib compression level */
-	png_set_compression_level( png_ptr, Z_BEST_COMPRESSION );
-#endif
-
-	// output header
-	int color_type;
-
-	switch (fmt) {
-	case FMT_RGBA8888: color_type = PNG_COLOR_TYPE_RGBA; break;
-	case FMT_RGB888:   color_type = PNG_COLOR_TYPE_RGB;  break;
-	case FMT_GRAY8:    color_type = PNG_COLOR_TYPE_GRAY; break;
-	default:
-		dbg->fatal( "raw_image_t::write_png", "Cannot write png file: Unupported source format" );
-	}
-
-	png_set_IHDR( png_ptr, info_ptr, width, height, 8, color_type, PNG_INTERLACE_NONE, PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT );
-	png_write_info(png_ptr, info_ptr);
-
-	switch (fmt) {
-	case FMT_RGBA8888:
-	case FMT_RGB888:
-	case FMT_GRAY8:
-		{
-			for (uint32 y = 0; y < height; ++y) {
-				// hack to compile with old libpng versions that take a png_bytep instead of a png_const_bytep
-				const uint8 *row = access_pixel(0, y);
-				png_write_row(png_ptr, const_cast<png_bytep>(row));
-			}
-		}
-		break;
-
-	default:
-		dbg->error("raw_image_t::write_png", "Unsupported source format for writing png");
-		png_destroy_write_struct(&png_ptr, &info_ptr);
-		fclose( fp );
-		return false;
-	}
-
-	// free all
-	png_write_end(png_ptr, info_ptr);
+	const bool ok = write_png_content(*this, png_ptr, info_ptr);
 	png_destroy_write_struct(&png_ptr, &info_ptr);
 
 	fclose( fp );
-	return true;
+	return ok;
+}
+
+
+bool raw_image_t::write_png(std::string &output) const
+{
+	output.clear();
+
+	png_structp png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
+	if (!png_ptr) {
+		return false;
+	}
+
+	png_infop info_ptr = png_create_info_struct(png_ptr);
+	if (!info_ptr) {
+		png_destroy_write_struct(&png_ptr, (png_infopp)NULL);
+		return false;
+	}
+
+#ifdef PNG_SETJMP_SUPPORTED
+	if (setjmp(png_jmpbuf(png_ptr))) {
+		dbg->error("raw_image_t::write_png", "fatal error writing PNG to memory");
+		png_destroy_write_struct(&png_ptr, &info_ptr);
+		output.clear();
+		return false;
+	}
+#endif
+
+	png_set_write_fn(png_ptr, &output, write_png_to_string, flush_png_string);
+	const bool ok = write_png_content(*this, png_ptr, info_ptr);
+	png_destroy_write_struct(&png_ptr, &info_ptr);
+	if (!ok) {
+		output.clear();
+	}
+	return ok;
 }

--- a/network/mcp_server.cc
+++ b/network/mcp_server.cc
@@ -417,11 +417,7 @@ std::string mcp_server_t::dispatch(mcp_connection_t   *c,
 			pending_scripts.push_back(new mcp_pending_t{pending_vm, c, id_json});
 			return "";
 		}
-		// wrap in MCP content array
-		std::string escaped_result = json_escape(result_json);
-		std::string content = "{\"content\":[{\"type\":\"text\",\"text\":\""
-		                    + escaped_result + "\"}]}";
-		return make_response(id_json, content);
+		return make_response(id_json, result_json);
 	}
 
 	// --- unknown method ---

--- a/network/mcp_tools.cc
+++ b/network/mcp_tools.cc
@@ -4,15 +4,14 @@
  */
 
 /**
- * MCP tool: run_squirrel
+ * MCP tool implementations.
  *
- * A single tool that accepts arbitrary Squirrel script code and executes it
- * inside a dedicated script VM that has the full Simutrans scripting API
- * (ai_base) available.  The script should return a value; that value is
- * converted to a string and returned to the MCP client as {"result":"..."}.
+ * run_squirrel accepts arbitrary Squirrel script code and executes it inside a
+ * dedicated script VM that has the full Simutrans scripting API (ai_base)
+ * available. capture_screen returns the current display as MCP image content.
  *
- * A fresh VM is created for each call and destroyed afterwards, so no state
- * (global variables, defined functions, etc.) leaks between invocations.
+ * A fresh VM is created for each run_squirrel call and destroyed afterwards,
+ * so no state (global variables, defined functions, etc.) leaks between calls.
  */
 
 #include "mcp_tools.h"
@@ -25,6 +24,7 @@
 #include "../script/script.h"
 #include "../script/script_loader.h"
 #include "../dataobj/environment.h"
+#include "../display/simgraph.h"
 #include "../utils/cbuffer_t.h"
 #include "../utils/plainstring.h"
 #include "../simconst.h"
@@ -38,6 +38,32 @@
 static std::string jesc(const std::string &s) { return mcp_server_t::json_escape(s); }
 static std::string jstr(const std::string &s)  { return "\"" + jesc(s) + "\""; }
 static std::string jstr(const char *s)          { return s ? jstr(std::string(s)) : "null"; }
+
+static std::string text_content(const std::string &text)
+{
+	return "{\"content\":[{\"type\":\"text\",\"text\":" + jstr(text) + "}]}";
+}
+
+static std::string base64_encode(const std::string &data)
+{
+	static const char chars[] =
+		"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+	std::string encoded;
+	encoded.reserve(((data.size() + 2) / 3) * 4);
+
+	for (size_t i = 0; i < data.size(); i += 3) {
+		const uint32 a = (uint8)data[i];
+		const uint32 b = i + 1 < data.size() ? (uint8)data[i + 1] : 0;
+		const uint32 c = i + 2 < data.size() ? (uint8)data[i + 2] : 0;
+		const uint32 value = (a << 16) | (b << 8) | c;
+
+		encoded += chars[(value >> 18) & 0x3F];
+		encoded += chars[(value >> 12) & 0x3F];
+		encoded += i + 1 < data.size() ? chars[(value >> 6) & 0x3F] : '=';
+		encoded += i + 2 < data.size() ? chars[value & 0x3F] : '=';
+	}
+	return encoded;
+}
 
 
 // ---------------------------------------------------------------------------
@@ -101,6 +127,19 @@ static std::string tool_run_squirrel(const std::string &code, int player_nr,
 	return result_json;
 }
 
+static std::string tool_capture_screen()
+{
+	std::string png_data;
+	const scr_rect screen_area(0, 0, display_get_width(), display_get_height());
+	if (!display_snapshot_png(screen_area, png_data)) {
+		return text_content("{\"error\":\"failed to capture the Simutrans screen\"}");
+	}
+
+	return "{\"content\":[{\"type\":\"image\",\"data\":"
+		+ jstr(base64_encode(png_data))
+		+ ",\"mimeType\":\"image/png\"}]}";
+}
+
 
 // ---------------------------------------------------------------------------
 // Tool registry
@@ -128,6 +167,12 @@ static const tool_def_t TOOL_DEFS[] = {
 		                   "\"description\":\"Player context index (0-15), default 1\"}"
 		 "},"
 		 "\"required\":[\"code\"]}"
+	},
+	{
+		"capture_screen",
+		"Capture the current Simutrans window as a PNG image. "
+		"Use this to inspect the actual on-screen game view and GUI state.",
+		"{\"type\":\"object\",\"properties\":{},\"additionalProperties\":false}"
 	}
 };
 static const int NUM_TOOLS = sizeof(TOOL_DEFS) / sizeof(TOOL_DEFS[0]);
@@ -170,10 +215,14 @@ std::string mcp_tools::tools_call(const std::string &name,
 		else if (pending_vm) {
 			// Caller doesn't support async — treat as error
 			delete pending_vm;
-			return "{\"error\":\"script suspended but caller does not support async\"}";
+			return text_content("{\"error\":\"script suspended but caller does not support async\"}");
 		}
-		return result;
+		return text_content(result);
 	}
 
-	return "{\"error\":\"unknown tool: " + jesc(name) + "\"}";
+	if (name == "capture_screen") {
+		return tool_capture_screen();
+	}
+
+	return text_content("{\"error\":\"unknown tool: " + jesc(name) + "\"}");
 }

--- a/network/mcp_tools.h
+++ b/network/mcp_tools.h
@@ -29,7 +29,7 @@ std::string tools_list_json();
  *                       the VM is stored here instead of being deleted; the caller
  *                       must resume and eventually delete it.  The return value is ""
  *                       in this case (response will be sent asynchronously).
- * @return JSON-serialised result value, or "" when *out_pending_vm was set.
+ * @return JSON-serialised MCP CallToolResult, or "" when *out_pending_vm was set.
  */
 std::string tools_call(const std::string &name,
                        const std::string &args_json,


### PR DESCRIPTION
## 概要
- MCP server に現在のゲーム画面を PNG 画像として返す capture_screen tool を追加しました。
- 既存の screenshot 保存処理と MCP 画像返却で同じ画面キャプチャ処理を使えるよう、raw_image_t の PNG 書き出しをファイル出力とメモリ出力に共通化しました。
- tools/call の返却形式を MCP の content 配列に合わせ、run_squirrel は text content、capture_screen は image content を返すようにしました。

## 確認
- simutrans MCP server の tools/list が run_squirrel と capture_screen を返すことを確認しました。
- capture_screen を呼び出し、現在のゲーム画面 PNG を取得できることを確認しました。
- 既存の PNG screenshot 機能も正常に動作することを確認済みです。