### PR TITLE
Add Squirrel API to open dialog tools

### DIFF
--- a/.agents/skills/simutrans-mcp-gui-debug/SKILL.md
+++ b/.agents/skills/simutrans-mcp-gui-debug/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: simutrans-mcp-gui-debug
+description: Start Simutrans test saves with -mcp-port, execute Squirrel scripts through the built-in MCP server, capture screenshots, and verify GUI/dialog behavior. Use for GUI-oriented debugging or when a test needs visual confirmation rather than the normal automated test runner.
+argument-hint: "[save_name] [squirrel_code]"
+allowed-tools: Bash(make *), Bash(./sim *), Bash(timeout *), Bash(python3 .agents/skills/simutrans-mcp-gui-debug/scripts/mcp_client.py *), Bash(lsof *), Bash(ps *), Bash(kill *), Bash(rg *), Bash(sed *), Read
+---
+
+# Simutrans MCP GUI Debug
+
+Use this skill when GUI state must be inspected visually. This is separate from the normal `run-automated-tests` workflow: start Simutrans with `-load` and `-mcp-port`, drive it through MCP `run_squirrel`, then capture the screen with MCP `capture_screen`.
+
+Do not hardcode local absolute paths, personal config paths, or machine-specific ports in repository files. Use environment variables and placeholders in notes or scripts.
+
+## Core Facts
+
+- Simutrans starts its built-in MCP server with `-mcp-port PORT`.
+- The automated-test scenario declares its base save in `tests/automated-tests/scenario.nut` as `map.file`.
+- For this workflow, load that save directly with `-load SAVE_NAME`, not with `-scenario`.
+- The `-load` argument is the save name without the `.sve` extension.
+- MCP exposes at least `run_squirrel` and `capture_screen`.
+- MCP `run_squirrel` currently runs in an AI-style VM. APIs needed only for MCP driving must be visible outside scenario-only bindings unless the MCP implementation changes.
+- The MCP listener may bind IPv6 loopback (`::1`) instead of IPv4 loopback. The helper script tries both by default.
+- The helper script requires Python 3.10 or newer.
+
+## Procedure
+
+1. Identify the save name:
+   - Read `tests/automated-tests/scenario.nut`.
+   - Use `map.file` without `.sve`, for example `empty-16x16`.
+
+2. Build if code changed:
+   ```bash
+   make -j8
+   ```
+
+3. Choose a temporary MCP port:
+   - Prefer an explicit `MCP_PORT` environment variable when the user provides one.
+   - Otherwise choose a high, task-local port and verify it is free if needed.
+
+4. Start Simutrans in a long-running shell session:
+   ```bash
+   ./sim -set_workdir "${SIMUTRANS_TEST_BASE}" -objects pak \
+     -load "${SAVE_NAME}" -mcp-port "${MCP_PORT}" \
+     -debug 2 -lang en -fps 20
+   ```
+   Keep the process running until all MCP calls and screenshots are complete. If local TCP or the external test base is blocked by sandboxing, request escalation.
+
+5. Call MCP through the helper:
+   ```bash
+   python3 .agents/skills/simutrans-mcp-gui-debug/scripts/mcp_client.py \
+     --port "${MCP_PORT}" \
+     --run-squirrel 'return "ok";'
+   ```
+
+6. Drive the GUI with Squirrel:
+   Set `MCP_SCREENSHOT` to a writable PNG path first. Examples:
+   - POSIX shell: `MCP_SCREENSHOT="${TMPDIR:-/tmp}/simutrans-gui-debug.png"`
+   - PowerShell: `$env:MCP_SCREENSHOT = Join-Path $env:TEMP "simutrans-gui-debug.png"`
+
+   ```bash
+   python3 .agents/skills/simutrans-mcp-gui-debug/scripts/mcp_client.py \
+     --port "${MCP_PORT}" \
+     --run-squirrel 'gui.close_all_windows(); return world.open_dialog_tool(2);' \
+     --capture "${MCP_SCREENSHOT}"
+   ```
+
+7. Inspect the screenshot:
+   - Use the image viewing tool on the captured PNG.
+   - Confirm the expected window, dialog title, selected control, or visual state is actually visible.
+   - Treat a true Squirrel return value as insufficient for GUI bugs unless the screenshot also matches.
+
+8. Clean up:
+   - Stop the Simutrans process you started.
+   - Confirm the MCP port is no longer listening if there is any doubt.
+
+## Troubleshooting
+
+- `connect EPERM`: local TCP is sandbox-blocked; rerun the MCP client with escalation.
+- `Connection refused`: Simutrans is not running, the port is wrong, or the listener bound only to another loopback address. Check the running process and try `::1` / `127.0.0.1`.
+- `the index '...' does not exist`: the Squirrel API is not exported to the VM used by MCP. Check whether it is scenario-only.
+- `Call function failed`: inspect `script-mcp.log` under the active Simutrans workdir for the Squirrel error.
+- Blank or stale screenshot: wait briefly after the GUI action, then call `capture_screen` again.

--- a/.agents/skills/simutrans-mcp-gui-debug/scripts/mcp_client.py
+++ b/.agents/skills/simutrans-mcp-gui-debug/scripts/mcp_client.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Small JSON-RPC client for Simutrans' built-in MCP server."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import socket
+import sys
+import time
+from pathlib import Path
+
+
+def connect(hosts: list[str], port: int, timeout: float) -> socket.socket:
+    last_error: OSError | None = None
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        for host in hosts:
+            try:
+                return socket.create_connection((host, port), timeout=1.0)
+            except OSError as exc:
+                last_error = exc
+        time.sleep(0.25)
+    if last_error is not None:
+        raise last_error
+    raise TimeoutError("could not connect")
+
+
+def send(sock: socket.socket, message: dict) -> None:
+    sock.sendall((json.dumps(message) + "\n").encode("utf-8"))
+
+
+def read_responses(sock: socket.socket, wanted_ids: set[int], timeout: float) -> dict[int, dict]:
+    deadline = time.time() + timeout
+    buffer = b""
+    responses: dict[int, dict] = {}
+    sock.settimeout(0.2)
+    while time.time() < deadline and not wanted_ids.issubset(responses):
+        try:
+            chunk = sock.recv(262144)
+            if not chunk:
+                break
+            buffer += chunk
+        except socket.timeout:
+            continue
+
+        while b"\n" in buffer:
+            line, buffer = buffer.split(b"\n", 1)
+            if not line.strip():
+                continue
+            response = json.loads(line)
+            response_id = response.get("id")
+            if isinstance(response_id, int):
+                responses[response_id] = response
+    return responses
+
+
+def content_text(response: dict) -> str:
+    content = response.get("result", {}).get("content", [])
+    if not content:
+        return json.dumps(response, ensure_ascii=False)
+    first = content[0]
+    if first.get("type") == "text":
+        return first.get("text", "")
+    return json.dumps(response, ensure_ascii=False)
+
+
+def save_capture(response: dict, output: Path) -> None:
+    content = response.get("result", {}).get("content", [])
+    if not content or content[0].get("type") != "image":
+        raise ValueError("capture_screen did not return image content")
+    output.write_bytes(base64.b64decode(content[0]["data"]))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--host", action="append", help="host to try; defaults to ::1 and 127.0.0.1")
+    parser.add_argument("--player-nr", type=int, default=0)
+    parser.add_argument("--run-squirrel", help="Squirrel code to execute through MCP run_squirrel")
+    parser.add_argument("--capture", type=Path, help="write MCP capture_screen PNG to this path")
+    parser.add_argument("--list-tools", action="store_true")
+    parser.add_argument("--timeout", type=float, default=8.0)
+    args = parser.parse_args()
+
+    hosts = args.host or ["::1", "127.0.0.1"]
+    sock = connect(hosts, args.port, args.timeout)
+    next_id = 1
+
+    send(sock, {
+        "jsonrpc": "2.0",
+        "id": next_id,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "simutrans-mcp-gui-debug", "version": "1"},
+        },
+    })
+    wanted = {next_id}
+    next_id += 1
+
+    list_id = None
+    if args.list_tools:
+        list_id = next_id
+        send(sock, {"jsonrpc": "2.0", "id": list_id, "method": "tools/list", "params": {}})
+        wanted.add(list_id)
+        next_id += 1
+
+    run_id = None
+    if args.run_squirrel is not None:
+        run_id = next_id
+        send(sock, {
+            "jsonrpc": "2.0",
+            "id": run_id,
+            "method": "tools/call",
+            "params": {
+                "name": "run_squirrel",
+                "arguments": {"code": args.run_squirrel, "player_nr": args.player_nr},
+            },
+        })
+        wanted.add(run_id)
+        next_id += 1
+
+    printed_run = False
+    if run_id is not None and args.capture is not None:
+        responses = read_responses(sock, wanted, args.timeout)
+        print(content_text(responses[run_id]))
+        printed_run = True
+        time.sleep(1.0)
+        wanted = set()
+    else:
+        responses = {}
+
+    capture_id = None
+    if args.capture is not None:
+        capture_id = next_id
+        send(sock, {
+            "jsonrpc": "2.0",
+            "id": capture_id,
+            "method": "tools/call",
+            "params": {"name": "capture_screen", "arguments": {}},
+        })
+        wanted.add(capture_id)
+
+    responses.update(read_responses(sock, wanted, args.timeout))
+    sock.close()
+
+    if list_id is not None:
+        print(json.dumps(responses[list_id], ensure_ascii=False))
+    if run_id is not None and run_id in responses and not printed_run:
+        print(content_text(responses[run_id]))
+    if capture_id is not None:
+        save_capture(responses[capture_id], args.capture)
+        print(str(args.capture))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/script/api/api_world.cc
+++ b/script/api/api_world.cc
@@ -13,6 +13,7 @@
 #include "../api_function.h"
 #include "../../simworld.h"
 #include "../../simversion.h"
+#include "../../simmenu.h"
 #include "../../player/simplay.h"
 #include "../../obj/gebaeude.h"
 #include "../../obj/label.h"
@@ -81,6 +82,28 @@ bool world_create_player(karte_t *welt, sint32 player_nr, sint32 player_type)
 	}
 	// This will not have an immediate effect in network games.
 	welt->call_change_player_tool(karte_t::new_player, (uint8)player_nr, (uint16)player_type, true /*scripted*/);
+	return true;
+}
+
+
+bool world_open_dialog_tool(karte_t *welt, sint32 tool_nr)
+{
+	if (tool_nr < 0  ||  tool_nr >= DIALOGE_TOOL_COUNT) {
+		return false;
+	}
+
+	player_t *player = welt->get_active_player();
+	if (player == NULL) {
+		return false;
+	}
+
+	tool_t *tool = create_tool((uint16)tool_nr | DIALOGE_TOOL);
+	if (tool == NULL) {
+		return false;
+	}
+
+	welt->set_tool(tool, player);
+	delete tool;
 	return true;
 }
 
@@ -335,6 +358,14 @@ void export_world(HSQUIRRELVM vm, bool scenario)
 		 */
 		STATIC register_method(vm, &world_generate_goods, "generate_goods", true);
 	}
+	/**
+	* Opens a dialog tool for the active player.
+	*
+	* @param tool_nr dialog tool number, for example DIALOG_MINIMAP = 2
+	* @returns whether the dialog tool request was accepted
+	*/
+	STATIC register_method(vm, &world_open_dialog_tool, "open_dialog_tool", true);
+
 	/**
 	 * Returns player number @p pl. If player does not exist, returns null.
 	 * @param pl player number

--- a/script/api/changelog.h
+++ b/script/api/changelog.h
@@ -9,6 +9,7 @@
  *
  * @section api-trunk Current trunk
  *
+ * - Added @ref world::open_dialog_tool to open dialog tools
  * - Added @ref world::create_player to create player companies (scenario only)
  * - Added @ref command_x::grid_lower, @ref command_x::grid_raise
  * - Added @ref settings::has_double_slopes, @ref settings::get_way_height_clearance

--- a/script/api/squirrel_types_ai.awk
+++ b/script/api/squirrel_types_ai.awk
@@ -376,6 +376,7 @@ BEGIN {
 	export_types_ai["world::is_coord_valid"] = "bool(coord)"
 	export_types_ai["world::find_nearest_city"] = "city_x(coord)"
 	export_types_ai["world::get_season"] = "integer()"
+	export_types_ai["world::open_dialog_tool"] = "bool(integer)"
 	export_types_ai["integer::get_player"] = "player_x()"
 	export_types_ai["world::get_time"] = "time_ticks_x()"
 	export_types_ai["world::get_citizens"] = "array<integer>()"

--- a/script/api/squirrel_types_scenario.awk
+++ b/script/api/squirrel_types_scenario.awk
@@ -404,6 +404,7 @@ BEGIN {
 	export_types_scenario["world::find_nearest_city"] = "city_x(coord)"
 	export_types_scenario["world::get_season"] = "integer()"
 	export_types_scenario["world::create_player"] = "bool(integer, integer)"
+	export_types_scenario["world::open_dialog_tool"] = "bool(integer)"
 	export_types_scenario["world::remove_player"] = "bool(player_x)"
 	export_types_scenario["world::generate_goods"] = "integer(coord, coord, good_desc_x, integer)"
 	export_types_scenario["integer::get_player"] = "player_x()"

--- a/tests/automated-tests/all_tests.nut
+++ b/tests/automated-tests/all_tests.nut
@@ -139,6 +139,7 @@ all_tests <- [
 	test_player_cash,
 	test_player_isactive,
 	test_player_create,
+	test_world_open_dialog_tool_invalid,
 	test_player_headquarters,
 	test_player_name,
 	test_player_lines,

--- a/tests/automated-tests/tests/test_player.nut
+++ b/tests/automated-tests/tests/test_player.nut
@@ -111,6 +111,13 @@ function test_player_create()
 }
 
 
+function test_world_open_dialog_tool_invalid()
+{
+	ASSERT_FALSE(world.open_dialog_tool(-1))
+	ASSERT_FALSE(world.open_dialog_tool(9999))
+}
+
+
 function test_player_headquarters()
 {
 	local pl = player_x(0)


### PR DESCRIPTION
## 概要
このPRでは、Squirrel APIから任意のdialog toolを開けるようにします。主な目的は、`-mcp-port` で起動したSimutransに対してMCP経由でSquirrel scriptを実行し、GUI上のdialog表示を自動デバッグ・スクリーンショット確認できるようにすることです。

## 追加されるもの
- `world.open_dialog_tool(tool_nr)` を追加します
  - `tool_nr` には `simmenu.h` の `DIALOG_*` enum番号を指定します
  - 例: `world.open_dialog_tool(2)` で `DIALOG_MINIMAP`、つまりMap dialogを開きます
  - 不正な番号やdialog tool生成失敗時は `false` を返します
- AI/シナリオ双方のSquirrel型定義に `world.open_dialog_tool` を登録します
  - MCPの `run_squirrel` はAI側VMで実行されるため、scenario-onlyではなく通常のworld APIとして利用可能にしています
- `test_world_open_dialog_tool_invalid` を追加します
  - 範囲外のdialog番号が `false` を返すことを確認します
- `simutrans-mcp-gui-debug` skillを追加します
  - `-load SAVE_NAME -mcp-port PORT` でtest環境のsaveを直接起動する手順をまとめています
  - MCP `run_squirrel` でGUI操作を実行し、`capture_screen` で実画面をPNG保存できます
  - 同梱のPython helperで、JSON-RPCを直接書かずにMCP呼び出しとスクリーンショット保存ができます

## できるようになること
- 自動テストだけでは確認しづらいdialog表示を、MCP経由で再現できます
- GUI操作をSquirrel scriptで実行した直後にスクリーンショットを取得し、実際に画面上にdialogが出ているか確認できます
- 例: `gui.close_all_windows(); return world.open_dialog_tool(2);` をMCPで実行し、Map dialogが表示された画面を `capture_screen` で検証できます
- 今後、GUI系の不具合調査やdialog toolの回帰確認を、手操作ではなく再現可能な手順として残しやすくなります

## 確認
- `make -j8`
- `WORKDIR=${SIMUTRANS_TEST_BASE} SIM_BINARY=./sim tests/run-automated-tests.sh test_world_open_dialog_tool_invalid`
- `-load empty-16x16 -mcp-port` でMCP GUI確認
  - `world.open_dialog_tool(2)` が `true` を返すことを確認
  - `capture_screen` でMap dialogが表示されていることを確認
