### PR TITLE
Add GUI accessibility snapshot API

### DIFF
--- a/.agents/skills/simutrans-mcp-gui-debug/SKILL.md
+++ b/.agents/skills/simutrans-mcp-gui-debug/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash(make *), Bash(./sim *), Bash(timeout *), Bash(python3 .agent
 
 # Simutrans MCP GUI Debug
 
-Use this skill when GUI state must be inspected visually. This is separate from the normal `run-automated-tests` workflow: start Simutrans with `-load` and `-mcp-port`, drive it through MCP `run_squirrel`, then capture the screen with MCP `capture_screen`.
+Use this skill when GUI state must be inspected visually. This is separate from the normal `run-automated-tests` workflow: start Simutrans with `-load` and `-mcp-port`, drive it through MCP `run_squirrel`, then capture the screen with MCP `capture_screen`. For GUI/debug work, also use the Squirrel GUI accessibility APIs (`gui.get_windows()` and `gui.get_window_components(window_id)`) to inspect the visible window and component tree.
 
 Do not hardcode local absolute paths, personal config paths, or machine-specific ports in repository files. Use environment variables and placeholders in notes or scripts.
 
@@ -21,6 +21,7 @@ Do not hardcode local absolute paths, personal config paths, or machine-specific
 - MCP `run_squirrel` currently runs in an AI-style VM. APIs needed only for MCP driving must be visible outside scenario-only bindings unless the MCP implementation changes.
 - The MCP listener may bind IPv6 loopback (`::1`) instead of IPv4 loopback. The helper script tries both by default.
 - The helper script requires Python 3.10 or newer.
+- `gui.get_windows()` returns open-window snapshots. Pass a returned window `id` to `gui.get_window_components(window_id)` to inspect that window's component tree.
 
 ## Procedure
 
@@ -60,16 +61,29 @@ Do not hardcode local absolute paths, personal config paths, or machine-specific
    ```bash
    python3 .agents/skills/simutrans-mcp-gui-debug/scripts/mcp_client.py \
      --port "${MCP_PORT}" \
-     --run-squirrel 'gui.close_all_windows(); return world.open_dialog_tool(2);' \
+     --run-squirrel 'gui.close_all_windows(); return gui.open_dialog_tool(2);' \
      --capture "${MCP_SCREENSHOT}"
    ```
 
-7. Inspect the screenshot:
+7. Capture the component tree:
+   - Use `gui.get_windows()` to find the target window, usually the top window after opening the dialog.
+   - Use `gui.get_window_components(window.id)` to retrieve component snapshots.
+   - When printing a component tree for human inspection, filter out components whose `role` is `"unknown"` unless their bounds or existence are directly relevant. These are often layout helpers or zero-size implementation details, and hiding them makes screenshot comparison easier.
+
+   Example:
+   ```bash
+   python3 .agents/skills/simutrans-mcp-gui-debug/scripts/mcp_client.py \
+     --port "${MCP_PORT}" \
+     --run-squirrel 'function b(s) { return "(" + s.x + "," + s.y + "," + s.w + "," + s.h + ")"; } function dump(c, d) { local out = ""; if (c.role != "unknown") { local indent = ""; for (local i = 0; i < d; i++) indent += "  "; out += indent + c.role + "#" + c.id + " screen=" + b(c.screen_bounds); if ("text" in c) out += " text=[" + c.text + "]"; out += "\n"; } foreach (child in c.children) out += dump(child, d + 1); return out; } local top = null; foreach (w in gui.get_windows()) if (w.top) top = w; local out = "window title=[" + top.title + "] bounds=" + b(top.bounds) + "\n"; foreach (c in gui.get_window_components(top.id)) out += dump(c, 0); return out;'
+   ```
+
+8. Inspect the screenshot and component tree:
    - Use the image viewing tool on the captured PNG.
    - Confirm the expected window, dialog title, selected control, or visual state is actually visible.
-   - Treat a true Squirrel return value as insufficient for GUI bugs unless the screenshot also matches.
+   - Compare the component tree's title, text labels, roles, and screen bounds against the screenshot.
+   - Treat a true Squirrel return value as insufficient for GUI bugs unless the screenshot and component tree also match.
 
-8. Clean up:
+9. Clean up:
    - Stop the Simutrans process you started.
    - Confirm the MCP port is no longer listening if there is any doubt.
 

--- a/gui/components/gui_button.h
+++ b/gui/components/gui_button.h
@@ -126,6 +126,8 @@ public:
 	enum type get_type() const { return this->type; }
 
 	const char * get_text() const {return text;}
+	const char *get_accessibility_role() const OVERRIDE { return "button"; }
+	const char *get_accessibility_text() const OVERRIDE { return get_text(); }
 
 	/**
 	 * Set the displayed text of the button

--- a/gui/components/gui_component.h
+++ b/gui/components/gui_component.h
@@ -15,6 +15,18 @@
 
 struct event_t;
 class karte_ptr_t;
+class gui_component_t;
+template<class T> class vector_tpl;
+
+class accessibility_property_collector_t
+{
+public:
+	virtual ~accessibility_property_collector_t() {}
+
+	virtual void add(const char *key, sint32 value) = 0;
+	virtual void add(const char *key, const char *value) = 0;
+	virtual void add(const char *key, bool value) = 0;
+};
 
 /**
  * Base class for all GUI components.
@@ -221,6 +233,12 @@ public:
 	 * @returns bounding box position and size.
 	 */
 	virtual scr_rect get_client( void ) { return scr_rect( pos, size ); }
+
+	virtual const char *get_accessibility_role() const { return "unknown"; }
+	virtual const char *get_accessibility_text() const { return NULL; }
+	virtual void add_accessibility_properties(accessibility_property_collector_t &) const {}
+	virtual void get_accessibility_children(vector_tpl<gui_component_t *> &) const {}
+	virtual scr_coord get_accessibility_child_screen_offset(gui_component_t *) { return pos; }
 
 	// remove margins around this GUI object
 	virtual bool is_marginless() const { return false; }

--- a/gui/components/gui_container.h
+++ b/gui/components/gui_container.h
@@ -90,6 +90,16 @@ public:
 	// FIXME
 	scr_size get_min_size() const OVERRIDE { return get_size(); }
 	scr_size get_max_size() const OVERRIDE { return get_size(); }
+
+	const char *get_accessibility_role() const OVERRIDE { return "container"; }
+	const vector_tpl<gui_component_t *>& get_components() const { return components; }
+	void get_accessibility_children(vector_tpl<gui_component_t *> &children) const OVERRIDE
+	{
+		for (uint32 i = 0; i < components.get_count(); i++) {
+			children.append(components[i]);
+		}
+	}
+	scr_coord get_accessibility_child_screen_offset(gui_component_t *) OVERRIDE { return get_pos(); }
 };
 
 #endif

--- a/gui/components/gui_label.h
+++ b/gui/components/gui_label.h
@@ -69,6 +69,8 @@ public:
 	 * returns the pointer (i.e. for freeing untranslated contents)
 	 */
 	const char * get_text_pointer() const { return text; }
+	const char *get_accessibility_role() const OVERRIDE { return "label"; }
+	const char *get_accessibility_text() const OVERRIDE { return get_text_pointer(); }
 
 	/**
 	 * returns the tooltip pointer (i.e. for freeing untranslated contents)

--- a/gui/components/gui_scrollpane.h
+++ b/gui/components/gui_scrollpane.h
@@ -7,6 +7,7 @@
 #define GUI_COMPONENTS_GUI_SCROLLPANE_H
 
 
+#include "../../tpl/vector_tpl.h"
 #include "gui_component.h"
 #include "gui_scrollbar.h"
 
@@ -48,6 +49,23 @@ public:
 	gui_scrollpane_t(gui_component_t *comp, bool b_scroll_x = false, bool b_scroll_y = true);
 
 	void set_component(gui_component_t *comp) { this->comp = comp; }
+	gui_component_t *get_component() const { return comp; }
+	const char *get_accessibility_role() const OVERRIDE { return "scrollpane"; }
+	void add_accessibility_properties(accessibility_property_collector_t &collector) const OVERRIDE
+	{
+		collector.add("scroll_x", (sint32)get_scroll_x());
+		collector.add("scroll_y", (sint32)get_scroll_y());
+	}
+	void get_accessibility_children(vector_tpl<gui_component_t *> &children) const OVERRIDE
+	{
+		if (comp) {
+			children.append(comp);
+		}
+	}
+	scr_coord get_accessibility_child_screen_offset(gui_component_t *) OVERRIDE
+	{
+		return get_client().get_pos() - scr_coord(get_scroll_x(), get_scroll_y());
+	}
 
 	/**
 	* this is the maximum width a scrollbar requests as minimum size

--- a/gui/components/gui_textinput.h
+++ b/gui/components/gui_textinput.h
@@ -103,6 +103,8 @@ public:
 	 */
 	char *get_text() const { return text; }
 	const char *get_composition() const { return composition.get_str(); }
+	const char *get_accessibility_role() const OVERRIDE { return "textinput"; }
+	const char *get_accessibility_text() const OVERRIDE { return get_text(); }
 
 	bool infowin_event(event_t const*) OVERRIDE;
 

--- a/gui/gui_frame.h
+++ b/gui/gui_frame.h
@@ -231,6 +231,8 @@ public:
 	void set_focus( gui_component_t *c ) { gui_aligned_container_t::set_focus(c); }
 
 	gui_component_t *get_focus() OVERRIDE { return gui_aligned_container_t::get_focus(); }
+
+	const vector_tpl<gui_component_t *>& get_components() const { return gui_aligned_container_t::get_components(); }
 };
 
 #endif

--- a/script/api/api_gui.cc
+++ b/script/api/api_gui.cc
@@ -16,6 +16,7 @@
 #include "../../dataobj/scenario.h"
 #include "../../display/viewport.h"
 #include "../../gui/simwin.h"
+#include "../../gui/gui_frame.h"
 #include "../../player/simplay.h"
 
 #include "../../dataobj/environment.h"
@@ -103,6 +104,235 @@ void_t set_zoom(uint8 val)
 	set_zoom_factor_safe(val);
 	welt->get_viewport()->metrics_updated();
 	return void_t();
+}
+
+static void create_bounds_slot(HSQUIRRELVM vm, const char *name, scr_coord pos, scr_size size, SQInteger table_idx = -1)
+{
+	sq_pushstring(vm, name, -1);
+	sq_newtableex(vm, 4);
+	create_slot(vm, "x", (SQInteger)pos.x);
+	create_slot(vm, "y", (SQInteger)pos.y);
+	create_slot(vm, "w", (SQInteger)size.w);
+	create_slot(vm, "h", (SQInteger)size.h);
+	sq_newslot(vm, table_idx > 0 ? table_idx : -3, false);
+}
+
+#ifdef SQAPI_DOC
+	/**
+	 * Rectangle in screen pixels.
+	 */
+	class gui_bounds_x {
+		public:
+			/**
+			 * Left coordinate.
+			 */
+			integer x;
+			/**
+			 * Top coordinate.
+			 */
+			integer y;
+			/**
+			 * Width.
+			 */
+			integer w;
+			/**
+			 * Height.
+			 */
+			integer h;
+	};
+
+	/**
+	 * Snapshot of an open GUI window returned by @ref gui::get_windows.
+	 */
+	class gui_window_x {
+		public:
+			/**
+			 * Window id to pass to @ref gui::get_window_components.
+			 */
+			integer id;
+			/**
+			 * Stacking order. Higher array indices are closer to the front.
+			 */
+			integer z_order;
+			/**
+			 * True if this is the top window.
+			 */
+			bool top;
+			/**
+			 * Window title, or an empty string if no title is available.
+			 */
+			string title;
+			/**
+			 * True if the window has a title bar.
+			 */
+			bool has_title;
+			/**
+			 * Full window bounds in screen pixels.
+			 */
+			gui_bounds_x bounds;
+			/**
+			 * Client area bounds in screen pixels.
+			 */
+			gui_bounds_x client_bounds;
+	};
+
+	/**
+	 * Snapshot of a GUI component returned by @ref gui::get_window_components.
+	 */
+	class gui_component_x {
+		public:
+			/**
+			 * Component id, unique within one component snapshot.
+			 */
+			integer id;
+			/**
+			 * Component role, such as "button", "label", "textinput", "container", or "scrollpane".
+			 */
+			string role;
+			/**
+			 * True if the component is visible.
+			 */
+			bool visible;
+			/**
+			 * True if the component can receive focus.
+			 */
+			bool focusable;
+			/**
+			 * True if the component currently has focus.
+			 */
+			bool focused;
+			/**
+			 * Bounds relative to the parent component.
+			 */
+			gui_bounds_x bounds;
+			/**
+			 * Bounds in screen pixels.
+			 */
+			gui_bounds_x screen_bounds;
+			/**
+			 * Text exposed by the component. Only present when the component has text.
+			 */
+			string text;
+			/**
+			 * Child component snapshots.
+			 */
+			array<gui_component_x> children;
+			/**
+			 * Horizontal scroll position. Only present on scrollpane components.
+			 */
+			integer scroll_x;
+			/**
+			 * Vertical scroll position. Only present on scrollpane components.
+			 */
+			integer scroll_y;
+	};
+#endif
+
+class squirrel_accessibility_property_collector_t : public accessibility_property_collector_t
+{
+private:
+	HSQUIRRELVM vm;
+	SQInteger table_idx;
+
+public:
+	squirrel_accessibility_property_collector_t(HSQUIRRELVM vm, SQInteger table_idx) : vm(vm), table_idx(table_idx) {}
+
+	void add(const char *key, sint32 value) OVERRIDE { create_slot(vm, key, value, false, table_idx); }
+	void add(const char *key, const char *value) OVERRIDE { create_slot(vm, key, value, false, table_idx); }
+	void add(const char *key, bool value) OVERRIDE { create_slot(vm, key, value, false, table_idx); }
+};
+
+static void push_accessible_component(HSQUIRRELVM vm, gui_component_t *comp, scr_coord offset, uint32 &next_id)
+{
+	const uint32 id = next_id++;
+	const scr_coord pos = comp->get_pos();
+	const scr_size size = comp->get_size();
+	const scr_coord screen_pos = offset + pos;
+
+	sq_newtable(vm);
+	const SQInteger table_idx = sq_gettop(vm);
+	create_slot(vm, "id", (SQInteger)id, false, table_idx);
+	create_slot(vm, "role", comp->get_accessibility_role(), false, table_idx);
+	create_slot(vm, "visible", comp->is_visible(), false, table_idx);
+	create_slot(vm, "focusable", comp->is_focusable(), false, table_idx);
+	create_slot(vm, "focused", win_get_focus() == comp, false, table_idx);
+	create_bounds_slot(vm, "bounds", pos, size, table_idx);
+	create_bounds_slot(vm, "screen_bounds", screen_pos, size, table_idx);
+
+	if (const char *text = comp->get_accessibility_text()) {
+		create_slot(vm, "text", text, false, table_idx);
+	}
+
+	squirrel_accessibility_property_collector_t collector(vm, table_idx);
+	comp->add_accessibility_properties(collector);
+
+	sq_pushstring(vm, "children", -1);
+	sq_newarray(vm, 0);
+	vector_tpl<gui_component_t *> children;
+	comp->get_accessibility_children(children);
+	for (uint32 i = 0; i < children.get_count(); i++) {
+		gui_component_t *child = children[i];
+		push_accessible_component(vm, child, offset + comp->get_accessibility_child_screen_offset(child), next_id);
+		sq_arrayappend(vm, -2);
+	}
+	sq_newslot(vm, table_idx, false);
+
+	sq_settop(vm, table_idx);
+}
+
+static SQInteger get_windows(HSQUIRRELVM vm)
+{
+	sq_newarray(vm, 0);
+	const uint32 count = win_get_open_count();
+	for (uint32 i = 0; i < count; i++) {
+		gui_frame_t *win = win_get_index(i);
+		if (!win) {
+			continue;
+		}
+
+		const scr_coord pos = win_get_pos(win);
+		const scr_size size = win->get_windowsize();
+		const scr_size client_size = win->get_client_windowsize();
+		const scr_coord client_pos(pos.x, pos.y + (win->has_title() ? D_TITLEBAR_HEIGHT : 0));
+
+		sq_newtable(vm);
+		const SQInteger table_idx = sq_gettop(vm);
+		create_slot(vm, "id", (SQInteger)i, false, table_idx);
+		create_slot(vm, "z_order", (SQInteger)i, false, table_idx);
+		create_slot(vm, "top", win_get_top() == win, false, table_idx);
+		create_slot(vm, "title", win->get_name() ? win->get_name() : "", false, table_idx);
+		create_slot(vm, "has_title", win->has_title(), false, table_idx);
+		create_bounds_slot(vm, "bounds", pos, size, table_idx);
+		create_bounds_slot(vm, "client_bounds", client_pos, client_size, table_idx);
+		sq_arrayappend(vm, -2);
+	}
+	return 1;
+}
+
+static SQInteger get_window_components(HSQUIRRELVM vm)
+{
+	SQInteger window_id;
+	sq_getinteger(vm, 2, &window_id);
+	if (window_id < 0 || (uint32)window_id >= win_get_open_count()) {
+		sq_pushnull(vm);
+		return 1;
+	}
+
+	gui_frame_t *win = win_get_index((uint32)window_id);
+	if (!win) {
+		sq_pushnull(vm);
+		return 1;
+	}
+
+	sq_newarray(vm, 0);
+	uint32 next_id = 0;
+	const scr_coord win_pos = win_get_pos(win);
+	const vector_tpl<gui_component_t *> &components = win->get_components();
+	for (uint32 i = 0; i < components.get_count(); i++) {
+		push_accessible_component(vm, components[i], win_pos, next_id);
+		sq_arrayappend(vm, -2);
+	}
+	return 1;
 }
 
 void export_gui(HSQUIRRELVM vm, bool scenario)
@@ -197,5 +427,25 @@ void export_gui(HSQUIRRELVM vm, bool scenario)
 	* @param zoom Zoom factor to set.
 	*/
 	STATIC register_method(vm, &set_zoom, "set_zoom");
+
+	/**
+	* Get snapshots of currently open GUI windows.
+	*
+	* Each entry contains id, z_order, top, title, has_title, bounds, and client_bounds.
+	* Pass the id to @ref gui::get_window_components to inspect the components in that window.
+	* @typemask array<gui_window_x> ()
+	*/
+	register_function(vm, get_windows, "get_windows", 1, ".");
+
+	/**
+	* Get snapshots of components in the given GUI window.
+	*
+	* Components are returned as a tree. Each component has role, bounds, screen_bounds,
+	* visible, focusable, focused, children, and optional text fields.
+	* @param window_id id property of a window snapshot returned by @ref gui::get_windows.
+	* @returns array of @ref gui_component_x, or null if window_id is invalid.
+	* @typemask array<gui_component_x> (integer)
+	*/
+	register_function(vm, get_window_components, "get_window_components", 2, ".i");
 	end_class(vm);
 }

--- a/script/api/api_gui.cc
+++ b/script/api/api_gui.cc
@@ -347,10 +347,10 @@ static SQInteger get_window_components(HSQUIRRELVM vm)
 
 	sq_newarray(vm, 0);
 	uint32 next_id = 0;
-	const scr_coord win_pos = win_get_pos(win);
+	const scr_coord component_offset = win_get_pos(win) + scr_coord(0, win->has_title() ? D_TITLEBAR_HEIGHT : 0);
 	const vector_tpl<gui_component_t *> &components = win->get_components();
 	for (uint32 i = 0; i < components.get_count(); i++) {
-		push_accessible_component(vm, components[i], win_pos, next_id);
+		push_accessible_component(vm, components[i], component_offset, next_id);
 		sq_arrayappend(vm, -2);
 	}
 	return 1;

--- a/script/api/api_gui.cc
+++ b/script/api/api_gui.cc
@@ -106,6 +106,27 @@ void_t set_zoom(uint8 val)
 	return void_t();
 }
 
+bool open_dialog_tool(sint32 tool_nr)
+{
+	if (tool_nr < 0  ||  tool_nr >= DIALOGE_TOOL_COUNT) {
+		return false;
+	}
+
+	player_t *player = welt->get_active_player();
+	if (player == NULL) {
+		return false;
+	}
+
+	tool_t *tool = create_tool((uint16)tool_nr | DIALOGE_TOOL);
+	if (tool == NULL) {
+		return false;
+	}
+
+	welt->set_tool(tool, player);
+	delete tool;
+	return true;
+}
+
 static void create_bounds_slot(HSQUIRRELVM vm, const char *name, scr_coord pos, scr_size size, SQInteger table_idx = -1)
 {
 	sq_pushstring(vm, name, -1);
@@ -427,6 +448,14 @@ void export_gui(HSQUIRRELVM vm, bool scenario)
 	* @param zoom Zoom factor to set.
 	*/
 	STATIC register_method(vm, &set_zoom, "set_zoom");
+
+	/**
+	* Opens a dialog tool for the active player.
+	*
+	* @param tool_nr dialog tool number, for example DIALOG_MINIMAP = 2
+	* @returns whether the dialog tool request was accepted
+	*/
+	STATIC register_method(vm, &open_dialog_tool, "open_dialog_tool");
 
 	/**
 	* Get snapshots of currently open GUI windows.

--- a/script/api/api_world.cc
+++ b/script/api/api_world.cc
@@ -86,28 +86,6 @@ bool world_create_player(karte_t *welt, sint32 player_nr, sint32 player_type)
 }
 
 
-bool world_open_dialog_tool(karte_t *welt, sint32 tool_nr)
-{
-	if (tool_nr < 0  ||  tool_nr >= DIALOGE_TOOL_COUNT) {
-		return false;
-	}
-
-	player_t *player = welt->get_active_player();
-	if (player == NULL) {
-		return false;
-	}
-
-	tool_t *tool = create_tool((uint16)tool_nr | DIALOGE_TOOL);
-	if (tool == NULL) {
-		return false;
-	}
-
-	welt->set_tool(tool, player);
-	delete tool;
-	return true;
-}
-
-
 uint32 world_generate_goods(karte_t *welt, koord from, koord to, const goods_desc_t *desc, uint32 count)
 {
 	if (count == 0 || count >= 1<<23) {
@@ -358,14 +336,6 @@ void export_world(HSQUIRRELVM vm, bool scenario)
 		 */
 		STATIC register_method(vm, &world_generate_goods, "generate_goods", true);
 	}
-	/**
-	* Opens a dialog tool for the active player.
-	*
-	* @param tool_nr dialog tool number, for example DIALOG_MINIMAP = 2
-	* @returns whether the dialog tool request was accepted
-	*/
-	STATIC register_method(vm, &world_open_dialog_tool, "open_dialog_tool", true);
-
 	/**
 	 * Returns player number @p pl. If player does not exist, returns null.
 	 * @param pl player number

--- a/script/api/changelog.h
+++ b/script/api/changelog.h
@@ -9,7 +9,7 @@
  *
  * @section api-trunk Current trunk
  *
- * - Added @ref world::open_dialog_tool to open dialog tools
+ * - Added @ref gui::open_dialog_tool to open dialog tools
  * - Added @ref world::create_player to create player companies (scenario only)
  * - Added @ref command_x::grid_lower, @ref command_x::grid_raise
  * - Added @ref settings::has_double_slopes, @ref settings::get_way_height_clearance

--- a/script/api/squirrel_types_ai.awk
+++ b/script/api/squirrel_types_ai.awk
@@ -376,7 +376,7 @@ BEGIN {
 	export_types_ai["world::is_coord_valid"] = "bool(coord)"
 	export_types_ai["world::find_nearest_city"] = "city_x(coord)"
 	export_types_ai["world::get_season"] = "integer()"
-	export_types_ai["world::open_dialog_tool"] = "bool(integer)"
+	export_types_ai["gui::open_dialog_tool"] = "bool(integer)"
 	export_types_ai["integer::get_player"] = "player_x()"
 	export_types_ai["world::get_time"] = "time_ticks_x()"
 	export_types_ai["world::get_citizens"] = "array<integer>()"

--- a/script/api/squirrel_types_scenario.awk
+++ b/script/api/squirrel_types_scenario.awk
@@ -404,7 +404,7 @@ BEGIN {
 	export_types_scenario["world::find_nearest_city"] = "city_x(coord)"
 	export_types_scenario["world::get_season"] = "integer()"
 	export_types_scenario["world::create_player"] = "bool(integer, integer)"
-	export_types_scenario["world::open_dialog_tool"] = "bool(integer)"
+	export_types_scenario["gui::open_dialog_tool"] = "bool(integer)"
 	export_types_scenario["world::remove_player"] = "bool(player_x)"
 	export_types_scenario["world::generate_goods"] = "integer(coord, coord, good_desc_x, integer)"
 	export_types_scenario["integer::get_player"] = "player_x()"

--- a/tests/automated-tests/all_tests.nut
+++ b/tests/automated-tests/all_tests.nut
@@ -16,6 +16,7 @@ include("tests/test_dir")
 include("tests/test_factory")
 include("tests/test_convoy_cargo")
 include("tests/test_good")
+include("tests/test_gui_accessibility")
 include("tests/test_groundobj")
 include("tests/test_halt")
 include("tests/test_headquarters")
@@ -102,6 +103,7 @@ all_tests <- [
 	test_convoy_cargo_loaded,
 	test_good_is_interchangeable,
 	test_good_speed_bonus,
+	test_gui_accessibility_windows_and_components,
 	test_groundobj_build_invalid_param,
 	test_groundobj_build_invalid_pos,
 	test_groundobj_build_random,

--- a/tests/automated-tests/all_tests.nut
+++ b/tests/automated-tests/all_tests.nut
@@ -141,7 +141,7 @@ all_tests <- [
 	test_player_cash,
 	test_player_isactive,
 	test_player_create,
-	test_world_open_dialog_tool_invalid,
+	test_gui_open_dialog_tool_invalid,
 	test_player_headquarters,
 	test_player_name,
 	test_player_lines,

--- a/tests/automated-tests/tests/test_gui_accessibility.nut
+++ b/tests/automated-tests/tests/test_gui_accessibility.nut
@@ -1,0 +1,79 @@
+//
+// This file is part of the Simutrans project under the Artistic License.
+// (see LICENSE.txt)
+//
+
+
+//
+// Tests for GUI accessibility snapshots.
+//
+
+function test_gui_accessibility_windows_and_components()
+{
+	gui.close_all_windows()
+	gui.open_info_win()
+
+	local windows = gui.get_windows()
+	ASSERT_TRUE(windows.len() > 0)
+
+	local target_window = null
+	foreach (w in windows) {
+		ASSERT_TRUE("id" in w)
+		ASSERT_TRUE("bounds" in w)
+		ASSERT_TRUE("client_bounds" in w)
+		ASSERT_TRUE("title" in w)
+		ASSERT_TRUE("x" in w.bounds)
+		ASSERT_TRUE("y" in w.bounds)
+		ASSERT_TRUE("w" in w.bounds)
+		ASSERT_TRUE("h" in w.bounds)
+
+		ASSERT_EQUAL(typeof(w.id), "integer")
+		ASSERT_EQUAL(typeof(w.z_order), "integer")
+		ASSERT_EQUAL(typeof(w.top), "bool")
+		ASSERT_EQUAL(typeof(w.title), "string")
+		ASSERT_EQUAL(typeof(w.has_title), "bool")
+		ASSERT_EQUAL(typeof(w.bounds.x), "integer")
+		ASSERT_EQUAL(typeof(w.bounds.y), "integer")
+		ASSERT_EQUAL(typeof(w.bounds.w), "integer")
+		ASSERT_EQUAL(typeof(w.bounds.h), "integer")
+		ASSERT_EQUAL(typeof(w.client_bounds.x), "integer")
+		ASSERT_EQUAL(typeof(w.client_bounds.y), "integer")
+		ASSERT_EQUAL(typeof(w.client_bounds.w), "integer")
+		ASSERT_EQUAL(typeof(w.client_bounds.h), "integer")
+
+		if (w.top) {
+			target_window = w
+		}
+	}
+	ASSERT_TRUE(target_window != null)
+
+	local components = gui.get_window_components(target_window.id)
+	ASSERT_TRUE(components != null)
+	ASSERT_TRUE(components.len() > 0)
+
+	foreach (c in components) {
+		ASSERT_TRUE("id" in c)
+		ASSERT_TRUE("role" in c)
+		ASSERT_TRUE("screen_bounds" in c)
+		ASSERT_TRUE("children" in c)
+		ASSERT_TRUE("x" in c.screen_bounds)
+		ASSERT_TRUE("y" in c.screen_bounds)
+		ASSERT_TRUE("w" in c.screen_bounds)
+		ASSERT_TRUE("h" in c.screen_bounds)
+
+		ASSERT_EQUAL(typeof(c.id), "integer")
+		ASSERT_EQUAL(typeof(c.role), "string")
+		ASSERT_EQUAL(typeof(c.visible), "bool")
+		ASSERT_EQUAL(typeof(c.focusable), "bool")
+		ASSERT_EQUAL(typeof(c.focused), "bool")
+		ASSERT_EQUAL(typeof(c.screen_bounds.x), "integer")
+		ASSERT_EQUAL(typeof(c.screen_bounds.y), "integer")
+		ASSERT_EQUAL(typeof(c.screen_bounds.w), "integer")
+		ASSERT_EQUAL(typeof(c.screen_bounds.h), "integer")
+		ASSERT_EQUAL(typeof(c.children), "array")
+	}
+
+	ASSERT_EQUAL(gui.get_window_components(-1), null)
+
+	gui.close_all_windows()
+}

--- a/tests/automated-tests/tests/test_gui_accessibility.nut
+++ b/tests/automated-tests/tests/test_gui_accessibility.nut
@@ -71,6 +71,8 @@ function test_gui_accessibility_windows_and_components()
 		ASSERT_EQUAL(typeof(c.screen_bounds.w), "integer")
 		ASSERT_EQUAL(typeof(c.screen_bounds.h), "integer")
 		ASSERT_EQUAL(typeof(c.children), "array")
+		ASSERT_TRUE(c.screen_bounds.x >= target_window.client_bounds.x)
+		ASSERT_TRUE(c.screen_bounds.y >= target_window.client_bounds.y)
 	}
 
 	ASSERT_EQUAL(gui.get_window_components(-1), null)

--- a/tests/automated-tests/tests/test_player.nut
+++ b/tests/automated-tests/tests/test_player.nut
@@ -111,10 +111,10 @@ function test_player_create()
 }
 
 
-function test_world_open_dialog_tool_invalid()
+function test_gui_open_dialog_tool_invalid()
 {
-	ASSERT_FALSE(world.open_dialog_tool(-1))
-	ASSERT_FALSE(world.open_dialog_tool(9999))
+	ASSERT_FALSE(gui.open_dialog_tool(-1))
+	ASSERT_FALSE(gui.open_dialog_tool(9999))
 }
 
 


### PR DESCRIPTION
## 概要

Squirrel API から現在開いている GUI window と、その window 内の component tree を取得できる accessibility snapshot API を追加しました。

- `gui.get_windows()` を追加
- `gui.get_window_components(window_id)` を追加
- `gui.open_dialog_tool(tool_nr)` を追加し、既存の `world.open_dialog_tool` は削除
- component の role/text/children/custom property を各 GUI component 側の仮想関数で拡張できる形に整理
- `scroll_x` / `scroll_y` など一部 component 固有の property を collector 経由で返せるように変更
- `simutrans-mcp-gui-debug` skill に component tree を使った GUI debug 手順を追記

## 確認

- `make -j8`
- `test_gui_accessibility_windows_and_components`
- `test_gui_open_dialog_tool_invalid`
- MCP GUI debug で DIALOG_PLAYERS を開き、screenshot と component tree を比較して妥当性を確認
