### PR TITLE
add finance_history_decade

### DIFF
--- a/gui/citylist_frame_t.cc
+++ b/gui/citylist_frame_t.cc
@@ -164,6 +164,7 @@ citylist_frame_t::citylist_frame_t() :
 
 	year_month_tabs.add_tab(&container_year, translator::translate("Years"));
 	year_month_tabs.add_tab(&container_month, translator::translate("Months"));
+	year_month_tabs.add_tab(&container_decade, translator::translate("Decades"));
 	// .. put the same buttons in both containers
 	button_t* buttons[karte_t::MAX_WORLD_COST];
 
@@ -201,6 +202,22 @@ citylist_frame_t::citylist_frame_t() :
 		button_to_chart.append(buttons[i], &mchart, curve);
 	}
 	container_month.end_table();
+
+	container_decade.set_table_layout(1,0);
+	container_decade.add_component(&dchart);
+	dchart.set_dimension(12, karte_t::MAX_WORLD_COST*MAX_WORLD_HISTORY_DECADES);
+	dchart.set_background(SYSCOL_CHART_BACKGROUND);
+	dchart.set_min_size(scr_size(0, 8*LINESPACE));
+
+	container_decade.add_table(4,3);
+	for (int i = 0; i<karte_t::MAX_WORLD_COST; i++) {
+		sint16 curve = dchart.add_curve(color_idx_to_rgb(hist_type_color[i]), welt->get_finance_history_decade(), karte_t::MAX_WORLD_COST, i, MAX_WORLD_HISTORY_DECADES, hist_type_type[i], false, true, (i==1) ? 1 : 0 );
+
+		// add button
+		container_decade.add_component(buttons[i]);
+		button_to_chart.append(buttons[i], &dchart, curve);
+	}
+	container_decade.end_table();
 
 	update_label();
 

--- a/gui/citylist_frame_t.h
+++ b/gui/citylist_frame_t.h
@@ -47,8 +47,8 @@ private:
 
 	gui_scrolled_list_t scrolly;
 
-	gui_aligned_container_t container_year, container_month;
-	gui_chart_t chart, mchart;
+	gui_aligned_container_t container_year, container_month, container_decade;
+	gui_chart_t chart, mchart, dchart;
 	gui_button_to_chart_array_t button_to_chart;
 	gui_tab_panel_t year_month_tabs;
 	gui_tab_panel_t main;

--- a/simworld.cc
+++ b/simworld.cc
@@ -4958,7 +4958,7 @@ DBG_MESSAGE("karte_t::save(loadsave_t *file)", "saved messages");
 			}
 		}
 	}
-	if(  file->get_OTRP_version() >= 56  ) {
+	if(  file->get_OTRP_version() >= 57  ) {
 		for (int decade = 0; decade<MAX_WORLD_HISTORY_DECADES; decade++) {
 			for (int cost_type = 0; cost_type<MAX_WORLD_COST; cost_type++) {
 				file->rdwr_longlong(finance_history_decade[decade][cost_type]);
@@ -5563,7 +5563,7 @@ DBG_MESSAGE("karte_t::load()", "%d factories loaded", fab_list.get_count());
 			restore_history(true);
 		}
 	}
-	if(  file->get_OTRP_version() >= 56  ) {
+	if(  file->get_OTRP_version() >= 57  ) {
 		for (int decade = 0; decade<MAX_WORLD_HISTORY_DECADES; decade++) {
 			for (int cost_type = 0; cost_type<MAX_WORLD_COST; cost_type++) {
 				file->rdwr_longlong(finance_history_decade[decade][cost_type]);

--- a/simworld.cc
+++ b/simworld.cc
@@ -648,6 +648,11 @@ void karte_t::init_tiles()
 			finance_history_month[month][cost_type] = 0;
 		}
 	}
+	for (int decade=0; decade<MAX_WORLD_HISTORY_DECADES; decade++) {
+		for (int cost_type=0; cost_type<MAX_WORLD_COST; cost_type++) {
+			finance_history_decade[decade][cost_type] = 0;
+		}
+	}
 	last_month_bev = 0;
 
 	tile_counter = 0;
@@ -4031,6 +4036,16 @@ void karte_t::new_year()
 		}
 	}
 
+	// record decade snapshot at 0, 10, 20, ... years after map start
+	if(  (last_year - settings.get_starting_year()) % 10 == 0  ) {
+		for(  int hist=0;  hist<karte_t::MAX_WORLD_COST;  hist++  ) {
+			for( int d=MAX_WORLD_HISTORY_DECADES-1; d>0; d--  ) {
+				finance_history_decade[d][hist] = finance_history_decade[d-1][hist];
+			}
+			finance_history_decade[0][hist] = finance_history_year[0][hist];
+		}
+	}
+
 DBG_MESSAGE("karte_t::new_year()","speedbonus for %d %i, %i, %i, %i, %i, %i, %i, %i", last_year,
 			average_speed[0], average_speed[1], average_speed[2], average_speed[3], average_speed[4], average_speed[5], average_speed[6], average_speed[7] );
 
@@ -4943,6 +4958,13 @@ DBG_MESSAGE("karte_t::save(loadsave_t *file)", "saved messages");
 			}
 		}
 	}
+	if(  file->get_OTRP_version() >= 56  ) {
+		for (int decade = 0; decade<MAX_WORLD_HISTORY_DECADES; decade++) {
+			for (int cost_type = 0; cost_type<MAX_WORLD_COST; cost_type++) {
+				file->rdwr_longlong(finance_history_decade[decade][cost_type]);
+			}
+		}
+	}
 
 	// finally a possible scenario
 	scenario->rdwr( file );
@@ -5539,6 +5561,13 @@ DBG_MESSAGE("karte_t::load()", "%d factories loaded", fab_list.get_count());
 
 		if (file->is_version_atleast(112, 5) &&  file->is_version_less(120, 6)) {
 			restore_history(true);
+		}
+	}
+	if(  file->get_OTRP_version() >= 56  ) {
+		for (int decade = 0; decade<MAX_WORLD_HISTORY_DECADES; decade++) {
+			for (int cost_type = 0; cost_type<MAX_WORLD_COST; cost_type++) {
+				file->rdwr_longlong(finance_history_decade[decade][cost_type]);
+			}
 		}
 	}
 

--- a/simworld.h
+++ b/simworld.h
@@ -101,6 +101,7 @@ public:
 
 	#define MAX_WORLD_HISTORY_YEARS   (12) // number of years to keep history
 	#define MAX_WORLD_HISTORY_MONTHS  (12) // number of months to keep history
+	#define MAX_WORLD_HISTORY_DECADES (12) // number of decades to keep history
 
 	enum {
 		NORMAL       = 0,
@@ -308,6 +309,11 @@ private:
 	 * The recorded history so far.
 	 */
 	sint64 finance_history_month[MAX_WORLD_HISTORY_MONTHS][MAX_WORLD_COST];
+
+	/**
+	 * The recorded history so far (one entry per decade).
+	 */
+	sint64 finance_history_decade[MAX_WORLD_HISTORY_DECADES][MAX_WORLD_COST];
 
 	/**
 	 * World record speed manager.
@@ -827,6 +833,16 @@ public:
 	 * Returns pointer to finance history for player.
 	 */
 	const sint64* get_finance_history_month() const { return *finance_history_month; }
+
+	/**
+	 * Returns the decade finance history for world.
+	 */
+	sint64 get_finance_history_decade(int decade, int type) const { return finance_history_decade[decade][type]; }
+
+	/**
+	 * Returns pointer to decade finance history for world.
+	 */
+	const sint64* get_finance_history_decade() const { return *finance_history_decade; }
 
 	/**
 	 * Recalcs all map images.


### PR DESCRIPTION
マップの`history`に関するデータについて、10年ごとに保存し120年間分を記録するようにしました。