### PR TITLE
do not add register_line or register_convoy when pass stop

### DIFF
--- a/gui/minimap.cc
+++ b/gui/minimap.cc
@@ -251,7 +251,7 @@ void minimap_t::add_to_schedule_cache( convoihandle_t cnv, bool with_waypoints )
 		//cycle on stops
 		//try to read station's coordinates if there's a station at this schedule stop
 		halthandle_t station = haltestelle_t::get_stoppable_halt( cur.pos, cnv->get_owner(), schedule->get_waytype() );
-		if(  station.is_bound()  ) {
+		if(  station.is_bound()  &&  !cur.is_pass_stop()  ) {
 			stop_cache.append_unique( station );
 			temp_stop = station->get_basis_pos();
 			stops ++;
@@ -338,7 +338,7 @@ void minimap_t::add_to_schedule_cache_without_cnv( schedule_t* schedule, player_
 		//cycle on stops
 		//try to read station's coordinates if there's a station at this schedule stop
 		halthandle_t station = haltestelle_t::get_stoppable_halt( cur.pos, owner, schedule->get_waytype() );
-		if(  station.is_bound()  ) {
+		if(  station.is_bound()  &&  !cur.is_pass_stop()  ) {
 			if (  is_highlighted  ) route_search_highlighted_halts.append_unique(station);
 			stop_cache.append_unique( station );
 			temp_stop = station->get_basis_pos();

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -4992,7 +4992,7 @@ void convoi_t::register_stops()
 	if(  schedule  ) {
 		FOR(minivec_tpl<schedule_entry_t>, const& i, schedule->get_entries()) {
 			halthandle_t const halt = haltestelle_t::get_stoppable_halt(i.pos, get_owner(), front()->get_waytype());
-			if(  halt.is_bound()  ) {
+			if(  halt.is_bound()&&!i.is_pass_stop()  ) {
 				halt->add_convoy(self);
 			}
 		}

--- a/simhalt.cc
+++ b/simhalt.cc
@@ -4378,7 +4378,7 @@ bool haltestelle_t::add_grund(grund_t *gr, bool relink_factories)
 				// only add unknown lines
 				if(  !registered_lines.is_contained(j)  &&  j->count_convoys() > 0  ) {
 					FOR(  minivec_tpl<schedule_entry_t>, const& k, j->get_schedule()->get_entries()  ) {
-						if(  get_stoppable_halt(k.pos, player, j->get_schedule()->get_waytype()) == self  ) {
+						if(  (get_stoppable_halt(k.pos, player, j->get_schedule()->get_waytype()) == self)  &&  !k.is_pass_stop()  ) {
 							registered_lines.append(j);
 							break;
 						}
@@ -4393,7 +4393,7 @@ bool haltestelle_t::add_grund(grund_t *gr, bool relink_factories)
 		if(  !cnv->get_line().is_bound()  &&  (public_halt  ||  cnv->get_owner()==get_owner())  &&  !registered_convoys.is_contained(cnv)  ) {
 			if(  const schedule_t *const schedule = cnv->get_schedule()  ) {
 				FOR(  minivec_tpl<schedule_entry_t>, const& k, schedule->get_entries()  ) {
-					if (get_stoppable_halt(k.pos, cnv->get_owner(), schedule->get_waytype()) == self) {
+					if (  (get_stoppable_halt(k.pos, cnv->get_owner(), schedule->get_waytype()) == self)  &&  !k.is_pass_stop()  ) {
 						registered_convoys.append(cnv);
 						break;
 					}
@@ -4502,7 +4502,7 @@ bool haltestelle_t::rem_grund(grund_t *gr)
 	for(  size_t j = registered_lines.get_count();  j-- != 0;  ) {
 		bool ok = false;
 		FOR(  minivec_tpl<schedule_entry_t>, const& k, registered_lines[j]->get_schedule()->get_entries()  ) {
-			if(  get_stoppable_halt(k.pos, registered_lines[j]->get_owner(),registered_lines[j]->get_schedule()->get_waytype()) == self  ) {
+			if(  (get_stoppable_halt(k.pos, registered_lines[j]->get_owner(),registered_lines[j]->get_schedule()->get_waytype()) == self  )  &&  !k.is_pass_stop()  ) {
 				ok = true;
 				break;
 			}
@@ -4518,7 +4518,7 @@ bool haltestelle_t::rem_grund(grund_t *gr)
 	for(  size_t j = registered_convoys.get_count();  j-- != 0;  ) {
 		bool ok = false;
 		FOR(  minivec_tpl<schedule_entry_t>, const& k, registered_convoys[j]->get_schedule()->get_entries()  ) {
-			if(  get_stoppable_halt(k.pos, registered_convoys[j]->get_owner(),registered_convoys[j]->get_schedule()->get_waytype()) == self  ) {
+			if(  (get_stoppable_halt(k.pos, registered_convoys[j]->get_owner(),registered_convoys[j]->get_schedule()->get_waytype()) == self)  &&  !k.is_pass_stop()  ) {
 				ok = true;
 				break;
 			}

--- a/simline.cc
+++ b/simline.cc
@@ -393,7 +393,7 @@ void simline_t::register_stops(schedule_t * schedule)
 DBG_DEBUG("simline_t::register_stops()", "%d schedule entries in schedule %p", schedule->get_count(),schedule);
 	FOR(minivec_tpl<schedule_entry_t>, const& i, schedule->get_entries()) {
 		halthandle_t const halt = haltestelle_t::get_stoppable_halt(i.pos, player, schedule->get_waytype());
-		if(halt.is_bound()) {
+		if(halt.is_bound()&&!i.is_pass_stop()) {
 //DBG_DEBUG("simline_t::register_stops()", "halt not null");
 			halt->add_line(self);
 		}


### PR DESCRIPTION
駅を通過する設定にした場合、駅の編成・路線一覧に表示しないようにしました。
また、地図の路線図表示でも中継点と同様の扱いとしました