### PR TITLE
Package macOS build as app bundle

### DIFF
--- a/.github/build-mac.sh
+++ b/.github/build-mac.sh
@@ -1,12 +1,6 @@
 #!/bin/sh
 # builds for macOS
 
-# remove dynamic libraries to force static linking
-rm /opt/homebrew/opt/freetype/lib/libfreetype.dylib
-rm /opt/homebrew/opt/libpng/lib/libpng16.dylib
-rm /opt/homebrew/opt/zstd/lib/libzstd.dylib
-rm /opt/homebrew/opt/sdl2/lib/libSDL2.dylib 
-
 # normal build
 echo "BACKEND = sdl2" >config.default
 echo "OSTYPE = mac" >>config.default
@@ -14,7 +8,7 @@ echo "COLOUR_DEPTH =16" >>config.default
 echo "DEBUG = 0" >>config.default
 echo "MSG_LEVEL = 3" >>config.default
 echo "OPTIMISE = 1" >>config.default
-echo "STATIC = 1" >>config.default
+echo "STATIC = 0" >>config.default
 echo "MULTI_THREAD = 1" >>config.default
 echo "USE_ZSTD = 1" >>config.default
 echo "USE_FREETYPE = 1" >>config.default
@@ -22,4 +16,3 @@ echo "WITH_REVISION = 9281" >>config.default
 echo "AV_FOUNDATION = 1" >>config.default
 echo "FLAGS = -std=c++20" >>config.default
 make -j4
-mv build/default/sim sim-mac-OTRP

--- a/.github/package-mac-app.sh
+++ b/.github/package-mac-app.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+set -euo pipefail
+
+usage() {
+	echo "usage: $0 --binary BINARY --app APP" >&2
+	exit 2
+}
+
+BINARY=
+APP=
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		--binary)
+			[ "$#" -ge 2 ] || usage
+			BINARY="$2"
+			shift 2
+			;;
+		--app)
+			[ "$#" -ge 2 ] || usage
+			APP="$2"
+			shift 2
+			;;
+		*)
+			usage
+			;;
+	esac
+done
+
+[ -n "$BINARY" ] || usage
+[ -n "$APP" ] || usage
+[ -f "$BINARY" ] || { echo "missing binary: $BINARY" >&2; exit 1; }
+
+ROOT_DIR="$(pwd)"
+BINARY="$(cd "$(dirname "$BINARY")" && pwd -P)/$(basename "$BINARY")"
+CONTENTS="$APP/Contents"
+MACOS="$CONTENTS/MacOS"
+FRAMEWORKS="$CONTENTS/Frameworks"
+RESOURCES="$CONTENTS/Resources"
+APP_EXE="$MACOS/sim"
+
+FREETYPE_PREFIX="$(brew --prefix freetype)"
+PNG_PREFIX="$(brew --prefix libpng)"
+ZSTD_PREFIX="$(brew --prefix zstd)"
+SDL2_PREFIX="$(brew --prefix sdl2)"
+SDL3_PREFIX="$(brew --prefix sdl3)"
+
+FREETYPE_DYLIB="$FREETYPE_PREFIX/lib/libfreetype.6.dylib"
+PNG_DYLIB="$PNG_PREFIX/lib/libpng16.16.dylib"
+ZSTD_DYLIB="$ZSTD_PREFIX/lib/libzstd.1.dylib"
+SDL2_DYLIB="$SDL2_PREFIX/lib/libSDL2-2.0.0.dylib"
+SDL3_DYLIB="$SDL3_PREFIX/lib/libSDL3.0.dylib"
+
+for dylib in "$FREETYPE_DYLIB" "$PNG_DYLIB" "$ZSTD_DYLIB" "$SDL2_DYLIB" "$SDL3_DYLIB"; do
+	[ -f "$dylib" ] || { echo "missing dylib: $dylib" >&2; exit 1; }
+done
+
+rm -rf "$APP"
+mkdir -p "$MACOS" "$FRAMEWORKS" "$RESOURCES"
+cp -p "$BINARY" "$APP_EXE"
+cp -p "$ROOT_DIR/OSX/Info.plist" "$CONTENTS/Info.plist"
+cp -p "$ROOT_DIR/OSX/simutrans.icns" "$RESOURCES/simutrans.icns"
+printf 'APPL????\n' > "$CONTENTS/PkgInfo"
+
+cp -p "$FREETYPE_DYLIB" "$FRAMEWORKS/libfreetype.6.dylib"
+cp -p "$PNG_DYLIB" "$FRAMEWORKS/libpng16.16.dylib"
+cp -p "$ZSTD_DYLIB" "$FRAMEWORKS/libzstd.1.dylib"
+cp -p "$SDL2_DYLIB" "$FRAMEWORKS/libSDL2-2.0.0.dylib"
+
+# Homebrew's SDL2 package is currently sdl2-compat, which dlopens SDL3.
+cp -p "$SDL3_DYLIB" "$FRAMEWORKS/libSDL3.0.dylib"
+cp -p "$SDL3_DYLIB" "$FRAMEWORKS/libSDL3.dylib"
+
+install_name_tool \
+	-change "$FREETYPE_DYLIB" "@executable_path/../Frameworks/libfreetype.6.dylib" \
+	-change "$PNG_DYLIB" "@executable_path/../Frameworks/libpng16.16.dylib" \
+	-change "$ZSTD_DYLIB" "@executable_path/../Frameworks/libzstd.1.dylib" \
+	-change "$SDL2_DYLIB" "@executable_path/../Frameworks/libSDL2-2.0.0.dylib" \
+	"$APP_EXE"
+
+install_name_tool \
+	-change "$PNG_DYLIB" "@executable_path/../Frameworks/libpng16.16.dylib" \
+	"$FRAMEWORKS/libfreetype.6.dylib"
+
+install_name_tool -id "@executable_path/../Frameworks/libfreetype.6.dylib" "$FRAMEWORKS/libfreetype.6.dylib"
+install_name_tool -id "@executable_path/../Frameworks/libpng16.16.dylib" "$FRAMEWORKS/libpng16.16.dylib"
+install_name_tool -id "@executable_path/../Frameworks/libzstd.1.dylib" "$FRAMEWORKS/libzstd.1.dylib"
+install_name_tool -id "@executable_path/../Frameworks/libSDL2-2.0.0.dylib" "$FRAMEWORKS/libSDL2-2.0.0.dylib"
+install_name_tool -id "@loader_path/libSDL3.0.dylib" "$FRAMEWORKS/libSDL3.0.dylib"
+install_name_tool -id "@loader_path/libSDL3.dylib" "$FRAMEWORKS/libSDL3.dylib"
+
+while IFS= read -r rpath; do
+	[ -n "$rpath" ] || continue
+	install_name_tool -delete_rpath "$rpath" "$FRAMEWORKS/libSDL2-2.0.0.dylib" 2>/dev/null || true
+done < <(otool -l "$FRAMEWORKS/libSDL2-2.0.0.dylib" | awk '
+	$1 == "cmd" && $2 == "LC_RPATH" {
+		getline
+		getline
+		if ($1 == "path") print $2
+	}
+')
+install_name_tool -add_rpath "@loader_path" "$FRAMEWORKS/libSDL2-2.0.0.dylib" 2>/dev/null || true
+
+codesign --force --deep --sign - "$APP"
+codesign --verify --deep --strict --verbose=2 "$APP"
+
+echo "Created $APP"

--- a/.github/workflows/otrp-macos.yml
+++ b/.github/workflows/otrp-macos.yml
@@ -17,7 +17,7 @@ jobs:
     - name: install_dependencies
       run: | 
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-        brew install sdl2 libpng miniupnpc pkg-config
+        brew install sdl2 sdl3 freetype libpng zstd miniupnpc pkg-config
 #        brew install freetype
 # freetype library is in the system, but not the header
 #        curl -L "https://downloads.sourceforge.net/project/freetype/freetype2/2.10.1/ft2101.zip?&use_mirror=autoselect" > ft2101.zip
@@ -36,14 +36,19 @@ jobs:
         if [[ $GITHUB_REF == refs/tags/* ]]; then
           echo "SUFFIX=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
         else
-          echo "SUFFIX=_${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+          REF_NAME="${GITHUB_REF#refs/heads/}"
+          echo "SUFFIX=_${REF_NAME//\//_}" >> $GITHUB_ENV
         fi
 
-    - name: Rename executable
-      run: mv sim-mac-OTRP sim-mac-OTRP${{ env.SUFFIX }}
+    - name: Package app
+      run: |
+        APP_NAME=sim-mac-OTRP${{ env.SUFFIX }}.app
+        bash ./.github/package-mac-app.sh --binary build/default/sim --app "$APP_NAME"
+        mkdir -p macos-artifact
+        mv "$APP_NAME" macos-artifact/
 
-    - name: Upload the executable
+    - name: Upload the app package
       uses: actions/upload-artifact@v4
       with:
-        name: sim-mac-OTRP${{ env.SUFFIX }}
-        path: ./sim-mac-OTRP${{ env.SUFFIX }}
+        name: sim-mac-OTRP${{ env.SUFFIX }}.app
+        path: ./macos-artifact

--- a/.github/workflows/otrp-macos.yml
+++ b/.github/workflows/otrp-macos.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - v*
+  pull_request:
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/otrp-macos.yml
+++ b/.github/workflows/otrp-macos.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
 
-    runs-on: macOS-latest
+    runs-on: macos-15
     
     steps:
     - uses: actions/checkout@v4

--- a/OSX/Info.plist
+++ b/OSX/Info.plist
@@ -2,9 +2,23 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
+    <key>CFBundleDisplayName</key>
+    <string>Simutrans OTRP</string>
     <key>CFBundleExecutable</key>
     <string>sim</string>
+    <key>CFBundleIconFile</key>
+    <string>simutrans.icns</string>
+    <key>CFBundleIdentifier</key>
+    <string>org.simutrans.simutrans-otrp</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
     <key>CFBundleName</key>
     <string>Simutrans OTRP</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleSignature</key>
+    <string>????</string>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
   </dict>
 </plist>


### PR DESCRIPTION
## 概要

macOS CI の成果物を単体実行ファイルではなく `.app` バンドルとして作成・アップロードするように変更しました。

- macOS build を pull request でも実行するように変更
- Homebrew の動的ライブラリを同梱する `.app` パッケージ作成スクリプトを追加
- static link 前提の dylib 削除処理をやめ、dynamic link + bundled Frameworks 構成に変更
- app bundle 用の `Info.plist` メタデータとアイコン設定を追加

## 確認

- `git diff --check OTRP-KUTAv6...HEAD`
