### PR TITLE
Fix city road replacement speed

### DIFF
--- a/bauer/wegbauer.cc
+++ b/bauer/wegbauer.cc
@@ -2656,6 +2656,7 @@ void way_builder_t::build_road()
 				player_t::add_maintenance(s, -str->get_desc()->get_maintenance(), str->get_desc()->get_finance_waytype());
 				// cost is the more expensive one, so downgrading is between removing and new building
 				cost -= max( str->get_desc()->get_price(), desc->get_price() );
+				str->set_gehweg(add_sidewalk);
 				str->set_desc(desc);
 				str->set_overtaking_mode(overtaking_mode);
 				str->set_street_flag(street_flag);
@@ -2664,7 +2665,6 @@ void way_builder_t::build_road()
 				if (wo  &&  wo->get_desc()->get_topspeed() < str->get_max_speed()) {
 					str->set_max_speed( wo->get_desc()->get_topspeed() );
 				}
-				str->set_gehweg(add_sidewalk);
 				player_t::add_maintenance( player_builder, str->get_desc()->get_maintenance(), str->get_desc()->get_finance_waytype());
 				str->set_owner(player_builder);
 				str->set_way_building(false);// show ribi
@@ -3159,5 +3159,4 @@ void way_builder_t::update_ribi_mask_oneway(strasse_t* str, uint32 i) {
 		}
 	}
 }
-
 

--- a/tests/automated-tests/tests/test_way_road.nut
+++ b/tests/automated-tests/tests/test_way_road.nut
@@ -1156,14 +1156,16 @@ function test_way_road_cityroad_downgrade_with_cityroad()
 function test_way_road_cityroad_replace_by_normal_road()
 {
 	local public_pl = player_x(1)
+	local pl = player_x(0)
 	local start_pos = coord3d(3, 2, 0)
 	local end_pos = coord3d(3, 6, 0)
+	local road_desc = way_desc_x("cobblestone_road")
 
 	ASSERT_EQUAL(command_x(tool_build_cityroad).work(public_pl, start_pos, end_pos, "city_road"), null)
 
 	// replace cityroad by normal road
 	{
-		ASSERT_EQUAL(command_x.build_way(public_pl start_pos, end_pos, way_desc_x("cobblestone_road"), true), null)
+		ASSERT_EQUAL(command_x.build_way(pl, start_pos, end_pos, road_desc, true), null)
 
 		for (local y = start_pos.y; y < end_pos.y; ++y) {
 			local r = way_x(start_pos.x, y, start_pos.z)
@@ -1171,6 +1173,7 @@ function test_way_road_cityroad_replace_by_normal_road()
 			ASSERT_TRUE(r.is_valid())
 			ASSERT_FALSE(r.has_sidewalk())
 			ASSERT_EQUAL(r.desc.name, "cobblestone_road")
+			ASSERT_EQUAL(r.get_max_speed(), road_desc.get_topspeed())
 		}
 
 		ASSERT_WAY_PATTERN(wt_road, coord3d(0, 0, 0),


### PR DESCRIPTION
Discord thread: https://discord.com/channels/973792214696202271/1521820412743520297/1521820412743520297

## 概要

公共事業ではないプレイヤーが city road を通常道路で上書きしたとき、道路の種類だけでなく制限速度も上書き後の道路に合わせて更新されるようにしました。

これにより、city road の歩道由来の 50km/h 制限が、歩道を持たない高速度道路への置換後に残らなくなります。

## 変更内容

- 既存道路を置換する際、歩道状態を更新してから道路 desc を設定するように変更
- 非公共プレイヤーが city road を `cobblestone_road` で置換した場合に、`get_max_speed()` が道路 desc の `get_topspeed()` と一致することを Squirrel テストで確認

## 確認

- `make -j8`
- 自動テストの通過を確認