### PR TITLE
Allow custom RGB colors for players and lines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ else ifeq ($(OSTYPE),mingw)
   endif
   LDFLAGS   += -pthread
   CFLAGS    += -Wno-deprecated-copy -DNOMINMAX -DWIN32_LEAN_AND_MEAN -DWINVER=0x0501 -D_WIN32_IE=0x0500
-  LIBS      += -lmingw32 -lgdi32 -lwinmm -lws2_32 -limm32
+  LIBS      += -lmingw32 -lgdi32 -lwinmm -lws2_32 -limm32 -lcomdlg32
 
   # Disable the console on Windows unless WIN32_CONSOLE is set or graphics are disabled
   ifdef WIN32_CONSOLE

--- a/Simutrans-GDI.vcxproj
+++ b/Simutrans-GDI.vcxproj
@@ -96,7 +96,7 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;shell32.lib;winmm.lib;zlibstat.lib;advapi32.lib;ws2_32.lib;imm32.lib;libbz2.lib;libpthreadVC3.lib;miniupnpc.lib;freetype.lib;Xaudio2.lib;libzstd_static.lib;libpng16.lib</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;shell32.lib;winmm.lib;zlibstat.lib;advapi32.lib;ws2_32.lib;imm32.lib;comdlg32.lib;libbz2.lib;libpthreadVC3.lib;miniupnpc.lib;freetype.lib;Xaudio2.lib;libzstd_static.lib;libpng16.lib</AdditionalDependencies>
       <IgnoreSpecificDefaultLibraries>libcmtd.lib</IgnoreSpecificDefaultLibraries>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>false</EnableCOMDATFolding>
@@ -142,7 +142,7 @@
       <MultiProcessorCompilation Condition="'$(Configuration)|$(Platform)'=='Stable|x64'">true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;shell32.lib;winmm.lib;zlibstat.lib;advapi32.lib;ws2_32.lib;imm32.lib;libbz2.lib;libpthreadVC3.lib;miniupnpc.lib;freetype.lib;Xaudio2.lib;libzstd_static.lib;libpng16.lib</AdditionalDependencies>
+      <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;shell32.lib;winmm.lib;zlibstat.lib;advapi32.lib;ws2_32.lib;imm32.lib;comdlg32.lib;libbz2.lib;libpthreadVC3.lib;miniupnpc.lib;freetype.lib;Xaudio2.lib;libzstd_static.lib;libpng16.lib</AdditionalDependencies>
       <GenerateDebugInformation>false</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <LargeAddressAware Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</LargeAddressAware>

--- a/boden/grund.cc
+++ b/boden/grund.cc
@@ -1681,18 +1681,22 @@ void grund_t::display_obj_fg(const sint16 xpos, const sint16 ypos, const bool is
 // display text label in player colors using different styles set by env_t::show_names
 void display_text_label(sint16 xpos, sint16 ypos, const char* text, const player_t *player, bool dirty)
 {
-	sint16 pc = player ? player->get_player_color1()+4 : SYSCOL_TEXT_HIGHLIGHT;
+	// For player: use shade-aware accessor; for null-player: fall back to palette index
+	const PIXVAL pc4 = player ? player->get_player_color1_pixval(4) : color_idx_to_rgb(SYSCOL_TEXT_HIGHLIGHT);
+	const PIXVAL pc7 = player ? player->get_player_color1_pixval(7) : color_idx_to_rgb(SYSCOL_TEXT_HIGHLIGHT+3);
+	const PIXVAL pc2 = player ? player->get_player_color1_pixval(2) : color_idx_to_rgb(SYSCOL_TEXT_HIGHLIGHT-2);
+	const PIXVAL pc6 = player ? player->get_player_color1_pixval(6) : color_idx_to_rgb(SYSCOL_TEXT_HIGHLIGHT+2);
 	switch( env_t::show_names >> 2 ) {
 		case 0:
-			display_ddd_proportional_clip( xpos, ypos, color_idx_to_rgb(pc), color_idx_to_rgb(COL_BLACK), text, dirty );
+			display_ddd_proportional_clip( xpos, ypos, pc4, color_idx_to_rgb(COL_BLACK), text, dirty );
 			break;
 		case 1:
-			display_outline_proportional_rgb( xpos, ypos, color_idx_to_rgb(pc+3), color_idx_to_rgb(COL_BLACK), text, dirty );
+			display_outline_proportional_rgb( xpos, ypos, pc7, color_idx_to_rgb(COL_BLACK), text, dirty );
 			break;
 		case 2: {
 			display_outline_proportional_rgb( xpos + LINESPACE + D_H_SPACE, ypos,   color_idx_to_rgb(COL_YELLOW), color_idx_to_rgb(COL_BLACK), text, dirty );
-			display_ddd_box_clip_rgb(         xpos,                         ypos,   LINESPACE,   LINESPACE,   color_idx_to_rgb(pc-2), PLAYER_FLAG|color_idx_to_rgb(pc+2) );
-			display_fillbox_wh_rgb(           xpos+1,                       ypos+1, LINESPACE-2, LINESPACE-2, color_idx_to_rgb(pc), dirty );
+			display_ddd_box_clip_rgb(         xpos,                         ypos,   LINESPACE,   LINESPACE,   pc2, PLAYER_FLAG|pc6 );
+			display_fillbox_wh_rgb(           xpos+1,                       ypos+1, LINESPACE-2, LINESPACE-2, pc4, dirty );
 			break;
 		}
 	}

--- a/display/simgraph.h
+++ b/display/simgraph.h
@@ -174,13 +174,22 @@ void display_day_night_shift(int night);
 // scrolls horizontally, will ignore clipping etc.
 void display_scroll_band( const scr_coord_val start_y, const scr_coord_val x_offset, const scr_coord_val h );
 
-// set first and second company color for player
+// set first and second company color for player (preset palette index)
 void display_set_player_color_scheme(const int player, const uint8 col1, const uint8 col2 );
+// set first and second company color for player using arbitrary RGB (r,g,b each 0-255)
+void display_set_player_color_scheme_rgb(const int player, uint8 r1, uint8 g1, uint8 b1, uint8 r2, uint8 g2, uint8 b2);
+// returns the day-mode PIXVAL for shade 0-7 of a player's color slot (shade 4 = base/"bright" color)
+PIXVAL display_get_player_color_pixval(const int player, bool is_color2, int shade);
+// convert 8-bit R,G,B to native PIXVAL (RGB565 or RGB555)
+PIXVAL make_rgb_pixval(uint8 r, uint8 g, uint8 b);
+// convert native PIXVAL (RGB565 or RGB555) back to 8-bit R,G,B
+void pixval_to_rgb8(PIXVAL col, uint8 &r, uint8 &g, uint8 &b);
 
 // draw image with per-object line color substitution (live rendering, no image cache slot used)
-void display_color_img_line(const image_id n, scr_coord_val xp, scr_coord_val yp, const uint8 col, const sint8 player_nr, const bool daynight, const bool dirty  CLIP_NUM_DEF);
+// line_color is the line's actual RGB pixel value (as returned by simline_t::get_colour()), not a palette index
+void display_color_img_line(const image_id n, scr_coord_val xp, scr_coord_val yp, const PIXVAL line_color, const sint8 player_nr, const bool daynight, const bool dirty  CLIP_NUM_DEF);
 // base-image variant: uses base coords when GUI viewport scale differs from game zoom
-void display_base_img_line(const image_id n, scr_coord_val xp, scr_coord_val yp, const uint8 col, const sint8 player_nr, const bool daynight, const bool dirty  CLIP_NUM_DEF);
+void display_base_img_line(const image_id n, scr_coord_val xp, scr_coord_val yp, const PIXVAL line_color, const sint8 player_nr, const bool daynight, const bool dirty  CLIP_NUM_DEF);
 
 // only used for GUI, display image inside a rect
 void display_img_aligned( const image_id n, scr_rect area, int align, const bool dirty);

--- a/display/simgraph0.cc
+++ b/display/simgraph0.cc
@@ -185,6 +185,33 @@ void display_base_img(const image_id, scr_coord_val, scr_coord_val, const sint8,
 {
 }
 
+void display_color_img_line(const image_id, scr_coord_val, scr_coord_val, const PIXVAL, const sint8, const bool, const bool  CLIP_NUM_DEF_NOUSE)
+{
+}
+
+void display_base_img_line(const image_id, scr_coord_val, scr_coord_val, const PIXVAL, const sint8, const bool, const bool  CLIP_NUM_DEF_NOUSE)
+{
+}
+
+void display_set_player_color_scheme_rgb(const int, uint8, uint8, uint8, uint8, uint8, uint8)
+{
+}
+
+PIXVAL display_get_player_color_pixval(const int, bool, int)
+{
+	return 0;
+}
+
+PIXVAL make_rgb_pixval(uint8, uint8, uint8)
+{
+	return 0;
+}
+
+void pixval_to_rgb8(PIXVAL, uint8 &r, uint8 &g, uint8 &b)
+{
+	r = g = b = 0;
+}
+
 void display_fit_img_to_width( const image_id, sint16)
 {
 }

--- a/display/simgraph16.cc
+++ b/display/simgraph16.cc
@@ -318,6 +318,20 @@ static uint8 transparent_map_all_day_rgb[(MAX_PLAYER_COUNT+LIGHT_COUNT+1024)*4];
 // offsets of first and second company color
 static uint8 player_offsets[MAX_PLAYER_COUNT][2];
 
+// Custom RGB colors (R,G,B as uint8) per player per color slot; active when player_use_custom is true
+static uint8 player_custom_rgb[MAX_PLAYER_COUNT][2][3];
+static bool  player_use_custom[MAX_PLAYER_COUNT];
+
+// Shade multipliers derived from actual Simutrans palette (relative to shade 4 = base color)
+// Values are numerators with denominator 189 (= shade4 value for reference blue channel)
+static const int SHADE_NUM[8] = { 103, 124, 145, 167, 189, 211, 233, 255 };
+static const int SHADE_BASE   = 189;
+
+static inline int shade_channel(int base_ch, int shade_idx)
+{
+	return min(255, base_ch * SHADE_NUM[shade_idx] / SHADE_BASE);
+}
+
 
 /*
  * Image map descriptor structure
@@ -358,6 +372,32 @@ struct imd {
 #define TWO_OUT_16 (0x39E7)
 #define ONE_OUT_15 (0x3DEF)
 #define TWO_OUT_15 (0x1CE7)
+
+// Fill 8 PIXVAL shade entries and 8 transparent entries for one player color slot,
+// applying the given night multipliers (same formula as calc_base_pal_from_night_shift).
+static void fill_custom_shades(PIXVAL* rgbmap8, PIXVAL* tmap8, uint8* tmap8_rgb,
+                                uint8 r, uint8 g, uint8 b,
+                                double rg_mult, double b_mult)
+{
+	for(int i = 0; i < 8; i++) {
+		const int R = (int)(shade_channel(r, i) * rg_mult);
+		const int G = (int)(shade_channel(g, i) * rg_mult);
+		const int B = (int)(shade_channel(b, i) * b_mult);
+		const PIXVAL col = get_system_color(R > 0 ? R : 0, G > 0 ? G : 0, B > 0 ? B : 0);
+		rgbmap8[i] = col;
+#ifdef RGB555
+		tmap8[i] = (col >> 2) & TWO_OUT_15;
+		tmap8_rgb[i*4+0] = col >> 10;
+		tmap8_rgb[i*4+1] = (col >> 5) & 0x1F;
+		tmap8_rgb[i*4+2] = col & 0x1F;
+#else
+		tmap8[i] = (col >> 2) & TWO_OUT_16;
+		tmap8_rgb[i*4+0] = col >> 11;
+		tmap8_rgb[i*4+1] = (col >> 5) & 0x3F;
+		tmap8_rgb[i*4+2] = col & 0x1F;
+#endif
+	}
+}
 
 static int bitdepth = 16;
 
@@ -1170,32 +1210,42 @@ static void activate_player_color(sint8 player_nr, bool daynight)
 	// caches the last settings
 	if(!daynight) {
 		if(player_day!=player_nr) {
-			int i;
 			player_day = player_nr;
-			for(i=0;  i<8;  i++  ) {
-				rgbmap_all_day[0x8000+i] = specialcolormap_all_day[player_offsets[player_day][0]+i];
-				rgbmap_all_day[0x8008+i] = specialcolormap_all_day[player_offsets[player_day][1]+i];
+			if(player_use_custom[player_day]) {
+				fill_custom_shades(
+					&rgbmap_all_day[0x8000], &transparent_map_all_day[0], &transparent_map_all_day_rgb[0],
+					player_custom_rgb[player_day][0][0], player_custom_rgb[player_day][0][1], player_custom_rgb[player_day][0][2],
+					1.0, 1.0);
+				fill_custom_shades(
+					&rgbmap_all_day[0x8008], &transparent_map_all_day[8], &transparent_map_all_day_rgb[32],
+					player_custom_rgb[player_day][1][0], player_custom_rgb[player_day][1][1], player_custom_rgb[player_day][1][2],
+					1.0, 1.0);
+			}
+			else {
+				int i;
+				for(i=0;  i<8;  i++  ) {
+					rgbmap_all_day[0x8000+i] = specialcolormap_all_day[player_offsets[player_day][0]+i];
+					rgbmap_all_day[0x8008+i] = specialcolormap_all_day[player_offsets[player_day][1]+i];
 #ifdef RGB555
-				transparent_map_all_day[i] = (specialcolormap_all_day[player_offsets[player_day][0] + i] >> 2) & TWO_OUT_15;
-				transparent_map_all_day[i + 8] = (specialcolormap_all_day[player_offsets[player_day][1] + i] >> 2) & TWO_OUT_15;
-				// those save RGB components
-				transparent_map_all_day_rgb[i * 4 + 0] = specialcolormap_all_day[player_offsets[player_day][0] + i] >> 10;
-				transparent_map_all_day_rgb[i * 4 + 1] = (specialcolormap_all_day[player_offsets[player_day][0] + i] >> 5) & 0x31;
-				transparent_map_all_day_rgb[i * 4 + 2] = specialcolormap_all_day[player_offsets[player_day][0] + i] & 0x1F;
-				transparent_map_all_day_rgb[i * 4 + 0 + 32] = specialcolormap_all_day[player_offsets[player_day][1] + i] >> 10;
-				transparent_map_all_day_rgb[i * 4 + 1 + 32] = (specialcolormap_all_day[player_offsets[player_day][1] + i] >> 5) & 0x1F;
-				transparent_map_all_day_rgb[i * 4 + 2 + 32] = specialcolormap_all_day[player_offsets[player_day][1] + i] & 0x1F;
+					transparent_map_all_day[i] = (specialcolormap_all_day[player_offsets[player_day][0] + i] >> 2) & TWO_OUT_15;
+					transparent_map_all_day[i + 8] = (specialcolormap_all_day[player_offsets[player_day][1] + i] >> 2) & TWO_OUT_15;
+					transparent_map_all_day_rgb[i * 4 + 0] = specialcolormap_all_day[player_offsets[player_day][0] + i] >> 10;
+					transparent_map_all_day_rgb[i * 4 + 1] = (specialcolormap_all_day[player_offsets[player_day][0] + i] >> 5) & 0x31;
+					transparent_map_all_day_rgb[i * 4 + 2] = specialcolormap_all_day[player_offsets[player_day][0] + i] & 0x1F;
+					transparent_map_all_day_rgb[i * 4 + 0 + 32] = specialcolormap_all_day[player_offsets[player_day][1] + i] >> 10;
+					transparent_map_all_day_rgb[i * 4 + 1 + 32] = (specialcolormap_all_day[player_offsets[player_day][1] + i] >> 5) & 0x1F;
+					transparent_map_all_day_rgb[i * 4 + 2 + 32] = specialcolormap_all_day[player_offsets[player_day][1] + i] & 0x1F;
 #else
-				transparent_map_all_day[i] = (specialcolormap_all_day[player_offsets[player_day][0] + i] >> 2) & TWO_OUT_16;
-				transparent_map_all_day[i + 8] = (specialcolormap_all_day[player_offsets[player_day][1] + i] >> 2) & TWO_OUT_16;
-				// those save RGB components
-				transparent_map_all_day_rgb[i * 4 + 0] = specialcolormap_all_day[player_offsets[player_day][0] + i] >> 11;
-				transparent_map_all_day_rgb[i * 4 + 1] = (specialcolormap_all_day[player_offsets[player_day][0] + i] >> 5) & 0x3F;
-				transparent_map_all_day_rgb[i * 4 + 2] = specialcolormap_all_day[player_offsets[player_day][0] + i] & 0x1F;
-				transparent_map_all_day_rgb[i * 4 + 0 + 32] = specialcolormap_all_day[player_offsets[player_day][1] + i] >> 11;
-				transparent_map_all_day_rgb[i * 4 + 1 + 32] = (specialcolormap_all_day[player_offsets[player_day][1] + i] >> 5) & 0x3F;
-				transparent_map_all_day_rgb[i * 4 + 2 + 32] = specialcolormap_all_day[player_offsets[player_day][1] + i] & 0x1F;
+					transparent_map_all_day[i] = (specialcolormap_all_day[player_offsets[player_day][0] + i] >> 2) & TWO_OUT_16;
+					transparent_map_all_day[i + 8] = (specialcolormap_all_day[player_offsets[player_day][1] + i] >> 2) & TWO_OUT_16;
+					transparent_map_all_day_rgb[i * 4 + 0] = specialcolormap_all_day[player_offsets[player_day][0] + i] >> 11;
+					transparent_map_all_day_rgb[i * 4 + 1] = (specialcolormap_all_day[player_offsets[player_day][0] + i] >> 5) & 0x3F;
+					transparent_map_all_day_rgb[i * 4 + 2] = specialcolormap_all_day[player_offsets[player_day][0] + i] & 0x1F;
+					transparent_map_all_day_rgb[i * 4 + 0 + 32] = specialcolormap_all_day[player_offsets[player_day][1] + i] >> 11;
+					transparent_map_all_day_rgb[i * 4 + 1 + 32] = (specialcolormap_all_day[player_offsets[player_day][1] + i] >> 5) & 0x3F;
+					transparent_map_all_day_rgb[i * 4 + 2 + 32] = specialcolormap_all_day[player_offsets[player_day][1] + i] & 0x1F;
 #endif
+				}
 			}
 		}
 		rgbmap_current = rgbmap_all_day;
@@ -1203,32 +1253,44 @@ static void activate_player_color(sint8 player_nr, bool daynight)
 	else {
 		// changing color table
 		if(player_night!=player_nr) {
-			int i;
 			player_night = player_nr;
-			for(i=0;  i<8;  i++  ) {
-				rgbmap_day_night[0x8000+i] = specialcolormap_day_night[player_offsets[player_night][0]+i];
-				rgbmap_day_night[0x8008+i] = specialcolormap_day_night[player_offsets[player_night][1]+i];
+			if(player_use_custom[player_night]) {
+				const double rg_mult = pow(0.75, night_shift) * ((light_level + 8.0) / 8.0);
+				const double b_mult  = pow(0.83, night_shift) * ((light_level + 8.0) / 8.0);
+				fill_custom_shades(
+					&rgbmap_day_night[0x8000], &transparent_map_day_night[0], &transparent_map_day_night_rgb[0],
+					player_custom_rgb[player_night][0][0], player_custom_rgb[player_night][0][1], player_custom_rgb[player_night][0][2],
+					rg_mult, b_mult);
+				fill_custom_shades(
+					&rgbmap_day_night[0x8008], &transparent_map_day_night[8], &transparent_map_day_night_rgb[32],
+					player_custom_rgb[player_night][1][0], player_custom_rgb[player_night][1][1], player_custom_rgb[player_night][1][2],
+					rg_mult, b_mult);
+			}
+			else {
+				int i;
+				for(i=0;  i<8;  i++  ) {
+					rgbmap_day_night[0x8000+i] = specialcolormap_day_night[player_offsets[player_night][0]+i];
+					rgbmap_day_night[0x8008+i] = specialcolormap_day_night[player_offsets[player_night][1]+i];
 #ifdef RGB555
-				transparent_map_day_night[i] = (specialcolormap_day_night[player_offsets[player_day][0] + i] >> 2) & TWO_OUT_15;
-				transparent_map_day_night[i + 8] = (specialcolormap_day_night[player_offsets[player_day][1] + i] >> 2) & TWO_OUT_15;
-				// those save RGB components
-				transparent_map_day_night_rgb[i * 4 + 0] = specialcolormap_day_night[player_offsets[player_day][0] + i] >> 10;
-				transparent_map_day_night_rgb[i * 4 + 1] = (specialcolormap_day_night[player_offsets[player_day][0] + i] >> 5) & 0x31;
-				transparent_map_day_night_rgb[i * 4 + 2] = specialcolormap_day_night[player_offsets[player_day][0] + i] & 0x1F;
-				transparent_map_day_night_rgb[i * 4 + 0 + 32] = specialcolormap_day_night[player_offsets[player_day][1] + i] >> 10;
-				transparent_map_day_night_rgb[i * 4 + 1 + 32] = (specialcolormap_day_night[player_offsets[player_day][1] + i] >> 5) & 0x1F;
-				transparent_map_day_night_rgb[i * 4 + 2 + 32] = specialcolormap_day_night[player_offsets[player_day][1] + i] & 0x1F;
+					transparent_map_day_night[i] = (specialcolormap_day_night[player_offsets[player_day][0] + i] >> 2) & TWO_OUT_15;
+					transparent_map_day_night[i + 8] = (specialcolormap_day_night[player_offsets[player_day][1] + i] >> 2) & TWO_OUT_15;
+					transparent_map_day_night_rgb[i * 4 + 0] = specialcolormap_day_night[player_offsets[player_day][0] + i] >> 10;
+					transparent_map_day_night_rgb[i * 4 + 1] = (specialcolormap_day_night[player_offsets[player_day][0] + i] >> 5) & 0x31;
+					transparent_map_day_night_rgb[i * 4 + 2] = specialcolormap_day_night[player_offsets[player_day][0] + i] & 0x1F;
+					transparent_map_day_night_rgb[i * 4 + 0 + 32] = specialcolormap_day_night[player_offsets[player_day][1] + i] >> 10;
+					transparent_map_day_night_rgb[i * 4 + 1 + 32] = (specialcolormap_day_night[player_offsets[player_day][1] + i] >> 5) & 0x1F;
+					transparent_map_day_night_rgb[i * 4 + 2 + 32] = specialcolormap_day_night[player_offsets[player_day][1] + i] & 0x1F;
 #else
-				transparent_map_day_night[i] = (specialcolormap_day_night[player_offsets[player_day][0]+i] >> 2) & TWO_OUT_16;
-				transparent_map_day_night[i+8] = (specialcolormap_day_night[player_offsets[player_day][1]+i] >> 2) & TWO_OUT_16;
-				// those save RGB components
-				transparent_map_day_night_rgb[i*4+0] = specialcolormap_day_night[player_offsets[player_day][0]+i] >> 11;
-				transparent_map_day_night_rgb[i*4+1] = (specialcolormap_day_night[player_offsets[player_day][0]+i] >> 5) & 0x3F;
-				transparent_map_day_night_rgb[i*4+2] = specialcolormap_day_night[player_offsets[player_day][0]+i] & 0x1F;
-				transparent_map_day_night_rgb[i*4+0+32] = specialcolormap_day_night[player_offsets[player_day][1]+i] >> 11;
-				transparent_map_day_night_rgb[i*4+1+32] = (specialcolormap_day_night[player_offsets[player_day][1]+i] >> 5) & 0x3F;
-				transparent_map_day_night_rgb[i*4+2+32] = specialcolormap_day_night[player_offsets[player_day][1]+i] & 0x1F;
+					transparent_map_day_night[i] = (specialcolormap_day_night[player_offsets[player_day][0]+i] >> 2) & TWO_OUT_16;
+					transparent_map_day_night[i+8] = (specialcolormap_day_night[player_offsets[player_day][1]+i] >> 2) & TWO_OUT_16;
+					transparent_map_day_night_rgb[i*4+0] = specialcolormap_day_night[player_offsets[player_day][0]+i] >> 11;
+					transparent_map_day_night_rgb[i*4+1] = (specialcolormap_day_night[player_offsets[player_day][0]+i] >> 5) & 0x3F;
+					transparent_map_day_night_rgb[i*4+2] = specialcolormap_day_night[player_offsets[player_day][0]+i] & 0x1F;
+					transparent_map_day_night_rgb[i*4+0+32] = specialcolormap_day_night[player_offsets[player_day][1]+i] >> 11;
+					transparent_map_day_night_rgb[i*4+1+32] = (specialcolormap_day_night[player_offsets[player_day][1]+i] >> 5) & 0x3F;
+					transparent_map_day_night_rgb[i*4+2+32] = specialcolormap_day_night[player_offsets[player_day][1]+i] & 0x1F;
 #endif
+				}
 			}
 		}
 		rgbmap_current = rgbmap_day_night;
@@ -1237,12 +1299,25 @@ static void activate_player_color(sint8 player_nr, bool daynight)
 
 
 /**
- * Flag all images to recode colors on next draw
+ * Flag all images to recode colors on next draw.
+ * If player_nr is negative (default), every player's cached variant is
+ * invalidated (needed after a global change like a day/night shift).
+ * Otherwise only the single affected player's cached variant is invalidated,
+ * so changing one player's color does not force every other player's
+ * (and every other cached image's) recolor cache to be rebuilt as well.
  */
-static void recode()
+static void recode(sint8 player_nr = -1)
 {
-	for(  image_id n = 0;  n < anz_images;  n++  ) {
-		images[n].player_flags = 0xFFFF;  // recode all player colors
+	if(  player_nr < 0  ) {
+		for(  image_id n = 0;  n < anz_images;  n++  ) {
+			images[n].player_flags = 0xFFFF;  // recode all player colors
+		}
+	}
+	else {
+		const uint16 mask = 1 << player_nr;
+		for(  image_id n = 0;  n < anz_images;  n++  ) {
+			images[n].player_flags |= mask;  // recode only this player's color
+		}
 	}
 }
 
@@ -2010,32 +2085,44 @@ static void calc_base_pal_from_night_shift(const int night)
 		specialcolormap_day_night_for_line[i] = 0;
 	}
 
-	// default player colors
-	for(i=0;  i<8;  i++  ) {
-		rgbmap_day_night[0x8000+i] = specialcolormap_day_night[player_offsets[0][0]+i];
-		rgbmap_day_night[0x8008+i] = specialcolormap_day_night[player_offsets[0][1]+i];
+	// default player colors (player slot 0)
+	if(player_use_custom[0]) {
+		fill_custom_shades(
+			&rgbmap_day_night[0x8000], &transparent_map_day_night[0], &transparent_map_day_night_rgb[0],
+			player_custom_rgb[0][0][0], player_custom_rgb[0][0][1], player_custom_rgb[0][0][2],
+			RG_night_multiplier, B_night_multiplier);
+		fill_custom_shades(
+			&rgbmap_day_night[0x8008], &transparent_map_day_night[8], &transparent_map_day_night_rgb[32],
+			player_custom_rgb[0][1][0], player_custom_rgb[0][1][1], player_custom_rgb[0][1][2],
+			RG_night_multiplier, B_night_multiplier);
+	}
+	else {
+		for(i=0;  i<8;  i++  ) {
+			rgbmap_day_night[0x8000+i] = specialcolormap_day_night[player_offsets[0][0]+i];
+			rgbmap_day_night[0x8008+i] = specialcolormap_day_night[player_offsets[0][1]+i];
 #ifdef RGB555
-		// 15 bit colors from here!
-		transparent_map_day_night[i] = (specialcolormap_day_night[player_offsets[player_day][0] + i] >> 2) & TWO_OUT_15;
-		transparent_map_day_night[i + 8] = (specialcolormap_day_night[player_offsets[player_day][1] + i] >> 2) & TWO_OUT_15;
-		transparent_map_day_night_rgb[i * 4 + 0] = specialcolormap_day_night[player_offsets[player_day][0] + i] >> 10;
-		transparent_map_day_night_rgb[i * 4 + 1] = (specialcolormap_day_night[player_offsets[player_day][0] + i] >> 5) & 0x1F;
-		transparent_map_day_night_rgb[i * 4 + 2] = specialcolormap_day_night[player_offsets[player_day][0] + i] & 0x1F;
-		transparent_map_day_night_rgb[i * 4 + 0 + 32] = specialcolormap_day_night[player_offsets[player_day][1] + i] >> 10;
-		transparent_map_day_night_rgb[i * 4 + 1 + 32] = (specialcolormap_day_night[player_offsets[player_day][1] + i] >> 5) & 0x1F;
-		transparent_map_day_night_rgb[i * 4 + 2 + 32] = specialcolormap_day_night[player_offsets[player_day][1] + i] & 0x1F;
+			// 15 bit colors from here!
+			transparent_map_day_night[i] = (specialcolormap_day_night[player_offsets[player_day][0] + i] >> 2) & TWO_OUT_15;
+			transparent_map_day_night[i + 8] = (specialcolormap_day_night[player_offsets[player_day][1] + i] >> 2) & TWO_OUT_15;
+			transparent_map_day_night_rgb[i * 4 + 0] = specialcolormap_day_night[player_offsets[player_day][0] + i] >> 10;
+			transparent_map_day_night_rgb[i * 4 + 1] = (specialcolormap_day_night[player_offsets[player_day][0] + i] >> 5) & 0x1F;
+			transparent_map_day_night_rgb[i * 4 + 2] = specialcolormap_day_night[player_offsets[player_day][0] + i] & 0x1F;
+			transparent_map_day_night_rgb[i * 4 + 0 + 32] = specialcolormap_day_night[player_offsets[player_day][1] + i] >> 10;
+			transparent_map_day_night_rgb[i * 4 + 1 + 32] = (specialcolormap_day_night[player_offsets[player_day][1] + i] >> 5) & 0x1F;
+			transparent_map_day_night_rgb[i * 4 + 2 + 32] = specialcolormap_day_night[player_offsets[player_day][1] + i] & 0x1F;
 #else
-		// 16 bit colors from here!
-		transparent_map_day_night[i] = (specialcolormap_day_night[player_offsets[player_day][0] + i] >> 2) & TWO_OUT_16;
-		transparent_map_day_night[i + 8] = (specialcolormap_day_night[player_offsets[player_day][1] + i] >> 2) & TWO_OUT_16;
-		// save RGB components
-		transparent_map_day_night_rgb[i * 4 + 0] = specialcolormap_day_night[player_offsets[player_day][0] + i] >> 11;
-		transparent_map_day_night_rgb[i * 4 + 1] = (specialcolormap_day_night[player_offsets[player_day][0] + i] >> 5) & 0x3F;
-		transparent_map_day_night_rgb[i * 4 + 2] = specialcolormap_day_night[player_offsets[player_day][0] + i] & 0x1F;
-		transparent_map_day_night_rgb[i * 4 + 0 + 32] = specialcolormap_day_night[player_offsets[player_day][1] + i] >> 11;
-		transparent_map_day_night_rgb[i * 4 + 1 + 32] = (specialcolormap_day_night[player_offsets[player_day][1] + i] >> 5) & 0x3F;
-		transparent_map_day_night_rgb[i * 4 + 2 + 32] = specialcolormap_day_night[player_offsets[player_day][1] + i] & 0x1F;
+			// 16 bit colors from here!
+			transparent_map_day_night[i] = (specialcolormap_day_night[player_offsets[player_day][0] + i] >> 2) & TWO_OUT_16;
+			transparent_map_day_night[i + 8] = (specialcolormap_day_night[player_offsets[player_day][1] + i] >> 2) & TWO_OUT_16;
+			// save RGB components
+			transparent_map_day_night_rgb[i * 4 + 0] = specialcolormap_day_night[player_offsets[player_day][0] + i] >> 11;
+			transparent_map_day_night_rgb[i * 4 + 1] = (specialcolormap_day_night[player_offsets[player_day][0] + i] >> 5) & 0x3F;
+			transparent_map_day_night_rgb[i * 4 + 2] = specialcolormap_day_night[player_offsets[player_day][0] + i] & 0x1F;
+			transparent_map_day_night_rgb[i * 4 + 0 + 32] = specialcolormap_day_night[player_offsets[player_day][1] + i] >> 11;
+			transparent_map_day_night_rgb[i * 4 + 1 + 32] = (specialcolormap_day_night[player_offsets[player_day][1] + i] >> 5) & 0x3F;
+			transparent_map_day_night_rgb[i * 4 + 2 + 32] = specialcolormap_day_night[player_offsets[player_day][1] + i] & 0x1F;
 #endif
+		}
 	}
 	player_night = 0;
 
@@ -2088,6 +2175,7 @@ void display_day_night_shift(int night)
 // set first and second company color for player
 void display_set_player_color_scheme(const int player, const uint8 col1, const uint8 col2 )
 {
+	player_use_custom[player] = false;
 	if(player_offsets[player][0]!=col1  ||  player_offsets[player][1]!=col2) {
 		// set new player colors
 		player_offsets[player][0] = col1;
@@ -2104,11 +2192,81 @@ void display_set_player_color_scheme(const int player, const uint8 col1, const u
 			// calc_base_pal_from_night_shift resets player_night to 0
 			player_day = player_night;
 		}
-		recode();
+		// only this player's color actually changed; no need to force every
+		// other player's cached sprite variants to be rebuilt as well
+		recode(player);
 		mark_screen_dirty();
 	}
 }
 
+
+void display_set_player_color_scheme_rgb(const int player, uint8 r1, uint8 g1, uint8 b1, uint8 r2, uint8 g2, uint8 b2)
+{
+	player_use_custom[player] = true;
+	player_custom_rgb[player][0][0] = r1;
+	player_custom_rgb[player][0][1] = g1;
+	player_custom_rgb[player][0][2] = b1;
+	player_custom_rgb[player][1][0] = r2;
+	player_custom_rgb[player][1][1] = g2;
+	player_custom_rgb[player][1][2] = b2;
+	// Invalidate cache so activate_player_color regenerates shades
+	player_day   = 0xFF;
+	player_night = 0xFF;
+	if(player == 0) {
+		// Slot 0 is also baked into the day/night maps by calc_base_pal_from_night_shift
+		calc_base_pal_from_night_shift(0);
+		memcpy(rgbmap_all_day, rgbmap_day_night, RGBMAPSIZE * sizeof(PIXVAL));
+		memcpy(transparent_map_all_day, transparent_map_day_night, lengthof(transparent_map_day_night) * sizeof(PIXVAL));
+		memcpy(transparent_map_all_day_rgb, transparent_map_day_night_rgb, lengthof(transparent_map_day_night_rgb) * sizeof(uint8));
+		if(night_shift != 0) {
+			calc_base_pal_from_night_shift(night_shift);
+		}
+	}
+	// only this player's color actually changed; no need to force every
+	// other player's cached sprite variants to be rebuilt as well
+	recode(player);
+	mark_screen_dirty();
+}
+
+
+// Returns the day-mode PIXVAL for a given player color slot and shade index (0-7).
+// shade 4 = gui_player_color_bright (the "base" color), 0 = darkest, 7 = lightest.
+PIXVAL display_get_player_color_pixval(const int player, bool is_color2, int shade)
+{
+	if(shade < 0) shade = 0;
+	if(shade > 7) shade = 7;
+	if(player_use_custom[player]) {
+		const uint8 r = player_custom_rgb[player][is_color2?1:0][0];
+		const uint8 g = player_custom_rgb[player][is_color2?1:0][1];
+		const uint8 b = player_custom_rgb[player][is_color2?1:0][2];
+		return get_system_color(
+			shade_channel(r, shade),
+			shade_channel(g, shade),
+			shade_channel(b, shade));
+	}
+	return specialcolormap_all_day[player_offsets[player][is_color2?1:0] + shade];
+}
+
+
+PIXVAL make_rgb_pixval(uint8 r, uint8 g, uint8 b)
+{
+	return get_system_color(r, g, b);
+}
+
+
+// Decode a native PIXVAL (RGB565 or RGB555) back into 8-bit R,G,B.
+void pixval_to_rgb8(PIXVAL col, uint8 &r, uint8 &g, uint8 &b)
+{
+#ifdef RGB555
+	r = ((col >> 10) & 0x1F) << 3;
+	g = ((col >>  5) & 0x1F) << 3;
+	b = ( col        & 0x1F) << 3;
+#else
+	r = ((col >> 11) & 0x1F) << 3;
+	g = ((col >>  5) & 0x3F) << 2;
+	b = ( col        & 0x1F) << 3;
+#endif
+}
 
 
 void register_image(image_t *image_in)
@@ -3214,12 +3372,35 @@ void display_color_img(const image_id n, scr_coord_val xp, scr_coord_val yp, sin
 
 
 /**
+ * Build an 8-shade ramp directly from a line's RGB565/555 color value (which may be an
+ * arbitrary custom color, not a palette family index), honoring the current night-shift
+ * dimming the same way fill_custom_shades() does for custom player colors.
+ */
+static void fill_line_color_shades(PIXVAL* out8, PIXVAL line_color, bool daynight)
+{
+	uint8 r, g, b;
+	pixval_to_rgb8(line_color, r, g, b);
+	double rg_mult = 1.0, b_mult = 1.0;
+	if(  daynight  &&  night_shift > 0  ) {
+		rg_mult = pow(0.75, night_shift) * ((light_level + 8.0) / 8.0);
+		b_mult  = pow(0.83, night_shift) * ((light_level + 8.0) / 8.0);
+	}
+	for(  int i = 0;  i < 8;  i++  ) {
+		const int R = (int)(shade_channel(r, i) * rg_mult);
+		const int G = (int)(shade_channel(g, i) * rg_mult);
+		const int B = (int)(shade_channel(b, i) * b_mult);
+		out8[i] = get_system_color(R > 0 ? R : 0, G > 0 ? G : 0, B > 0 ? B : 0);
+	}
+}
+
+
+/**
  * Draw image with a specific line color applied per-object, using live rendering.
  * Unlike display_color_img, this does NOT use the pre-recoded image cache.
  * It temporarily installs the line color into rgbmap and draws from raw zoom_data,
  * then restores the original mapping — so different objects can each use their own color.
  */
-void display_color_img_line(const image_id n, scr_coord_val xp, scr_coord_val yp, const uint8 col, const sint8 player_nr, const bool daynight, const bool dirty  CLIP_NUM_DEF)
+void display_color_img_line(const image_id n, scr_coord_val xp, scr_coord_val yp, const PIXVAL line_color, const sint8 player_nr, const bool daynight, const bool dirty  CLIP_NUM_DEF)
 {
 	if(  n < anz_images  ) {
 		if(  (images[n].recode_flags & FLAG_HAS_PLAYER_COLOR) == 0  ) {
@@ -3242,15 +3423,9 @@ void display_color_img_line(const image_id n, scr_coord_val xp, scr_coord_val yp
 			mark_rect_dirty_wc( x, y, x + w - 1, y + h - 1 );
 		}
 
-		// build local line-color ramp (no global state modified)
-		// player-color-family-based line colors (col%8==0) use a darker palette to distinguish from player colors
-		const PIXVAL *const specmap = (col % 8 == 0)
-			? (daynight ? specialcolormap_day_night_for_line : specialcolormap_all_day_for_line)
-			: (daynight ? specialcolormap_day_night           : specialcolormap_all_day);
+		// build local line-color ramp directly from the line's RGB color (no global state modified)
 		PIXVAL line_col[8];
-		for(  int i = 0;  i < 8;  i++  ) {
-			line_col[i] = specmap[(col/8)*8 + i];
-		}
+		fill_line_color_shades( line_col, line_color, daynight );
 
 		// build local player color 2 ramp from owner's palette (thread-safe, no global rgbmap)
 		const PIXVAL *const specmap2 = daynight ? specialcolormap_day_night : specialcolormap_all_day;
@@ -3356,11 +3531,11 @@ void display_base_img(const image_id n, scr_coord_val xp, scr_coord_val yp, cons
  * Draw Image using line color, using base image data when GUI viewport scale differs from game zoom.
  * Parallel to display_base_img but substitutes player colors with line colors.
  */
-void display_base_img_line(const image_id n, scr_coord_val xp, scr_coord_val yp, const uint8 col, const sint8 player_nr, const bool daynight, const bool dirty  CLIP_NUM_DEF)
+void display_base_img_line(const image_id n, scr_coord_val xp, scr_coord_val yp, const PIXVAL line_color, const sint8 player_nr, const bool daynight, const bool dirty  CLIP_NUM_DEF)
 {
 	if(  base_tile_raster_width == tile_raster_width  ) {
 		// same scale: the zoomed-coord routine works correctly
-		display_color_img_line( n, xp, yp, col, player_nr, daynight, dirty  CLIP_NUM_PAR );
+		display_color_img_line( n, xp, yp, line_color, player_nr, daynight, dirty  CLIP_NUM_PAR );
 		return;
 	}
 	if(  n < anz_images  ) {
@@ -3383,13 +3558,8 @@ void display_base_img_line(const image_id n, scr_coord_val xp, scr_coord_val yp,
 			mark_rect_dirty_wc( x, y, x + w - 1, y + h - 1 );
 		}
 
-		const PIXVAL *const specmap = (col % 8 == 0)
-			? (daynight ? specialcolormap_day_night_for_line : specialcolormap_all_day_for_line)
-			: (daynight ? specialcolormap_day_night           : specialcolormap_all_day);
 		PIXVAL line_col[8];
-		for(  int i = 0;  i < 8;  i++  ) {
-			line_col[i] = specmap[(col/8)*8 + i];
-		}
+		fill_line_color_shades( line_col, line_color, daynight );
 
 		const PIXVAL *const specmap2 = daynight ? specialcolormap_day_night : specialcolormap_all_day;
 		PIXVAL player_col2[8];

--- a/documentation/ja.OTRP.tab
+++ b/documentation/ja.OTRP.tab
@@ -793,3 +793,7 @@ Color Picker
 カラーピッカー
 A color picker is already open.
 カラーピッカーは既に開いています。
+Custom primary (R G B):
+カスタム基調色 (R G B):
+Custom secondary (R G B):
+カスタム補助色 (R G B):

--- a/documentation/ja.OTRP.tab
+++ b/documentation/ja.OTRP.tab
@@ -787,3 +787,9 @@ Avg. density
 平均輸送密度
 Toggle convoy following underground mode
 編成追跡時の表示モード変更
+Apply
+適用
+Color Picker
+カラーピッカー
+A color picker is already open.
+カラーピッカーは既に開いています。

--- a/gui/citylist_frame_t.cc
+++ b/gui/citylist_frame_t.cc
@@ -87,7 +87,7 @@ class playername_const_scroll_item_t : public gui_scrolled_list_t::const_text_sc
 public:
 	const uint8 player_nr;
 
-	playername_const_scroll_item_t( player_t *pl ) : gui_scrolled_list_t::const_text_scrollitem_t( pl->get_name(), color_idx_to_rgb(pl->get_player_color1()+env_t::gui_player_color_dark) ), player_nr(pl->get_player_nr()) { }
+	playername_const_scroll_item_t( player_t *pl ) : gui_scrolled_list_t::const_text_scrollitem_t( pl->get_name(), pl->get_player_color1_pixval(env_t::gui_player_color_dark) ), player_nr(pl->get_player_nr()) { }
 };
 
 

--- a/gui/components/gui_colorbox.cc
+++ b/gui/components/gui_colorbox.cc
@@ -16,19 +16,19 @@ gui_colorbox_t::gui_colorbox_t(PIXVAL c)
 
 scr_size gui_colorbox_t::get_min_size() const
 {
-	return scr_size(D_INDICATOR_WIDTH, D_INDICATOR_HEIGHT);
+	return scr_size(D_INDICATOR_WIDTH, max_size.h);
 }
 
 
 scr_size gui_colorbox_t::get_max_size() const
 {
-	return scr_size(max_size.w, D_INDICATOR_HEIGHT);
+	return max_size;
 }
 
 
 void gui_colorbox_t::draw(scr_coord offset)
 {
 	offset += pos;
-	display_ddd_box_clip_rgb(offset.x, offset.y, size.w, D_INDICATOR_HEIGHT, color_idx_to_rgb(MN_GREY0), color_idx_to_rgb(MN_GREY4));
-	display_fillbox_wh_clip_rgb(offset.x + 1, offset.y + 1, size.w - 2, D_INDICATOR_HEIGHT-2, color, true);
+	display_ddd_box_clip_rgb(offset.x, offset.y, size.w, size.h, color_idx_to_rgb(MN_GREY0), color_idx_to_rgb(MN_GREY4));
+	display_fillbox_wh_clip_rgb(offset.x + 1, offset.y + 1, size.w - 2, size.h - 2, color, true);
 }

--- a/gui/convoi_detail_t.cc
+++ b/gui/convoi_detail_t.cc
@@ -208,7 +208,7 @@ void convoi_detail_t::init(convoihandle_t cnv)
 			viewable_players[ 0 ] = 0;
 			for(  int np = 0, count = 0;  np < MAX_PLAYER_COUNT;  np++  ) {
 				if(  welt->get_player( np )  ) {
-					trade_player_num.new_component<gui_scrolled_list_t::const_text_scrollitem_t>(welt->get_player( np )->get_name(), color_idx_to_rgb(welt->get_player( np )->get_player_color1()+env_t::gui_player_color_dark));
+					trade_player_num.new_component<gui_scrolled_list_t::const_text_scrollitem_t>(welt->get_player( np )->get_name(), welt->get_player( np )->get_player_color1_pixval(env_t::gui_player_color_dark));
 					viewable_players[ count++ ] = np;
 				}
 			}

--- a/gui/curiositylist_frame_t.cc
+++ b/gui/curiositylist_frame_t.cc
@@ -27,7 +27,7 @@ const char* sort_text[curiositylist::SORT_MODES] = {
 class playername_const_scroll_item_t : public gui_scrolled_list_t::const_text_scrollitem_t {
 public:
 	const uint8 player_nr;
-	playername_const_scroll_item_t( player_t *pl ) : gui_scrolled_list_t::const_text_scrollitem_t( pl->get_name(), color_idx_to_rgb(pl->get_player_color1()+env_t::gui_player_color_dark) ), player_nr(pl->get_player_nr()) { }
+	playername_const_scroll_item_t( player_t *pl ) : gui_scrolled_list_t::const_text_scrollitem_t( pl->get_name(), pl->get_player_color1_pixval(env_t::gui_player_color_dark) ), player_nr(pl->get_player_nr()) { }
 };
 
 curiositylist_frame_t::curiositylist_frame_t() :

--- a/gui/factorylist_frame_t.cc
+++ b/gui/factorylist_frame_t.cc
@@ -26,7 +26,7 @@ const char *factorylist_frame_t::sort_text[factorylist::SORT_MODES] = {
 class playername_const_scroll_item_t : public gui_scrolled_list_t::const_text_scrollitem_t {
 public:
 	const uint8 player_nr;
-	playername_const_scroll_item_t( player_t *pl ) : gui_scrolled_list_t::const_text_scrollitem_t( pl->get_name(), color_idx_to_rgb(pl->get_player_color1()+env_t::gui_player_color_dark) ), player_nr(pl->get_player_nr()) { }
+	playername_const_scroll_item_t( player_t *pl ) : gui_scrolled_list_t::const_text_scrollitem_t( pl->get_name(), pl->get_player_color1_pixval(env_t::gui_player_color_dark) ), player_nr(pl->get_player_nr()) { }
 };
 
 factorylist_frame_t::factorylist_frame_t() :

--- a/gui/gui_frame.cc
+++ b/gui/gui_frame.cc
@@ -96,7 +96,7 @@ void gui_frame_t::reset_min_windowsize()
  */
 FLAGGED_PIXVAL gui_frame_t::get_titlecolor() const
 {
-	return owner ? PLAYER_FLAG|color_idx_to_rgb(owner->get_player_color1()+env_t::gui_player_color_dark) : env_t::default_window_title_color;
+	return owner ? PLAYER_FLAG|owner->get_player_color1_pixval(env_t::gui_player_color_dark) : env_t::default_window_title_color;
 }
 
 

--- a/gui/halt_info.cc
+++ b/gui/halt_info.cc
@@ -384,7 +384,7 @@ void halt_info_t::init(halthandle_t halt)
 			add_table(1,1);
 			{
 				bt_change_to_owner.init(button_t::box_state | button_t::flexible, halt->get_owner()->get_name());
-				bt_change_to_owner.background_color = color_idx_to_rgb(halt->get_owner()->get_player_color1());
+				bt_change_to_owner.background_color = halt->get_owner()->get_player_color1_pixval(0);
 				bt_change_to_owner.add_listener(this);
 				add_component(&bt_change_to_owner);
 			}
@@ -756,7 +756,7 @@ void gui_halt_detail_t::update_connections( halthandle_t h )
 			new_component<gui_line_button_t>(line);
 
 			// Line labels with color of player
-			gui_label_buf_t *lb = new_component<gui_label_buf_t>(PLAYER_FLAG | color_idx_to_rgb(line->get_owner()->get_player_color1()+env_t::gui_player_color_dark) );
+			gui_label_buf_t *lb = new_component<gui_label_buf_t>(PLAYER_FLAG | line->get_owner()->get_player_color1_pixval(env_t::gui_player_color_dark) );
 			schedule_t::get_schedule_flag_text(lb->buf(), line->get_schedule());
 			lb->buf().append( line->get_name() );
 			lb->update();
@@ -777,7 +777,7 @@ void gui_halt_detail_t::update_connections( halthandle_t h )
 			new_component<gui_convoi_button_t>(cnv);
 
 			// Line labels with color of player
-			gui_label_buf_t *lb = new_component<gui_label_buf_t>(PLAYER_FLAG | color_idx_to_rgb(cnv->get_owner()->get_player_color1()+env_t::gui_player_color_dark) );
+			gui_label_buf_t *lb = new_component<gui_label_buf_t>(PLAYER_FLAG | cnv->get_owner()->get_player_color1_pixval(env_t::gui_player_color_dark) );
 			lb->buf().append( cnv->get_name() );
 			lb->update();
 		}

--- a/gui/kennfarbe.cc
+++ b/gui/kennfarbe.cc
@@ -13,6 +13,12 @@
 #include "components/gui_image.h"
 #include "../simtool.h"
 #include "../simline.h"
+#include "../display/simgraph.h"
+#include "../sys/simsys.h"
+#include "messagebox.h"
+#include "simwin.h"
+#include <stdio.h>
+#include <string.h>
 
 /**
  * Buttons forced to be square ...
@@ -31,11 +37,52 @@ public:
 	}
 };
 
+// Format R,G,B into "#RRGGBB" in buf (must be at least 8 bytes)
+static void rgb_to_hex(uint8 r, uint8 g, uint8 b, char *buf)
+{
+	snprintf(buf, 8, "#%02X%02X%02X", r, g, b);
+}
+
+// Parse "#RRGGBB" or "RRGGBB" → r,g,b. Returns true on success.
+static bool hex_to_rgb(const char *buf, uint8 &r, uint8 &g, uint8 &b)
+{
+	const char *s = buf;
+	if (*s == '#') s++;
+	if (strlen(s) != 6) return false;
+	unsigned rv, gv, bv;
+	if (sscanf(s, "%2x%2x%2x", &rv, &gv, &bv) != 3) return false;
+	r = (uint8)rv;
+	g = (uint8)gv;
+	b = (uint8)bv;
+	return true;
+}
+
+// Build the tool param string for a custom RGB color change
+static void send_custom_player_color(player_t *player, char which,
+                                     uint8 r1, uint8 g1, uint8 b1,
+                                     uint8 r2, uint8 g2, uint8 b2)
+{
+	cbuffer_t buf;
+	buf.printf("%c%u,#%02x%02x%02x,#%02x%02x%02x",
+	           which, player->get_player_nr(),
+	           r1, g1, b1, r2, g2, b2);
+	tool_t *w = create_tool(TOOL_RECOLOUR_TOOL | SIMPLE_TOOL);
+	w->set_default_param(buf);
+	world()->set_tool(w, player);
+	delete w;
+}
+
+
+// ---------------------------------------------------------------
+// line_colour_gui_t
+// ---------------------------------------------------------------
+
 line_colour_gui_t::line_colour_gui_t(linehandle_t line_, player_t *player_) :
 	gui_frame_t( translator::translate("Line Colour"), player_ )
 {
 	line = line_;
 	player = player_;
+	pending_os_pick = false;
 
 	set_table_layout(1, 0);
 
@@ -44,29 +91,137 @@ line_colour_gui_t::line_colour_gui_t(linehandle_t line_, player_t *player_) :
 
 	add_table(14,4);
 
-	//Line colour buttons
-	//same as player colours
+	//Line colour buttons (preset palette)
 	for(unsigned i=0;  i<28;  i++) {
 		line_colour[i] = new_component<choose_color_button_t>();
 		line_colour[i]->init( button_t::box_state, (" "));
 		line_colour[i]->background_color = color_idx_to_rgb(i*8+env_t::gui_player_color_bright);
 		line_colour[i]->add_listener(this);
 	}
-	//add some colours
 	for(unsigned i=0;  i<28;  i++) {
 		line_colour[i+28] = new_component<choose_color_button_t>();
 		line_colour[i+28]->init( button_t::box_state, (" "));
 		line_colour[i+28]->background_color = color_idx_to_rgb(i*8);
 		line_colour[i+28]->add_listener(this);
 	}
-	line_colour[line->get_colour()%8==env_t::gui_player_color_bright?line->get_colour()/8:line->get_colour()/8+28]->pressed = true;
+	// Mark currently selected preset if it matches
+	if(line.is_bound()) {
+		const PIXVAL cur = line->get_colour();
+		for(unsigned i = 0; i < 56; i++) {
+			if(line_colour[i]->background_color == cur) {
+				line_colour[i]->pressed = true;
+				break;
+			}
+		}
+	}
 	end_table();
-	reset_min_windowsize();
 
+	// Custom color picker section
+	new_component<gui_label_t>("Custom colour (R G B):");
+	add_table(5, 1);
+	{
+		// Prefill from current line color
+		uint8 cr = 128, cg = 128, cb = 128;
+		if(line.is_bound()) {
+			pixval_to_rgb8(line->get_colour(), cr, cg, cb);
+		}
+		inp_r.init(cr, 0, 255, 1, false, 3, false);
+		inp_g.init(cg, 0, 255, 1, false, 3, false);
+		inp_b.init(cb, 0, 255, 1, false, 3, false);
+		inp_r.add_listener(this);
+		inp_g.add_listener(this);
+		inp_b.add_listener(this);
+		add_component(&inp_r);
+		add_component(&inp_g);
+		add_component(&inp_b);
+
+		preview.set_color(make_rgb_pixval(cr, cg, cb));
+		preview.set_max_size(scr_size(D_BUTTON_HEIGHT * 2, D_BUTTON_HEIGHT * 1));
+		add_component(&preview);
+
+		bt_apply_custom.init(button_t::roundbox, translator::translate("Apply"));
+		bt_apply_custom.add_listener(this);
+		add_component(&bt_apply_custom);
+	}
+	end_table();
+
+	// Hex input and OS color picker row
+	add_table(2, 1);
+	{
+		rgb_to_hex((uint8)inp_r.get_value(), (uint8)inp_g.get_value(), (uint8)inp_b.get_value(), hex_buf);
+		inp_hex.set_text(hex_buf, sizeof(hex_buf));
+		inp_hex.add_listener(this);
+		add_component(&inp_hex);
+
+		bt_os_picker.init(button_t::roundbox, translator::translate("Color Picker"));
+		bt_os_picker.add_listener(this);
+		add_component(&bt_os_picker);
+	}
+	end_table();
+
+	reset_min_windowsize();
 }
 
-bool line_colour_gui_t::action_triggered( gui_action_creator_t *comp, value_t /* */)
+void line_colour_gui_t::update_preview()
 {
+	const uint8 r = (uint8)inp_r.get_value();
+	const uint8 g = (uint8)inp_g.get_value();
+	const uint8 b = (uint8)inp_b.get_value();
+	preview.set_color(make_rgb_pixval(r, g, b));
+	rgb_to_hex(r, g, b, hex_buf);
+}
+
+void line_colour_gui_t::apply_custom_colour()
+{
+	if(!line.is_bound()) return;
+	const uint8 r = (uint8)inp_r.get_value();
+	const uint8 g = (uint8)inp_g.get_value();
+	const uint8 b = (uint8)inp_b.get_value();
+
+	// Deselect all preset buttons
+	for(unsigned i = 0; i < 56; i++) {
+		line_colour[i]->pressed = false;
+	}
+
+	cbuffer_t buf;
+	buf.printf("o,%i,#%02x%02x%02x", line.get_id(), r, g, b);
+	tool_t *w = create_tool(TOOL_CHANGE_LINE | SIMPLE_TOOL);
+	w->set_default_param(buf);
+	world()->set_tool(w, player);
+	delete w;
+}
+
+bool line_colour_gui_t::action_triggered(gui_action_creator_t *comp, value_t /* */)
+{
+	if(comp == &bt_apply_custom) {
+		apply_custom_colour();
+		return true;
+	}
+	if(comp == &inp_r || comp == &inp_g || comp == &inp_b) {
+		update_preview();
+		return true;
+	}
+	if(comp == &inp_hex) {
+		uint8 r, g, b;
+		if(hex_to_rgb(hex_buf, r, g, b)) {
+			inp_r.set_value(r);
+			inp_g.set_value(g);
+			inp_b.set_value(b);
+			preview.set_color(make_rgb_pixval(r, g, b));
+		}
+		return true;
+	}
+	if(comp == &bt_os_picker) {
+		uint8 r = (uint8)inp_r.get_value();
+		uint8 g = (uint8)inp_g.get_value();
+		uint8 b = (uint8)inp_b.get_value();
+		pending_os_pick = dr_pick_color_start(r, g, b);
+		if(!pending_os_pick) {
+			create_win( new news_img("A color picker is already open."), w_time_delete, magic_none );
+		}
+		return true;
+	}
+
 	for(unsigned i=0;  i<56;  i++){
 		if(comp==line_colour[i]) {
 			for(unsigned j=0;  j<56;  j++) {
@@ -75,15 +230,21 @@ bool line_colour_gui_t::action_triggered( gui_action_creator_t *comp, value_t /*
 			line_colour[i]->pressed = true;
 
 			if (line.is_bound()) {
-				// re-colour the line
+				const PIXVAL col = line_colour[i]->background_color;
+				// Update custom inputs to match selected preset
+				uint8 r, g, b;
+				pixval_to_rgb8(col, r, g, b);
+				inp_r.set_value(r);
+				inp_g.set_value(g);
+				inp_b.set_value(b);
+				preview.set_color(col);
+
 				cbuffer_t buf;
-				buf.printf( "o,%i,%i", line.get_id(), i<28? i*8+env_t::gui_player_color_bright: (i-28)*8 );
-				tool_t* w = create_tool( TOOL_CHANGE_LINE | SIMPLE_TOOL );
+				buf.printf("o,%i,#%02x%02x%02x", line.get_id(), r, g, b);
+				tool_t *w = create_tool(TOOL_CHANGE_LINE | SIMPLE_TOOL);
 				w->set_default_param(buf);
-				world()->set_tool( w, player );
-
+				world()->set_tool(w, player);
 				delete w;
-
 				return true;
 			}
 		}
@@ -92,29 +253,49 @@ bool line_colour_gui_t::action_triggered( gui_action_creator_t *comp, value_t /*
 	return false;
 }
 
+
+void line_colour_gui_t::draw(scr_coord pos, scr_size size)
+{
+	if(pending_os_pick) {
+		uint8 r, g, b;
+		const color_pick_result_t res = dr_pick_color_poll(r, g, b);
+		if(res == COLOR_PICK_OK) {
+			inp_r.set_value(r);
+			inp_g.set_value(g);
+			inp_b.set_value(b);
+			preview.set_color(make_rgb_pixval(r, g, b));
+			rgb_to_hex(r, g, b, hex_buf);
+		}
+		if(res != COLOR_PICK_RUNNING) {
+			pending_os_pick = false;
+		}
+	}
+	gui_frame_t::draw(pos, size);
+}
+
+
+// ---------------------------------------------------------------
+// farbengui_t
+// ---------------------------------------------------------------
+
 farbengui_t::farbengui_t(player_t *player_) :
 	gui_frame_t( translator::translate("Farbe"), player_ ),
 	txt(&buf)
 {
 	player = player_;
+	pending_os_pick = -1;
 	buf.clear();
 	buf.append(translator::translate("COLOR_CHOOSE\n"));
 
 	set_table_layout(1,0);
 
 	add_table(2,1);
-	// Info text
 	txt.recalc_size();
 	add_component( &txt );
-
-	// Picture
 	new_component<gui_image_t>(skinverwaltung_t::color_options->get_image_id(0), player->get_player_nr(), ALIGN_NONE, true);
 	end_table();
 
-	// Player's primary color label
-	new_component<gui_label_t>("Your primary color:");
-
-	// Get all colors (except the current player's)
+	// Get all colors used by other players
 	uint32 used_colors1 = 0;
 	uint32 used_colors2 = 0;
 	for(  int i=0;  i<MAX_PLAYER_COUNT;  i++  ) {
@@ -124,29 +305,116 @@ farbengui_t::farbengui_t(player_t *player_) :
 		}
 	}
 
+	// Primary color preset buttons
+	new_component<gui_label_t>("Your primary color:");
 	add_table(14,2);
-	// Primary color buttons
 	for(unsigned i=0;  i<28;  i++) {
 		player_color_1[i] = new_component<choose_color_button_t>();
 		player_color_1[i]->init( button_t::box_state, (used_colors1 & (1<<i) ? "X" : " "));
 		player_color_1[i]->background_color = color_idx_to_rgb(i*8+env_t::gui_player_color_bright);
 		player_color_1[i]->add_listener(this);
 	}
-	player_color_1[player->get_player_color1()/8]->pressed = true;
+	if(!player->is_player_color_custom()) {
+		player_color_1[player->get_player_color1()/8]->pressed = true;
+	}
 	end_table();
 
-	// Player's secondary color label
-	new_component<gui_label_t>("Your secondary color:");
+	// Primary custom color picker
+	new_component<gui_label_t>("Custom primary (R G B):");
+	add_table(5, 1);
+	{
+		uint8 r = 128, g = 128, b = 128;
+		if(player->is_player_color_custom()) {
+			r = player->get_player_color_r(0);
+			g = player->get_player_color_g(0);
+			b = player->get_player_color_b(0);
+		}
+		else {
+			pixval_to_rgb8(player->get_player_color1_pixval(env_t::gui_player_color_bright), r, g, b);
+		}
+		inp_r1.init(r, 0, 255, 1, false, 3, false);
+		inp_g1.init(g, 0, 255, 1, false, 3, false);
+		inp_b1.init(b, 0, 255, 1, false, 3, false);
+		inp_r1.add_listener(this); inp_g1.add_listener(this); inp_b1.add_listener(this);
+		add_component(&inp_r1); add_component(&inp_g1); add_component(&inp_b1);
+		preview_1.set_color(make_rgb_pixval(r, g, b));
+		preview_1.set_max_size(scr_size(D_BUTTON_HEIGHT * 2, D_BUTTON_HEIGHT * 1));
+		add_component(&preview_1);
+		bt_apply_custom.init(button_t::roundbox, translator::translate("Apply"));
+		bt_apply_custom.add_listener(this);
+		add_component(&bt_apply_custom);
+	}
+	end_table();
 
+	// Primary hex + OS picker row
+	add_table(2, 1);
+	{
+		uint8 r = (uint8)inp_r1.get_value(), g = (uint8)inp_g1.get_value(), b = (uint8)inp_b1.get_value();
+		rgb_to_hex(r, g, b, hex_buf1);
+		inp_hex1.set_text(hex_buf1, sizeof(hex_buf1));
+		inp_hex1.add_listener(this);
+		add_component(&inp_hex1);
+
+		bt_os_picker_1.init(button_t::roundbox, translator::translate("Color Picker"));
+		bt_os_picker_1.add_listener(this);
+		add_component(&bt_os_picker_1);
+	}
+	end_table();
+
+	// Secondary color preset buttons
+	new_component<gui_label_t>("Your secondary color:");
 	add_table(14,2);
-	// Secondary color buttons
 	for(unsigned i=0;  i<28;  i++) {
 		player_color_2[i] = new_component<choose_color_button_t>();
 		player_color_2[i]->init( button_t::box_state, (used_colors2 & (1<<i) ? "X" : " "));
 		player_color_2[i]->background_color = color_idx_to_rgb(i*8+env_t::gui_player_color_bright);
 		player_color_2[i]->add_listener(this);
 	}
-	player_color_2[player->get_player_color2()/8]->pressed = true;
+	if(!player->is_player_color_custom()) {
+		player_color_2[player->get_player_color2()/8]->pressed = true;
+	}
+	end_table();
+
+	// Secondary custom color picker
+	new_component<gui_label_t>("Custom secondary (R G B):");
+	add_table(5, 1);
+	{
+		uint8 r = 128, g = 128, b = 128;
+		if(player->is_player_color_custom()) {
+			r = player->get_player_color_r(1);
+			g = player->get_player_color_g(1);
+			b = player->get_player_color_b(1);
+		}
+		else {
+			pixval_to_rgb8(player->get_player_color2_pixval(env_t::gui_player_color_bright), r, g, b);
+		}
+		inp_r2.init(r, 0, 255, 1, false, 3, false);
+		inp_g2.init(g, 0, 255, 1, false, 3, false);
+		inp_b2.init(b, 0, 255, 1, false, 3, false);
+		inp_r2.add_listener(this); inp_g2.add_listener(this); inp_b2.add_listener(this);
+		add_component(&inp_r2); add_component(&inp_g2); add_component(&inp_b2);
+		preview_2.set_color(make_rgb_pixval(r, g, b));
+		preview_2.set_max_size(scr_size(D_BUTTON_HEIGHT * 2, D_BUTTON_HEIGHT * 1));
+		add_component(&preview_2);
+		bt_apply_custom_2.init(button_t::roundbox, translator::translate("Apply"));
+		bt_apply_custom_2.add_listener(this);
+		add_component(&bt_apply_custom_2);
+	}
+	end_table();
+
+	// Secondary hex + OS picker row
+	add_table(2, 1);
+	{
+		uint8 r2 = (uint8)inp_r2.get_value(), g2 = (uint8)inp_g2.get_value(), b2 = (uint8)inp_b2.get_value();
+		rgb_to_hex(r2, g2, b2, hex_buf2);
+		inp_hex2.set_text(hex_buf2, sizeof(hex_buf2));
+		inp_hex2.add_listener(this);
+		add_component(&inp_hex2);
+
+		bt_os_picker_2.init(button_t::roundbox, translator::translate("Color Picker"));
+		bt_os_picker_2.add_listener(this);
+		add_component(&bt_os_picker_2);
+	}
 	end_table();
 
 	bt_all_line_color_change.init(button_t::roundbox, "Change line color as current player color");
@@ -156,49 +424,150 @@ farbengui_t::farbengui_t(player_t *player_) :
 	reset_min_windowsize();
 }
 
-
-/**
- * This method is called if an action is triggered
- */
-bool farbengui_t::action_triggered( gui_action_creator_t *comp,value_t /* */)
+void farbengui_t::update_preview()
 {
+	const uint8 r1 = (uint8)inp_r1.get_value(), g1 = (uint8)inp_g1.get_value(), b1 = (uint8)inp_b1.get_value();
+	const uint8 r2 = (uint8)inp_r2.get_value(), g2 = (uint8)inp_g2.get_value(), b2 = (uint8)inp_b2.get_value();
+	preview_1.set_color(make_rgb_pixval(r1, g1, b1));
+	preview_2.set_color(make_rgb_pixval(r2, g2, b2));
+	rgb_to_hex(r1, g1, b1, hex_buf1);
+	rgb_to_hex(r2, g2, b2, hex_buf2);
+}
+
+void farbengui_t::apply_custom_color()
+{
+	// Deselect all preset buttons
+	for(unsigned i = 0; i < 28; i++) {
+		player_color_1[i]->pressed = false;
+		player_color_2[i]->pressed = false;
+	}
+	const uint8 r1 = (uint8)inp_r1.get_value(), g1 = (uint8)inp_g1.get_value(), b1 = (uint8)inp_b1.get_value();
+	const uint8 r2 = (uint8)inp_r2.get_value(), g2 = (uint8)inp_g2.get_value(), b2 = (uint8)inp_b2.get_value();
+	send_custom_player_color(player, '1', r1, g1, b1, r2, g2, b2);
+}
+
+bool farbengui_t::action_triggered( gui_action_creator_t *comp, value_t /* */)
+{
+	// Custom color apply button
+	if(comp == &bt_apply_custom || comp == &bt_apply_custom_2) {
+		apply_custom_color();
+		return true;
+	}
+	// Preview update on RGB number input change
+	if(comp == &inp_r1 || comp == &inp_g1 || comp == &inp_b1 ||
+	   comp == &inp_r2 || comp == &inp_g2 || comp == &inp_b2) {
+		update_preview();
+		return true;
+	}
+	// Hex input → RGB sync
+	if(comp == &inp_hex1) {
+		uint8 r, g, b;
+		if(hex_to_rgb(hex_buf1, r, g, b)) {
+			inp_r1.set_value(r); inp_g1.set_value(g); inp_b1.set_value(b);
+			preview_1.set_color(make_rgb_pixval(r, g, b));
+		}
+		return true;
+	}
+	if(comp == &inp_hex2) {
+		uint8 r, g, b;
+		if(hex_to_rgb(hex_buf2, r, g, b)) {
+			inp_r2.set_value(r); inp_g2.set_value(g); inp_b2.set_value(b);
+			preview_2.set_color(make_rgb_pixval(r, g, b));
+		}
+		return true;
+	}
+	// OS color picker buttons
+	if(comp == &bt_os_picker_1) {
+		uint8 r = (uint8)inp_r1.get_value(), g = (uint8)inp_g1.get_value(), b = (uint8)inp_b1.get_value();
+		if(dr_pick_color_start(r, g, b)) {
+			pending_os_pick = 0;
+		}
+		else {
+			create_win( new news_img("A color picker is already open."), w_time_delete, magic_none );
+		}
+		return true;
+	}
+	if(comp == &bt_os_picker_2) {
+		uint8 r = (uint8)inp_r2.get_value(), g = (uint8)inp_g2.get_value(), b = (uint8)inp_b2.get_value();
+		if(dr_pick_color_start(r, g, b)) {
+			pending_os_pick = 1;
+		}
+		else {
+			create_win( new news_img("A color picker is already open."), w_time_delete, magic_none );
+		}
+		return true;
+	}
+
 	for(unsigned i=0;  i<28;  i++) {
 
 		// new player 1 color?
 		if(comp==player_color_1[i]) {
 			for(unsigned j=0;  j<28;  j++) {
 				player_color_1[j]->pressed = false;
+				player_color_2[j]->pressed = false;
 			}
 			player_color_1[i]->pressed = true;
-			//env_t::default_settings.set_default_player_color(player->get_player_nr(), player->get_player_color1(), player->get_player_color2());
 
-			// re-colour a player
+			// Also update color2 inputs to current values so Apply works consistently
+			uint8 r2, g2, b2;
+			if(player->is_player_color_custom()) {
+				r2 = player->get_player_color_r(1);
+				g2 = player->get_player_color_g(1);
+				b2 = player->get_player_color_b(1);
+			}
+			else {
+				pixval_to_rgb8(player->get_player_color2_pixval(env_t::gui_player_color_bright), r2, g2, b2);
+			}
+			inp_r2.set_value(r2); inp_g2.set_value(g2); inp_b2.set_value(b2);
+			preview_2.set_color(make_rgb_pixval(r2, g2, b2));
+
+			// Use preset palette index (not custom RGB)
 			cbuffer_t buf;
 			buf.printf( "1%u,%i", player->get_player_nr(), i*8);
 			tool_t *w = create_tool( TOOL_RECOLOUR_TOOL | SIMPLE_TOOL );
 			w->set_default_param( buf );
 			world()->set_tool( w, player );
-			// since init always returns false, it is save to delete immediately
 			delete w;
+
+			// Sync inp_r1/g1/b1 to chosen preset color
+			uint8 r1, g1, b1;
+			pixval_to_rgb8(color_idx_to_rgb(i*8 + env_t::gui_player_color_bright), r1, g1, b1);
+			inp_r1.set_value(r1); inp_g1.set_value(g1); inp_b1.set_value(b1);
+			preview_1.set_color(make_rgb_pixval(r1, g1, b1));
 			return true;
 		}
 
 		// new player color 2?
 		if(comp==player_color_2[i]) {
 			for(unsigned j=0;  j<28;  j++) {
+				player_color_1[j]->pressed = false;
 				player_color_2[j]->pressed = false;
 			}
 			player_color_2[i]->pressed = true;
-			//env_t::default_settings.set_default_player_color(player->get_player_nr(), player->get_player_color1(), player->get_player_color2());
 
-			// re-colour a player
+			uint8 r1, g1, b1;
+			if(player->is_player_color_custom()) {
+				r1 = player->get_player_color_r(0);
+				g1 = player->get_player_color_g(0);
+				b1 = player->get_player_color_b(0);
+			}
+			else {
+				pixval_to_rgb8(player->get_player_color1_pixval(env_t::gui_player_color_bright), r1, g1, b1);
+			}
+			inp_r1.set_value(r1); inp_g1.set_value(g1); inp_b1.set_value(b1);
+			preview_1.set_color(make_rgb_pixval(r1, g1, b1));
+
 			cbuffer_t buf;
 			buf.printf( "2%u,%i", player->get_player_nr(), i*8);
 			tool_t *w = create_tool( TOOL_RECOLOUR_TOOL | SIMPLE_TOOL );
 			w->set_default_param( buf );
 			world()->set_tool( w, player );
-			// since init always returns false, it is save to delete immediately
 			delete w;
+
+			uint8 r2, g2, b2;
+			pixval_to_rgb8(color_idx_to_rgb(i*8 + env_t::gui_player_color_bright), r2, g2, b2);
+			inp_r2.set_value(r2); inp_g2.set_value(g2); inp_b2.set_value(b2);
+			preview_2.set_color(make_rgb_pixval(r2, g2, b2));
 			return true;
 		}
 
@@ -219,4 +588,29 @@ bool farbengui_t::action_triggered( gui_action_creator_t *comp,value_t /* */)
 	}
 
 	return false;
+}
+
+
+void farbengui_t::draw(scr_coord pos, scr_size size)
+{
+	if(pending_os_pick >= 0) {
+		uint8 r, g, b;
+		const color_pick_result_t res = dr_pick_color_poll(r, g, b);
+		if(res == COLOR_PICK_OK) {
+			if(pending_os_pick == 0) {
+				inp_r1.set_value(r); inp_g1.set_value(g); inp_b1.set_value(b);
+				preview_1.set_color(make_rgb_pixval(r, g, b));
+				rgb_to_hex(r, g, b, hex_buf1);
+			}
+			else {
+				inp_r2.set_value(r); inp_g2.set_value(g); inp_b2.set_value(b);
+				preview_2.set_color(make_rgb_pixval(r, g, b));
+				rgb_to_hex(r, g, b, hex_buf2);
+			}
+		}
+		if(res != COLOR_PICK_RUNNING) {
+			pending_os_pick = -1;
+		}
+	}
+	gui_frame_t::draw(pos, size);
 }

--- a/gui/kennfarbe.h
+++ b/gui/kennfarbe.h
@@ -12,6 +12,9 @@
 #include "components/action_listener.h"
 #include "components/gui_textarea.h"
 #include "components/gui_button.h"
+#include "components/gui_colorbox.h"
+#include "components/gui_numberinput.h"
+#include "components/gui_textinput.h"
 #include "../simline.h"
 
 class choose_color_button_t;
@@ -32,6 +35,21 @@ class farbengui_t : public gui_frame_t, action_listener_t
 
 		button_t bt_all_line_color_change;
 
+		// Custom color picker widgets
+		gui_numberinput_t inp_r1, inp_g1, inp_b1;
+		gui_numberinput_t inp_r2, inp_g2, inp_b2;
+		gui_colorbox_t    preview_1, preview_2;
+		button_t          bt_apply_custom, bt_apply_custom_2;
+		char              hex_buf1[8], hex_buf2[8];
+		gui_textinput_t   inp_hex1, inp_hex2;
+		button_t          bt_os_picker_1, bt_os_picker_2;
+
+		void apply_custom_color();
+		void update_preview();
+
+		// -1 = no pick pending, 0 = primary color slot, 1 = secondary color slot
+		int pending_os_pick;
+
 	public:
 		farbengui_t(player_t *player_);
 
@@ -42,6 +60,8 @@ class farbengui_t : public gui_frame_t, action_listener_t
 		const char * get_help_filename() const OVERRIDE { return "color.txt"; }
 
 		bool action_triggered(gui_action_creator_t*, value_t) OVERRIDE;
+
+		void draw(scr_coord pos, scr_size size) OVERRIDE;
 };
 
 class line_colour_gui_t : public gui_frame_t, action_listener_t
@@ -52,12 +72,27 @@ class line_colour_gui_t : public gui_frame_t, action_listener_t
 
 		choose_color_button_t* line_colour[56];
 
+		// Custom color picker widgets for line
+		gui_numberinput_t inp_r, inp_g, inp_b;
+		gui_colorbox_t    preview;
+		button_t          bt_apply_custom;
+		char              hex_buf[8];
+		gui_textinput_t   inp_hex;
+		button_t          bt_os_picker;
+
+		void apply_custom_colour();
+		void update_preview();
+
+		bool pending_os_pick;
+
 	public:
 		line_colour_gui_t(linehandle_t line_, player_t *player_);
 
 		const char * get_help_filename() const OVERRIDE { return "color.txt"; }
 
 		bool action_triggered(gui_action_creator_t*, value_t ) OVERRIDE;
+
+		void draw(scr_coord pos, scr_size size) OVERRIDE;
 };
 
 #endif

--- a/gui/labellist_stats_t.cc
+++ b/gui/labellist_stats_t.cc
@@ -76,7 +76,7 @@ labellist_stats_t::labellist_stats_t(koord label_pos)
 	label.update();
 
 	if (const label_t *lb = get_label()) {
-		label.set_color(PLAYER_FLAG | color_idx_to_rgb(lb->get_owner()->get_player_color1()+env_t::gui_player_color_dark));
+		label.set_color(PLAYER_FLAG | lb->get_owner()->get_player_color1_pixval(env_t::gui_player_color_dark));
 	}
 }
 

--- a/gui/line_item.h
+++ b/gui/line_item.h
@@ -48,18 +48,17 @@ class line_color_line_scroll_item_t: public line_scrollitem_t
 public:
 	line_color_line_scroll_item_t( linehandle_t l ) : line_scrollitem_t(l) {};
 	PIXVAL get_color() const OVERRIDE {
-		const uint8 color_idx = get_line()->get_colour();
-		return color_idx_to_rgb(color_idx);
+		return get_line()->get_colour();
 	}
 };
 
-class company_color_line_scroll_item_t: public line_scrollitem_t 
+class company_color_line_scroll_item_t: public line_scrollitem_t
 {
 public:
 	company_color_line_scroll_item_t( linehandle_t l ) : line_scrollitem_t(l) {};
 	PIXVAL get_color() const OVERRIDE {
-		const uint8 color_idx = get_line()->get_owner()->get_player_color1();
-		return color_idx_to_rgb(color_idx);
+		// get_player_color1_pixval() (not get_player_color1()) so custom RGB player colors show correctly
+		return get_line()->get_owner()->get_player_color1_pixval(0);
 	}
 };
 

--- a/gui/map_frame.cc
+++ b/gui/map_frame.cc
@@ -267,7 +267,7 @@ map_frame_t::map_frame_t() :
 	viewable_players[ 0 ] = -1;
 	for(  int np = 0, count = 1;  np < MAX_PLAYER_COUNT;  np++  ) {
 		if(  welt->get_player( np )  &&  welt->get_player( np )->get_finance()->has_convoi()) {
-			viewed_player_c.new_component<gui_scrolled_list_t::const_text_scrollitem_t>(welt->get_player( np )->get_name(), color_idx_to_rgb(welt->get_player( np )->get_player_color1()+env_t::gui_player_color_dark));
+			viewed_player_c.new_component<gui_scrolled_list_t::const_text_scrollitem_t>(welt->get_player( np )->get_name(), welt->get_player( np )->get_player_color1_pixval(env_t::gui_player_color_dark));
 			viewable_players[ count++ ] = np;
 		}
 	}

--- a/gui/minimap.cc
+++ b/gui/minimap.cc
@@ -121,12 +121,12 @@ const uint8 minimap_t::severity_color[MAX_SEVERITY_COLORS] =
 };
 
 
-minimap_t::line_segment_t::line_segment_t(koord s, uint8 so, koord e, uint8 eo, schedule_t* sched, player_t* p, uint8 cc, bool diagonal, bool is_highlighted)
+minimap_t::line_segment_t::line_segment_t(koord s, uint8 so, koord e, uint8 eo, schedule_t* sched, player_t* p, PIXVAL lc, bool diagonal, bool is_highlighted)
 {
 	schedule = sched;
 	waytype = sched->get_waytype();
 	player = p;
-	colorcount = cc;
+	line_color = lc;
 	start_diagonal = diagonal;
 	if(  s.x<e.x  ||  (s.x==e.x  &&  s.y<e.y)  ) {
 		start = s;
@@ -167,7 +167,8 @@ bool minimap_t::LineSegmentOrdering::operator()(const minimap_t::line_segment_t&
 }
 
 
-static uint8 colore_idx = 0;
+static PIXVAL colore_idx = 0; // holds the final RGB pixel value for the next inserted line_segment_t
+static uint8 original_color_cycle = 0; // palette index cycled through in ORIGINAL color mode only
 static inthashtable_tpl< int, slist_tpl<schedule_t *> > waypoint_hash;
 
 
@@ -180,13 +181,14 @@ void minimap_t::add_to_schedule_cache( convoihandle_t cnv, bool with_waypoints )
 	}
 	schedule_t *schedule = cnv->get_schedule();
 	if(  network_color_mode==ORIGINAL  ) {
-		colore_idx += 8;
-		if(  colore_idx >= 208  ) {
-			colore_idx = (colore_idx % 8) + 1;
-			if(  colore_idx == 7  ) {
-				colore_idx = 0;
+		original_color_cycle += 8;
+		if(  original_color_cycle >= 208  ) {
+			original_color_cycle = (original_color_cycle % 8) + 1;
+			if(  original_color_cycle == 7  ) {
+				original_color_cycle = 0;
 			}
 		}
+		colore_idx = color_idx_to_rgb(original_color_cycle);
 	}
 	else if(  network_color_mode==LOAD_FACTOR  ) {
 		//TODO: extract common part from with schedule_list_gui_t::display()
@@ -219,14 +221,14 @@ void minimap_t::add_to_schedule_cache( convoihandle_t cnv, bool with_waypoints )
 		// and we do not like to divide by zero, do we?
 		if(capacity > 0) {
 			const uint32 load_idx = clamp(load * MAX_SEVERITY_COLORS / capacity, 0, MAX_SEVERITY_COLORS-1);
-			colore_idx = severity_color[MAX_SEVERITY_COLORS-1 - load_idx];
+			colore_idx = color_idx_to_rgb(severity_color[MAX_SEVERITY_COLORS-1 - load_idx]);
 		}
 		else {
-			colore_idx = severity_color[MAX_SEVERITY_COLORS-1];
+			colore_idx = color_idx_to_rgb(severity_color[MAX_SEVERITY_COLORS-1]);
 		}
 	}
 	else if(  network_color_mode==PLAYER_COLOR  ) {
-		colore_idx = cnv->get_owner()->get_player_color1();
+		colore_idx = cnv->get_owner()->get_player_color1_pixval(0);
 	}
 	else if(  network_color_mode==LINE_COLOR  ) {
 		if(  cnv->get_line().is_bound()  ) {
@@ -234,7 +236,7 @@ void minimap_t::add_to_schedule_cache( convoihandle_t cnv, bool with_waypoints )
 			colore_idx = cnv->get_line()->get_colour();
 		} else {
 			// this convoy is not line's convoy. show player color
-			colore_idx = cnv->get_owner()->get_player_color1();
+			colore_idx = cnv->get_owner()->get_player_color1_pixval(0);
 		}
 	}
 
@@ -928,7 +930,7 @@ void minimap_t::calc_map_pixel(const koord k)
 			for( int i = 0; i < plan->get_haltlist_count(); i++  ) {
 				halthandle_t halt = plan->get_haltlist()[i];
 				if (halt->get_pax_enabled() && !halt->get_pax_connections().empty()) {
-					set_map_color( k, color_idx_to_rgb(halt->get_owner()->get_player_color1() + 3) );
+					set_map_color( k, halt->get_owner()->get_player_color1_pixval(3) );
 					break;
 				}
 			}
@@ -940,7 +942,7 @@ void minimap_t::calc_map_pixel(const koord k)
 			for( int i = 0; i < plan->get_haltlist_count(); i++  ) {
 				halthandle_t halt = plan->get_haltlist()[i];
 				if (halt->get_mail_enabled() && !halt->get_mail_connections().empty()) {
-					set_map_color( k, color_idx_to_rgb(halt->get_owner()->get_player_color1() + 3) );
+					set_map_color( k, halt->get_owner()->get_player_color1_pixval(3) );
 					break;
 				}
 			}
@@ -1047,14 +1049,14 @@ void minimap_t::calc_map_pixel(const koord k)
 			// show ownership
 			{
 				if(  gr->is_halt()  ) {
-					set_map_color(k, color_idx_to_rgb(gr->get_halt()->get_owner()->get_player_color1()+3));
+					set_map_color(k, gr->get_halt()->get_owner()->get_player_color1_pixval(3));
 				}
 				else if(  weg_t *weg = gr->get_weg_nr(0)  ) {
-					set_map_color(k, weg->get_owner()==NULL ? color_idx_to_rgb(COL_ORANGE) : color_idx_to_rgb(weg->get_owner()->get_player_color1()+3) );
+					set_map_color(k, weg->get_owner()==NULL ? color_idx_to_rgb(COL_ORANGE) : weg->get_owner()->get_player_color1_pixval(3) );
 				}
 				if(  gebaeude_t *gb = gr->find<gebaeude_t>()  ) {
 					if(  gb->get_owner()!=NULL  ) {
-						set_map_color(k, color_idx_to_rgb(gb->get_owner()->get_player_color1()+3) );
+						set_map_color(k, gb->get_owner()->get_player_color1_pixval(3) );
 					}
 				}
 				break;
@@ -1527,11 +1529,11 @@ void minimap_t::draw(scr_coord pos)
 		// DISPLAY STATIONS AND AIRPORTS: moved here so station spots are not overwritten by lines drawn
 		FOR(  vector_tpl<line_segment_t>, seg, schedule_cache  ) {
 
-			uint8 color = seg.colorcount;
+			PIXVAL color = seg.line_color;
 			if(  event_get_last_control_shift()==2  ||  is_cnv_schedule_bound()  ) {
 				// on control / single convoi use only player colors
-				static uint8 last_color = color;
-				color = seg.player->get_player_color1()+1;
+				static PIXVAL last_color = color;
+				color = seg.player->get_player_color1_pixval(1);
 				// all lines same thickness if same color
 				if(  color == last_color || is_cnv_schedule_bound()  ) {
 					offset = 0;
@@ -1550,9 +1552,9 @@ void minimap_t::draw(scr_coord pos)
 			}
 			// and finally draw ...
 			if (  current_schedule  ) {
-				line_segment_draw( seg.waytype, k1, seg.start_offset*offset, k2, seg.end_offset*offset, diagonal, color_idx_to_rgb(color), seg.is_minimap_route_visible );
+				line_segment_draw( seg.waytype, k1, seg.start_offset*offset, k2, seg.end_offset*offset, diagonal, color, seg.is_minimap_route_visible );
 			} else {
-				line_segment_draw( seg.waytype, k1, seg.start_offset*offset, k2, seg.end_offset*offset, diagonal, color_idx_to_rgb(color) );
+				line_segment_draw( seg.waytype, k1, seg.start_offset*offset, k2, seg.end_offset*offset, diagonal, color );
 			}
 		}
 	}
@@ -1658,7 +1660,7 @@ void minimap_t::draw(scr_coord pos)
 		}
 		else {
 			const int stype = station->get_connected_station_type();
-			color = color_idx_to_rgb(station->get_owner()->get_player_color1()+3);
+			color = station->get_owner()->get_player_color1_pixval(3);
 
 			if (  route_search_transfer_halts.is_contained(station) && current_schedule && current_schedule->is_minimap_route_search_found()  ) {
 				radius = 6;
@@ -1752,7 +1754,7 @@ void minimap_t::draw(scr_coord pos)
 	if(  display_station.is_bound()  ) {
 		scr_coord temp_stop = map_to_screen_coord( display_station->get_basis_pos() );
 		temp_stop = temp_stop + pos;
-		display_ddd_proportional_clip( temp_stop.x + 10, temp_stop.y + 7, color_idx_to_rgb(display_station->get_owner()->get_player_color1()+3), color_idx_to_rgb(COL_WHITE), display_station->get_name(), false );
+		display_ddd_proportional_clip( temp_stop.x + 10, temp_stop.y + 7, display_station->get_owner()->get_player_color1_pixval(3), color_idx_to_rgb(COL_WHITE), display_station->get_name(), false );
 	}
 	max_waiting_change = new_max_waiting_change; // update waiting tendencies
 
@@ -1889,7 +1891,7 @@ void minimap_t::draw(scr_coord pos)
 			const bool has_filter = !highlighted_depot_positions.empty();
 			const bool highlighted = !has_filter || highlighted_depot_positions.is_contained(d->get_pos().get_2d());
 			const sint16 r = highlighted ? 4 : 2;
-			display_filled_circle_rgb( depot_pos.x, depot_pos.y, r, color_idx_to_rgb(d->get_owner()->get_player_color1()+4) );
+			display_filled_circle_rgb( depot_pos.x, depot_pos.y, r, d->get_owner()->get_player_color1_pixval(4) );
 			display_circle_rgb( depot_pos.x, depot_pos.y, r, color_idx_to_rgb(COL_BLACK) );
 			if(  highlighted && has_filter  ) {
 				display_circle_rgb( depot_pos.x, depot_pos.y, r + 3, color_idx_to_rgb(COL_WHITE) );
@@ -2001,7 +2003,7 @@ void minimap_t::draw(scr_coord pos)
 			}
 			else {
 				display_fillbox_wh_clip_rgb(draw_pos.x - 3, draw_pos.y - 3, 7, 7, color_idx_to_rgb(COL_BLACK), true);
-				display_fillbox_wh_clip_rgb(draw_pos.x - 2, draw_pos.y - 2, 5, 5, color_idx_to_rgb(cnv->get_owner()->get_player_color1() + 3), true);
+				display_fillbox_wh_clip_rgb(draw_pos.x - 2, draw_pos.y - 2, 5, 5, cnv->get_owner()->get_player_color1_pixval(3), true);
 			}
 
 			if(  abs(cnv_scr.x - hover_scr.x) <= 8  &&  abs(cnv_scr.y - hover_scr.y) <= 8  ) {

--- a/gui/minimap.h
+++ b/gui/minimap.h
@@ -100,14 +100,14 @@ private:
 		schedule_t *schedule;
 		player_t *player;
 		waytype_t waytype;
-		uint8 colorcount;
+		PIXVAL line_color; // already the final RGB pixel value to draw with, not a palette index
 		uint8 start_offset;
 		uint8 end_offset;
 		bool start_diagonal;
 		bool is_minimap_route_visible;
 
 		line_segment_t() {}
-		line_segment_t( koord s, uint8 so, koord e, uint8 eo, schedule_t *sched, player_t *p, uint8 cc, bool diagonal, bool is_highlighted = true );
+		line_segment_t( koord s, uint8 so, koord e, uint8 eo, schedule_t *sched, player_t *p, PIXVAL lc, bool diagonal, bool is_highlighted = true );
 
 		bool operator==(const line_segment_t & other) const;
 	};

--- a/gui/money_frame.cc
+++ b/gui/money_frame.cc
@@ -330,7 +330,7 @@ money_frame_t::money_frame_t(player_t *player) :
 		viewable_players[ 0 ] = 0;
 		for(  int np = 0, count = 0;  np < MAX_PLAYER_COUNT;  np++  ) {
 			if(  welt->get_player( np )  ) {
-				send_money_player_num.new_component<gui_scrolled_list_t::const_text_scrollitem_t>(welt->get_player( np )->get_name(), color_idx_to_rgb(welt->get_player( np )->get_player_color1()+env_t::gui_player_color_dark));
+				send_money_player_num.new_component<gui_scrolled_list_t::const_text_scrollitem_t>(welt->get_player( np )->get_name(), welt->get_player( np )->get_player_color1_pixval(env_t::gui_player_color_dark));
 				viewable_players[ count++ ] = np;
 			}
 		}

--- a/gui/player_frame_t.cc
+++ b/gui/player_frame_t.cc
@@ -22,6 +22,7 @@
 #include "money_frame.h" // for the finances
 #include "password_frame.h" // for the password
 #include "ai_selector.h"
+#include "kennfarbe.h"
 #include "player_frame_t.h"
 #include "player_merge_frame.h"
 
@@ -42,7 +43,7 @@ public:
 ki_kontroll_t::ki_kontroll_t() :
 	gui_frame_t( translator::translate("Spielerliste") )
 {
-	set_table_layout(5,0);
+	set_table_layout(6,0);
 
 	for(int i=0; i<MAX_PLAYER_COUNT-1; i++) {
 
@@ -69,7 +70,7 @@ ki_kontroll_t::ki_kontroll_t() :
 
 		// Prepare finances button
 		player_get_finances[i].init( button_t::box | button_t::flexible, "");
-		player_get_finances[i].background_color = PLAYER_FLAG | color_idx_to_rgb((player ? player->get_player_color1():i*8)+env_t::gui_player_color_bright);
+		player_get_finances[i].background_color = PLAYER_FLAG | (player ? player->get_player_color1_pixval(env_t::gui_player_color_bright) : color_idx_to_rgb(i*8+env_t::gui_player_color_bright));
 		player_get_finances[i].add_listener(this);
 
 		// Player type selector, Combobox
@@ -99,6 +100,13 @@ ki_kontroll_t::ki_kontroll_t() :
 		player_lock[i]->add_listener(this);
 		player_lock[i]->set_rigid(true);
 
+		// Company color button
+		player_color_btn[i] = new_component<password_button_t>();
+		player_color_btn[i]->background_color = player ? (PLAYER_FLAG | player->get_player_color1_pixval(env_t::gui_player_color_bright)) : color_idx_to_rgb(i*8+env_t::gui_player_color_bright);
+		player_color_btn[i]->set_visible(player != NULL);
+		player_color_btn[i]->set_rigid(true);
+		player_color_btn[i]->add_listener(this);
+
 		// Income label
 		ai_income[i] = new_component<gui_label_buf_t>(MONEY_PLUS, gui_label_t::money_right);
 		ai_income[i]->set_rigid(true);
@@ -108,13 +116,13 @@ ki_kontroll_t::ki_kontroll_t() :
 	freeplay.init( button_t::square_state, "freeplay mode");
 	freeplay.add_listener(this);
 	freeplay.pressed = welt->get_settings().is_freeplay();
-	add_component( &freeplay, 5 );
-	
+	add_component( &freeplay, 6 );
+
 	// player merging
 	merge_player.init( button_t::roundbox_state | button_t::flexible, "merge player");
 	merge_player.add_listener(this);
 	merge_player.pressed = false;
-	add_component( &merge_player, 5 );
+	add_component( &merge_player, 6 );
 	
 	update_data(); // calls reset_min_windowsize
 
@@ -209,6 +217,13 @@ bool ki_kontroll_t::action_triggered( gui_action_creator_t *comp,value_t p )
 			}
 		}
 
+		// Open company color dialog - only for the currently selected player
+		if(  comp == player_color_btn[i]  &&  welt->get_player(i)  &&  i == welt->get_active_player_nr()  ) {
+			player_color_btn[i]->pressed = false;
+			create_win( new farbengui_t(welt->get_player(i)), w_info, magic_farbengui_t );
+			break;
+		}
+
 		// New player assigned in an empty slot
 		if(  comp == (player_select+i)  ) {
 
@@ -271,8 +286,11 @@ void ki_kontroll_t::update_data()
 			}
 
 			// always update locking status
-			player_get_finances[i].background_color = PLAYER_FLAG | color_idx_to_rgb(player->get_player_color1()+env_t::gui_player_color_bright);
+			player_get_finances[i].background_color = PLAYER_FLAG | player->get_player_color1_pixval(env_t::gui_player_color_bright);
 			player_lock[i]->background_color = color_idx_to_rgb(player->is_locked() ? (player->is_unlock_pending() ? COL_YELLOW : COL_RED) : COL_GREEN);
+			player_color_btn[i]->background_color = PLAYER_FLAG | player->get_player_color1_pixval(env_t::gui_player_color_bright);
+			player_color_btn[i]->set_visible(true);
+			player_color_btn[i]->enable( i == welt->get_active_player_nr() );
 
 			// human players cannot be deactivated
 			if (i>1) {
@@ -288,6 +306,7 @@ void ki_kontroll_t::update_data()
 			player_change_to[i].set_visible(false);
 			player_select[i].set_visible(player_tools_allowed);
 			player_lock[i]->set_visible(false);
+			player_color_btn[i]->set_visible(false);
 
 			if (i>1) {
 				player_active[i-2].set_visible(0 < player_select[i].get_selection()  &&  player_select[i].get_selection() < player_t::MAX_AI);
@@ -373,6 +392,9 @@ void ki_kontroll_t::draw(scr_coord pos, scr_size size)
 		}
 
 		player_lock[i]->background_color = color_idx_to_rgb(player  &&  player->is_locked() ? (player->is_unlock_pending() ? COL_YELLOW : COL_RED) : COL_GREEN);
+		if(  player  ) {
+			player_color_btn[i]->enable( i == welt->get_active_player_nr() );
+		}
 	}
 
 	player_change_to[welt->get_active_player_nr()].pressed = true;

--- a/gui/player_frame_t.h
+++ b/gui/player_frame_t.h
@@ -31,6 +31,7 @@ class ki_kontroll_t : public gui_frame_t, private action_listener_t
 			player_get_finances[MAX_PLAYER_COUNT-1], // Finance buttons
 			player_change_to[MAX_PLAYER_COUNT-1],    // Set active player button
 			*player_lock[MAX_PLAYER_COUNT-1],         // Set name & password button
+			*player_color_btn[MAX_PLAYER_COUNT-1],   // Open company color dialog
 			freeplay,
 			merge_player;
 

--- a/gui/route_search_frame.cc
+++ b/gui/route_search_frame.cc
@@ -305,8 +305,8 @@ void route_search_frame_t::append_connection_row(haltestelle_t::connection_t con
     const player_t* player = std::visit([&](const auto& t) {
         return t->get_owner();
     }, connection.best_weight_traveler);
-    const uint8 color_idx = player->get_player_color1();
-    result_container.new_component<gui_label_t>(best_weight_traveler_name, color_idx_to_rgb(color_idx));
+    // get_player_color1_pixval() (not get_player_color1()) so custom RGB player colors show correctly
+    result_container.new_component<gui_label_t>(best_weight_traveler_name, player->get_player_color1_pixval(0));
 
     result_container.end_table();
 }

--- a/gui/schedule_list.cc
+++ b/gui/schedule_list.cc
@@ -690,7 +690,7 @@ void schedule_list_gui_t::draw(scr_coord pos, scr_size size)
 		if(  (!line->get_schedule()->empty()  &&  !line->get_schedule()->matches( welt, last_schedule ))  ||  last_vehicle_count != line->count_convoys()  ) {
 			update_lineinfo( line );
 		}
-		bt_colour_line.background_color = color_idx_to_rgb(line->get_colour());
+		bt_colour_line.background_color = line->get_colour();
 		PUSH_CLIP( pos.x + 1, pos.y + D_TITLEBAR_HEIGHT, size.w - 2, size.h - D_TITLEBAR_HEIGHT);
 		display(pos);
 		POP_CLIP();

--- a/gui/simwin.cc
+++ b/gui/simwin.cc
@@ -2026,7 +2026,7 @@ void win_display_flush(double konto)
 
 	if(wl->get_active_player()) {
 		char buffer[256];
-		display_proportional_rgb( middle-5, status_bar_text_y, wl->get_active_player()->get_name(), ALIGN_RIGHT, PLAYER_FLAG|color_idx_to_rgb(wl->get_active_player()->get_player_color1()+env_t::gui_player_color_dark), true);
+		display_proportional_rgb( middle-5, status_bar_text_y, wl->get_active_player()->get_name(), ALIGN_RIGHT, PLAYER_FLAG|wl->get_active_player()->get_player_color1_pixval(env_t::gui_player_color_dark), true);
 		money_to_string(buffer, konto );
 		display_proportional_rgb( middle+5, status_bar_text_y, buffer, ALIGN_LEFT, konto >= 0.0?MONEY_PLUS:MONEY_MINUS, true);
 	}

--- a/network/network_cmd_ingame.cc
+++ b/network/network_cmd_ingame.cc
@@ -302,7 +302,7 @@ void nwc_chat_t::add_message (karte_t* welt) const
 	dbg->warning("nwc_chat_t::add_message", "");
 	cbuffer_t buf;  // Output which will be printed to chat window
 
-	FLAGGED_PIXVAL color = player_nr < PLAYER_UNOWNED  ?  color_idx_to_rgb(welt->get_player( player_nr )->get_player_color1()+env_t::gui_player_color_dark)  :  color_idx_to_rgb(COL_WHITE);
+	FLAGGED_PIXVAL color = player_nr < PLAYER_UNOWNED  ?  welt->get_player( player_nr )->get_player_color1_pixval(env_t::gui_player_color_dark)  :  color_idx_to_rgb(COL_WHITE);
 	uint16 flag = message_t::chat;
 
 	if (  destination == NULL  ) {

--- a/obj/roadsign.cc
+++ b/obj/roadsign.cc
@@ -633,7 +633,7 @@ void roadsign_t::display_after(int xpos, int ypos, bool ) const
 		// draw with owner
 		if(  get_owner_nr() != PLAYER_UNOWNED  ) {
 			if(  obj_t::show_owner  ) {
-				display_blend( foreground_image, xpos, ypos, 0, color_idx_to_rgb(get_owner()->get_player_color1()+2) | OUTLINE_FLAG | TRANSPARENT75_FLAG, 0, dirty  CLIP_NUM_PAR);
+				display_blend( foreground_image, xpos, ypos, 0, get_owner()->get_player_color1_pixval(2) | OUTLINE_FLAG | TRANSPARENT75_FLAG, 0, dirty  CLIP_NUM_PAR);
 			}
 			else {
 				display_color( foreground_image, xpos, ypos, get_owner_nr(), true, get_flag(obj_t::dirty)  CLIP_NUM_PAR);

--- a/obj/simobj.cc
+++ b/obj/simobj.cc
@@ -217,7 +217,7 @@ void obj_t::display(int xpos, int ypos  CLIP_NUM_DEF) const
 		ypos += tile_raster_scale_y(get_yoff(), raster_width);
 
 		// Determine if this vehicle should use its convoy's line color
-		uint8 line_colour = 0;
+		PIXVAL line_colour = 0;
 		bool line_color_active = false;
 		if(  owner_n != PLAYER_UNOWNED  ) {
 			if(  vt  ) {
@@ -236,7 +236,7 @@ void obj_t::display(int xpos, int ypos  CLIP_NUM_DEF) const
 
 			if(  owner_n != PLAYER_UNOWNED  ) {
 				if(  obj_t::show_owner  ) {
-					display_blend( image, xpos, ypos, owner_n, color_idx_to_rgb(welt->get_player(owner_n)->get_player_color1()+2) | OUTLINE_FLAG | TRANSPARENT75_FLAG, 0, is_dirty  CLIP_NUM_PAR);
+					display_blend( image, xpos, ypos, owner_n, welt->get_player(owner_n)->get_player_color1_pixval(2) | OUTLINE_FLAG | TRANSPARENT75_FLAG, 0, is_dirty  CLIP_NUM_PAR);
 				}
 				else if(  line_color_active  ) {
 					// per-object live color substitution: each vehicle uses its own line color
@@ -315,7 +315,7 @@ void obj_t::display_after(int xpos, int ypos, bool) const
 
 		if(  owner_n != PLAYER_UNOWNED  ) {
 			if(  obj_t::show_owner  ) {
-				display_blend( image, xpos, ypos, owner_n, color_idx_to_rgb(welt->get_player(owner_n)->get_player_color1()+2) | OUTLINE_FLAG | TRANSPARENT75_FLAG, 0, is_dirty  CLIP_NUM_PAR);
+				display_blend( image, xpos, ypos, owner_n, welt->get_player(owner_n)->get_player_color1_pixval(2) | OUTLINE_FLAG | TRANSPARENT75_FLAG, 0, is_dirty  CLIP_NUM_PAR);
 			}
 			else if(  obj_t::get_flag( highlight )  ) {
 				// highlight this tile

--- a/player/simplay.cc
+++ b/player/simplay.cc
@@ -20,6 +20,7 @@
 #include "../gui/simwin.h"
 #include "../simworld.h"
 #include "../display/viewport.h"
+#include "../display/simgraph.h"
 
 #include "../bauer/brueckenbauer.h"
 #include "../bauer/hausbauer.h"
@@ -222,7 +223,7 @@ void player_t::display_messages()
 
 		const scr_coord scr_pos = vp->get_screen_coord(koord3d(m->pos,welt->lookup_hgt(m->pos)),koord(0,m->alter >> 4)) + scr_coord((get_tile_raster_width()-display_calc_proportional_string_len_width(m->str, 0x7FFF))/2,0);
 
-		display_shadow_proportional_rgb( scr_pos.x, scr_pos.y, PLAYER_FLAG|color_idx_to_rgb(player_color_1+3), color_idx_to_rgb(COL_BLACK), m->str, true);
+		display_shadow_proportional_rgb( scr_pos.x, scr_pos.y, PLAYER_FLAG|get_player_color1_pixval(3), color_idx_to_rgb(COL_BLACK), m->str, true);
 		if(  m->pos.x < 3  ||  m->pos.y < 3  ) {
 			// very close to border => renew background
 			welt->set_background_dirty();
@@ -267,7 +268,26 @@ void player_t::set_player_color(uint8 col1, uint8 col2)
 {
 	player_color_1 = col1;
 	player_color_2 = col2;
+	player_color_custom = false;
 	display_set_player_color_scheme( player_nr, col1, col2 );
+}
+
+void player_t::set_player_color_rgb(uint8 r1, uint8 g1, uint8 b1, uint8 r2, uint8 g2, uint8 b2)
+{
+	player_color_custom = true;
+	player_color_rgb[0][0] = r1; player_color_rgb[0][1] = g1; player_color_rgb[0][2] = b1;
+	player_color_rgb[1][0] = r2; player_color_rgb[1][1] = g2; player_color_rgb[1][2] = b2;
+	display_set_player_color_scheme_rgb(player_nr, r1, g1, b1, r2, g2, b2);
+}
+
+PIXVAL player_t::get_player_color1_pixval(int shade) const
+{
+	return display_get_player_color_pixval(player_nr, false, shade);
+}
+
+PIXVAL player_t::get_player_color2_pixval(int shade) const
+{
+	return display_get_player_color_pixval(player_nr, true, shade);
 }
 
 
@@ -296,7 +316,7 @@ bool player_t::new_month()
 				if(  finance->get_netwealth() < 0 ) {
 					destroy_all_win(true);
 					create_win( display_get_width()/2-128, 40, new news_img("Bankrott:\n\nDu bist bankrott.\n"), w_info, magic_none);
-					ticker::add_msg( translator::translate("Bankrott:\n\nDu bist bankrott.\n"), koord::invalid, PLAYER_FLAG + player_color_1 + 1 );
+					ticker::add_msg( translator::translate("Bankrott:\n\nDu bist bankrott.\n"), koord::invalid, PLAYER_FLAG | get_player_color1_pixval(1) );
 					welt->stop(false);
 				}
 				else if(  finance->get_netwealth()*10 < welt->get_settings().get_starting_money(welt->get_current_month()/12)  ){
@@ -670,6 +690,25 @@ void player_t::rdwr(loadsave_t *file)
 		file->rdwr_byte(player_color_2);
 	}
 
+	if(file->get_OTRP_version() >= 56) {
+		file->rdwr_bool(player_color_custom);
+		file->rdwr_byte(player_color_rgb[0][0]);
+		file->rdwr_byte(player_color_rgb[0][1]);
+		file->rdwr_byte(player_color_rgb[0][2]);
+		file->rdwr_byte(player_color_rgb[1][0]);
+		file->rdwr_byte(player_color_rgb[1][1]);
+		file->rdwr_byte(player_color_rgb[1][2]);
+	}
+	else if(file->is_loading()) {
+		player_color_custom = false;
+		// Migrate palette-based colors to player_color_rgb for clean OTRP 56 saves.
+		// color_idx_to_rgb uses specialcolormap_all_day which is ready during load.
+		PIXVAL col1 = color_idx_to_rgb(player_color_1 + env_t::gui_player_color_bright);
+		PIXVAL col2 = color_idx_to_rgb(player_color_2 + env_t::gui_player_color_bright);
+		pixval_to_rgb8(col1, player_color_rgb[0][0], player_color_rgb[0][1], player_color_rgb[0][2]);
+		pixval_to_rgb8(col2, player_color_rgb[1][0], player_color_rgb[1][1], player_color_rgb[1][2]);
+	}
+
 	sint32 halt_count=0;
 	if(file->is_version_less(99, 8)) {
 		file->rdwr_long(halt_count);
@@ -762,7 +801,14 @@ DBG_DEBUG("player_t::rdwr()","player %i: loading %i halts.",welt->sp2num( this )
 void player_t::finish_rd()
 {
 	simlinemgmt.finish_rd();
-	display_set_player_color_scheme( player_nr, player_color_1, player_color_2 );
+	if(player_color_custom) {
+		display_set_player_color_scheme_rgb(player_nr,
+			player_color_rgb[0][0], player_color_rgb[0][1], player_color_rgb[0][2],
+			player_color_rgb[1][0], player_color_rgb[1][1], player_color_rgb[1][2]);
+	}
+	else {
+		display_set_player_color_scheme( player_nr, player_color_1, player_color_2 );
+	}
 	// recalculate vehicle value
 	calc_assets();
 

--- a/player/simplay.cc
+++ b/player/simplay.cc
@@ -270,6 +270,11 @@ void player_t::set_player_color(uint8 col1, uint8 col2)
 	player_color_2 = col2;
 	player_color_custom = false;
 	display_set_player_color_scheme( player_nr, col1, col2 );
+
+	// update player window
+	if (ki_kontroll_t *frame = dynamic_cast<ki_kontroll_t *>( win_get_magic(magic_ki_kontroll_t) ) ) {
+		frame->update_data();
+	}
 }
 
 void player_t::set_player_color_rgb(uint8 r1, uint8 g1, uint8 b1, uint8 r2, uint8 g2, uint8 b2)
@@ -278,6 +283,11 @@ void player_t::set_player_color_rgb(uint8 r1, uint8 g1, uint8 b1, uint8 r2, uint
 	player_color_rgb[0][0] = r1; player_color_rgb[0][1] = g1; player_color_rgb[0][2] = b1;
 	player_color_rgb[1][0] = r2; player_color_rgb[1][1] = g2; player_color_rgb[1][2] = b2;
 	display_set_player_color_scheme_rgb(player_nr, r1, g1, b1, r2, g2, b2);
+
+	// update player window
+	if (ki_kontroll_t *frame = dynamic_cast<ki_kontroll_t *>( win_get_magic(magic_ki_kontroll_t) ) ) {
+		frame->update_data();
+	}
 }
 
 PIXVAL player_t::get_player_color1_pixval(int shade) const

--- a/player/simplay.h
+++ b/player/simplay.h
@@ -10,6 +10,7 @@
 #include "../utils/sha1_hash.h"
 #include "../simtypes.h"
 #include "../simlinemgmt.h"
+#include "../simcolor.h"
 
 #include "../halthandle_t.h"
 #include "../convoihandle_t.h"
@@ -91,9 +92,16 @@ protected:
 	void add_money_message(sint64 amount, koord k);
 
 	/**
-	 * Colors of the player
+	 * Colors of the player (palette indices, kept for save/load backward compat)
 	 */
 	uint8 player_color_1, player_color_2;
+
+	/**
+	 * Custom RGB color (r,g,b each 0-255) for each color slot, used when player_color_custom is true.
+	 * player_color_rgb[0] = primary, player_color_rgb[1] = secondary
+	 */
+	bool  player_color_custom;
+	uint8 player_color_rgb[2][3];
 
 	/**
 	 * Player number; only player 0 can do interaction
@@ -230,7 +238,16 @@ public:
 	/// Handles player colors
 	uint8 get_player_color1() const { return player_color_1; }
 	uint8 get_player_color2() const { return player_color_2; }
+	// Returns the display PIXVAL for this player's primary/secondary color at the given shade (0-7).
+	// shade 4 = gui_player_color_bright (base color). Works for both preset and custom RGB.
+	PIXVAL get_player_color1_pixval(int shade = 0) const;
+	PIXVAL get_player_color2_pixval(int shade = 0) const;
+	bool is_player_color_custom() const { return player_color_custom; }
+	uint8 get_player_color_r(int slot) const { return player_color_rgb[slot][0]; }
+	uint8 get_player_color_g(int slot) const { return player_color_rgb[slot][1]; }
+	uint8 get_player_color_b(int slot) const { return player_color_rgb[slot][2]; }
 	void set_player_color(uint8 col1, uint8 col2);
+	void set_player_color_rgb(uint8 r1, uint8 g1, uint8 b1, uint8 r2, uint8 g2, uint8 b2);
 
 	/**
 	 * @return the name of the player; "player -1" sits in front of the screen

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -6405,7 +6405,7 @@ void convoi_t::next_stop_button_pressed() {
 		// However, if the convoy is coupled convoy, calling c->set_schedule() destroy coupling information.
 		// So, we only call c->set_schedule() if c is leading.
 		if( !c->is_coupled() ) {
-			c->set_schedule(schedule);
+			c->set_schedule(schedule);			
 		}
 		if( c->is_coupling_done() ) {
 			c->set_coupling_done(false);

--- a/simline.cc
+++ b/simline.cc
@@ -13,6 +13,7 @@
 #include "dataobj/schedule.h"
 #include "dataobj/translator.h"
 #include "dataobj/loadsave.h"
+#include "display/simgraph.h"
 #include "gui/gui_theme.h"
 #include "player/simplay.h"
 #include "player/finance.h" // convert_money
@@ -46,7 +47,7 @@ simline_t::simline_t(player_t* player, linetype type)
 	sprintf(printname, "(%i) %s", self.get_id(), translator::translate("Line", welt->get_settings().get_name_language_id()));
 	name = printname;
 	memo = "";
-	colour = player->get_player_color1() + env_t::gui_player_color_bright;
+	colour = player->get_player_color1_pixval(env_t::gui_player_color_bright);
 
 	init_financial_history();
 	this->type = type;
@@ -147,7 +148,7 @@ void simline_t::set_memo(const char* new_memo)
 	memo = new_memo;
 }
 
-void simline_t::set_colour(const uint8 new_colour)
+void simline_t::set_colour(const PIXVAL new_colour)
 {
 	colour = new_colour;
 }
@@ -359,12 +360,30 @@ void simline_t::rdwr(loadsave_t *file)
 		memo = "";
 	}
 
-	if (file->get_OTRP_version() >= 51) {
-		file->rdwr_enum(colour);
-		// read colour of the line
+	if(file->get_OTRP_version() >= 56) {
+		// colour stored as portable R,G,B (3 bytes) so save files are readable
+		// regardless of whether the build uses RGB565 or RGB555 native pixels
+		uint8 r, g, b;
+		if(file->is_saving()) {
+			pixval_to_rgb8(colour, r, g, b);
+		}
+		file->rdwr_byte(r);
+		file->rdwr_byte(g);
+		file->rdwr_byte(b);
+		if(file->is_loading()) {
+			colour = make_rgb_pixval(r, g, b);
+		}
+	}
+	else if(file->get_OTRP_version() >= 51) {
+		// old format: palette index stored as sint32 via rdwr_enum (4 bytes)
+		sint32 old_idx = 0;
+		file->rdwr_long(old_idx);
+		colour = color_idx_to_rgb((uint8)old_idx);
 	}
 	else {
-		colour = player->get_player_color1();
+		// OTRP < 51: colour not stored; derive from palette index directly
+		// (player_offsets in display may not be updated yet before finish_rd)
+		colour = color_idx_to_rgb(player->get_player_color1() + env_t::gui_player_color_bright);
 	}
 	// otherwise initialized to zero if loading ...
 	financial_history[0][LINE_CONVOIS] = count_convoys();

--- a/simline.h
+++ b/simline.h
@@ -91,9 +91,9 @@ private:
 	sint64 financial_history[MAX_MONTHS][MAX_LINE_COST];
 
 	/**
-	 * colour of line
+	 * colour of line (stored as PIXVAL = 16-bit RGB565/RGB555 native screen color)
 	 */
-	uint8 colour;
+	PIXVAL colour;
 
 	/**
 	 * creates empty schedule with type depending on line-type
@@ -161,8 +161,8 @@ public:
 	/**
 	 * get colour of line
 	 */
-	uint8 const get_colour() const { return colour; }
-	void set_colour(const uint8 colour);
+	PIXVAL get_colour() const { return colour; }
+	void set_colour(const PIXVAL colour);
 
 	/*
 	 * load or save the line

--- a/simmesg.cc
+++ b/simmesg.cc
@@ -61,7 +61,7 @@ FLAGGED_PIXVAL message_t::node::get_player_color(karte_t *welt) const
 	FLAGGED_PIXVAL colorval = color;
 	if(  color&PLAYER_FLAG  ) {
 		player_t *player = welt->get_player(color&(~PLAYER_FLAG));
-		colorval = player ? PLAYER_FLAG+color_idx_to_rgb(player->get_player_color1()+env_t::gui_player_color_dark) : color_idx_to_rgb(MN_GREY0);
+		colorval = player ? PLAYER_FLAG | player->get_player_color1_pixval(env_t::gui_player_color_dark) : color_idx_to_rgb(MN_GREY0);
 	}
 	return colorval;
 }

--- a/simplan.cc
+++ b/simplan.cc
@@ -599,7 +599,7 @@ void planquadrat_t::display_overlay(const sint16 xpos, const sint16 ypos) const
 			image_id img = overlay_img(gr);
 
 			for(int halt_count = 0; halt_count < halt_list_count; halt_count++) {
-				const FLAGGED_PIXVAL transparent = PLAYER_FLAG | OUTLINE_FLAG | color_idx_to_rgb(halt_list[halt_count]->get_owner()->get_player_color1() + 4);
+				const FLAGGED_PIXVAL transparent = PLAYER_FLAG | OUTLINE_FLAG | halt_list[halt_count]->get_owner()->get_player_color1_pixval(4);
 				display_img_blend( img, xpos, ypos, transparent | TRANSPARENT25_FLAG, 0, 0);
 			}
 /*
@@ -627,7 +627,7 @@ void planquadrat_t::display_overlay(const sint16 xpos, const sint16 ypos) const
 			const sint16 off = (raster_tile_width>>5);
 			// suitable start search
 			for (size_t h = halt_list_count; h-- != 0;) {
-				display_fillbox_wh_clip_rgb(x - h * off, y + h * off, r, r, PLAYER_FLAG | color_idx_to_rgb(halt_list[h]->get_owner()->get_player_color1() + 4), kartenboden_dirty);
+				display_fillbox_wh_clip_rgb(x - h * off, y + h * off, r, r, PLAYER_FLAG | halt_list[h]->get_owner()->get_player_color1_pixval(4), kartenboden_dirty);
 			}
 		}
 	}

--- a/simtool.cc
+++ b/simtool.cc
@@ -15,6 +15,7 @@
 
 #include "gui/simwin.h"
 #include "display/viewport.h"
+#include "display/simgraph.h"
 
 #include "bauer/fabrikbauer.h"
 #include "bauer/vehikelbauer.h"
@@ -9899,10 +9900,12 @@ bool tool_change_line_t::init( player_t *player )
 			}
 			break;
 
-		case 'o': // change colour of line
+		case 'o': // change colour of line: "#RRGGBB", portable across RGB565/RGB555 builds
 			{
-				uint8 n_colour = atoi(p);
-				line->set_colour(n_colour);
+				unsigned int r = 0, g = 0, b = 0;
+				if(*p == '#'  &&  sscanf(p, "#%02x%02x%02x", &r, &g, &b) == 3) {
+					line->set_colour( make_rgb_pixval((uint8)r, (uint8)g, (uint8)b) );
+				}
 			}
 			break;
 
@@ -10868,30 +10871,82 @@ bool tool_recolour_t::init(player_t *sp)
 			return false;
 	}
 
-	const uint8 colour = atoi(p);
-
 	// now for action ...
+	player_t *target = welt->get_player(id);
+	if(!target) {
+		dbg->error( "wkz_recolour_t::init", "could not perform (%s)", default_param );
+		return false;
+	}
+
+	// Custom RGB format: "#RRGGBB,#RRGGBB" (both colors) or "#RRGGBB" with what=1 or what=2 (keep other)
+	if(*p == '#') {
+		// Parse hex RGB
+		unsigned int r1 = 0, g1 = 0, b1 = 0, r2 = 0, g2 = 0, b2 = 0;
+		if(sscanf(p, "#%02x%02x%02x", &r1, &g1, &b1) == 3) {
+			const char *q = strchr(p, ',');
+			if(q && *(q+1) == '#' && sscanf(q+1, "#%02x%02x%02x", &r2, &g2, &b2) == 3) {
+				// Both colors provided
+				target->set_player_color_rgb(r1, g1, b1, r2, g2, b2);
+			}
+			else if(what == '1') {
+				uint8 or2 = target->get_player_color_r(1);
+				uint8 og2 = target->get_player_color_g(1);
+				uint8 ob2 = target->get_player_color_b(1);
+				if(!target->is_player_color_custom()) {
+					// Convert existing preset to RGB first
+					PIXVAL col2 = target->get_player_color2_pixval(env_t::gui_player_color_bright);
+					pixval_to_rgb8(col2, or2, og2, ob2);
+				}
+				target->set_player_color_rgb(r1, g1, b1, or2, og2, ob2);
+			}
+			else {
+				uint8 or1 = target->get_player_color_r(0);
+				uint8 og1 = target->get_player_color_g(0);
+				uint8 ob1 = target->get_player_color_b(0);
+				if(!target->is_player_color_custom()) {
+					PIXVAL col1 = target->get_player_color1_pixval(env_t::gui_player_color_bright);
+					pixval_to_rgb8(col1, or1, og1, ob1);
+				}
+				target->set_player_color_rgb(or1, og1, ob1, r1, g1, b1);
+			}
+		}
+		return false;
+	}
+
+	// Legacy palette-index format
+	const uint8 colour = atoi(p);
 	switch(  what  )
 	{
 		case '1': // Change player colour 1
-		{
-			if(welt->get_player(id))
-			{
-				welt->get_player(id)->set_player_color(colour, welt->get_player(id)->get_player_color2());
-				return false;
+			if(  target->is_player_color_custom()  ) {
+				// player is currently using a custom RGB color: get_player_color2()
+				// only holds a stale preset index, not the real custom color of slot 2,
+				// so convert the newly chosen preset to RGB and keep slot 2 as-is
+				const PIXVAL new_col1 = color_idx_to_rgb(colour + env_t::gui_player_color_bright);
+				uint8 r1, g1, b1;
+				pixval_to_rgb8(new_col1, r1, g1, b1);
+				target->set_player_color_rgb(r1, g1, b1,
+					target->get_player_color_r(1), target->get_player_color_g(1), target->get_player_color_b(1));
 			}
-			break;
-		}
+			else {
+				target->set_player_color(colour, target->get_player_color2());
+			}
+			return false;
 
 		case '2': // Change player colour 2
-		{
-			if(welt->get_player(id))
-			{
-				welt->get_player(id)->set_player_color( welt->get_player(id)->get_player_color1(), colour);
-				return false;
+			if(  target->is_player_color_custom()  ) {
+				// same as above, mirrored for slot 2
+				const PIXVAL new_col2 = color_idx_to_rgb(colour + env_t::gui_player_color_bright);
+				uint8 r2, g2, b2;
+				pixval_to_rgb8(new_col2, r2, g2, b2);
+				target->set_player_color_rgb(
+					target->get_player_color_r(0), target->get_player_color_g(0), target->get_player_color_b(0),
+					r2, g2, b2);
 			}
-			break;
-		}
+			else {
+				target->set_player_color(target->get_player_color1(), colour);
+			}
+			return false;
 	}
 
 	// we are only getting here, if we could not process this request

--- a/simtool.cc
+++ b/simtool.cc
@@ -9916,8 +9916,9 @@ bool tool_change_line_t::init( player_t *player )
 				}
 				vector_tpl<linehandle_t> lines;
 				player->simlinemgmt.get_lines(simline_t::line, &lines);
+				const PIXVAL new_colour = player->get_player_color1_pixval(env_t::gui_player_color_bright);
 				FOR(vector_tpl<linehandle_t>, const l, lines) {
-					l->set_colour(player->get_player_color1()+env_t::gui_player_color_bright);
+					l->set_colour(new_colour);
 				}
 			}
 			break;

--- a/sys/simsys.h
+++ b/sys/simsys.h
@@ -271,4 +271,26 @@ sint16 dr_toggle_borderless();
 
 int sysmain(int argc, char** argv);
 
+enum color_pick_result_t {
+	COLOR_PICK_NONE,      // nothing in progress (never started, or already collected)
+	COLOR_PICK_RUNNING,   // dialog still open, keep polling
+	COLOR_PICK_OK,        // user confirmed, r/g/b filled in
+	COLOR_PICK_CANCELLED  // user cancelled
+};
+
+/**
+ * Open the OS native color picker dialog on a background thread, so the
+ * caller (and the game loop) is not blocked while it is open.
+ * @param r/g/b initial color
+ * @return false if a pick is already in progress (poll it first with dr_pick_color_poll)
+ *         or if not supported on this platform.
+ */
+bool dr_pick_color_start(uint8 r, uint8 g, uint8 b);
+
+/**
+ * Non-blocking poll for the outcome of a pick started with dr_pick_color_start().
+ * @param r/g/b out: chosen color, only valid when COLOR_PICK_OK is returned
+ */
+color_pick_result_t dr_pick_color_poll(uint8 &r, uint8 &g, uint8 &b);
+
 #endif

--- a/sys/simsys_posix.cc
+++ b/sys/simsys_posix.cc
@@ -201,6 +201,10 @@ sint16 dr_toggle_borderless()
 	return 0;
 }
 
+bool dr_pick_color_start(uint8, uint8, uint8) { return false; }
+color_pick_result_t dr_pick_color_poll(uint8 &, uint8 &, uint8 &) { return COLOR_PICK_NONE; }
+
+
 int main(int argc, char **argv)
 {
 	signal( SIGTERM, posix_sigterm );

--- a/sys/simsys_s.cc
+++ b/sys/simsys_s.cc
@@ -746,6 +746,9 @@ sint16 dr_toggle_borderless()
 	return fullscreen;
 }
 
+bool dr_pick_color_start(uint8, uint8, uint8) { return false; }
+color_pick_result_t dr_pick_color_poll(uint8 &, uint8 &, uint8 &) { return COLOR_PICK_NONE; }
+
 #ifdef _MSC_VER
 // Needed for MS Visual C++ with /SUBSYSTEM:CONSOLE to work , if /SUBSYSTEM:WINDOWS this function is compiled but unreachable
 #undef main

--- a/sys/simsys_s2.cc
+++ b/sys/simsys_s2.cc
@@ -1116,6 +1116,9 @@ int main()
 #endif
 
 
+bool dr_pick_color_start(uint8, uint8, uint8) { return false; }
+color_pick_result_t dr_pick_color_poll(uint8 &, uint8 &, uint8 &) { return COLOR_PICK_NONE; }
+
 #ifdef _WIN32
 int CALLBACK WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
 #else

--- a/sys/simsys_w.cc
+++ b/sys/simsys_w.cc
@@ -1066,9 +1066,18 @@ static DWORD WINAPI color_pick_proc(LPVOID)
 
 bool dr_pick_color_start(uint8 r, uint8 g, uint8 b)
 {
-	if(  InterlockedCompareExchange(&color_pick_state, 1, 0) != 0  ) {
-		// a pick is already running, or a finished result has not been collected yet
-		return false;
+	// Claim the slot from idle(0) or done-but-uncollected(2): the latter happens
+	// when the GUI that started a previous pick was closed before it could poll
+	// the result (e.g. the color picker window was closed after the requesting
+	// dialog had already been closed). Only a genuinely running(1) pick refuses.
+	for(;;) {
+		const LONG old_state = color_pick_state;
+		if(  old_state == 1  ) {
+			return false;
+		}
+		if(  InterlockedCompareExchange(&color_pick_state, 1, old_state) == old_state  ) {
+			break;
+		}
 	}
 	if(  color_pick_thread  ) {
 		CloseHandle( color_pick_thread );

--- a/sys/simsys_w.cc
+++ b/sys/simsys_w.cc
@@ -1031,6 +1031,84 @@ int main()
 #endif
 
 
+// ChooseColor() runs its own modal message loop and does not return until the
+// dialog is closed. Since the game's simulation and rendering are stepped
+// synchronously from the same thread that would call it, doing so directly
+// would freeze the game for as long as the dialog stays open. Instead, the
+// dialog is run on a dedicated worker thread (with no owner window, so
+// Windows does not disable/grey out the main window either) and the result
+// is picked up later via dr_pick_color_poll(), called once per frame from
+// the GUI while a pick is pending.
+static LONG volatile color_pick_state = 0; // 0=idle, 1=running, 2=done, use Interlocked* for cross-thread visibility
+static HANDLE color_pick_thread = NULL;
+static uint8 color_pick_in_r, color_pick_in_g, color_pick_in_b;
+static uint8 color_pick_out_r, color_pick_out_g, color_pick_out_b;
+static bool color_pick_accepted = false;
+
+static DWORD WINAPI color_pick_proc(LPVOID)
+{
+	static COLORREF custom_colors[16] = {};
+	CHOOSECOLOR cc = {};
+	cc.lStructSize  = sizeof(cc);
+	cc.hwndOwner    = NULL; // no owner: keeps the main window enabled and responsive
+	cc.lpCustColors = custom_colors;
+	cc.rgbResult    = RGB(color_pick_in_r, color_pick_in_g, color_pick_in_b);
+	cc.Flags        = CC_FULLOPEN | CC_RGBINIT;
+	color_pick_accepted = ChooseColor(&cc) != 0;
+	if(  color_pick_accepted  ) {
+		color_pick_out_r = GetRValue(cc.rgbResult);
+		color_pick_out_g = GetGValue(cc.rgbResult);
+		color_pick_out_b = GetBValue(cc.rgbResult);
+	}
+	InterlockedExchange(&color_pick_state, 2);
+	return 0;
+}
+
+bool dr_pick_color_start(uint8 r, uint8 g, uint8 b)
+{
+	if(  InterlockedCompareExchange(&color_pick_state, 1, 0) != 0  ) {
+		// a pick is already running, or a finished result has not been collected yet
+		return false;
+	}
+	if(  color_pick_thread  ) {
+		CloseHandle( color_pick_thread );
+		color_pick_thread = NULL;
+	}
+	color_pick_in_r = r;
+	color_pick_in_g = g;
+	color_pick_in_b = b;
+	color_pick_thread = CreateThread( NULL, 0, color_pick_proc, NULL, 0, NULL );
+	if(  color_pick_thread == NULL  ) {
+		InterlockedExchange(&color_pick_state, 0);
+		return false;
+	}
+	return true;
+}
+
+color_pick_result_t dr_pick_color_poll(uint8 &r, uint8 &g, uint8 &b)
+{
+	const LONG state = InterlockedCompareExchange(&color_pick_state, 0, 0);
+	if(  state == 1  ) {
+		return COLOR_PICK_RUNNING;
+	}
+	if(  state != 2  ) {
+		return COLOR_PICK_NONE;
+	}
+	if(  color_pick_thread  ) {
+		CloseHandle( color_pick_thread ); // already signalled done, does not block
+		color_pick_thread = NULL;
+	}
+	InterlockedExchange(&color_pick_state, 0);
+	if(  color_pick_accepted  ) {
+		r = color_pick_out_r;
+		g = color_pick_out_g;
+		b = color_pick_out_b;
+		return COLOR_PICK_OK;
+	}
+	return COLOR_PICK_CANCELLED;
+}
+
+
 const char* dr_get_locale()
 {
 	static char LanguageCode[5]="";

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -2093,7 +2093,7 @@ void vehicle_t::display_after(int xpos, int ypos, bool is_global) const
 	}
 	if( state==env_t::LINE_NAME_TOOLTIPS || color == 0 ) {
 		if(state==env_t::LINE_NAME_TOOLTIPS || state==env_t::LINE_NAME_AND_STATES_TOOLTIPS) {
-			color = color_idx_to_rgb( cnv->get_owner()->get_player_color1()+7 );
+			color = cnv->get_owner()->get_player_color1_pixval(7);
 		} else {
 			color = color_idx_to_rgb(COL_YELLOW);
 		}
@@ -2117,7 +2117,7 @@ void vehicle_t::display_after(int xpos, int ypos, bool is_global) const
 				if(  env_t::show_line_colors && lh.is_bound()  ) {
 					// show line colour
 					sint32 tooltip_width = proportional_string_width(tooltip_text);
-					display_fillbox_wh_clip_rgb( xpos, ypos-D_WAITINGBAR_WIDTH, tooltip_width+4, D_WAITINGBAR_WIDTH, color_idx_to_rgb(lh->get_colour()), dirty );
+					display_fillbox_wh_clip_rgb( xpos, ypos-D_WAITINGBAR_WIDTH, tooltip_width+4, D_WAITINGBAR_WIDTH, lh->get_colour(), dirty );
 				}
 			}
 		}


### PR DESCRIPTION
プレイヤーカラーとラインカラーをRGB値で指定できるようにしました。
セーブデータの形式変更が入っているので、バージョン56でのリリース前提で書いてます。
<img width="546" height="317" alt="image" src="https://github.com/user-attachments/assets/b1dadae2-cd12-4fa3-a552-039215ffe942" />
