### PR TITLE
Fix route cache validation after road direction changes

### DIFF
--- a/dataobj/route.cc
+++ b/dataobj/route.cc
@@ -805,13 +805,19 @@ bool route_t::is_passable(karte_t *welt, test_driver_t *tdriver, bool need_elect
 		if (!gr || !tdriver->check_next_tile(gr, need_electric)) {
 			return false;
 		}
-		if( i==route.get_count()-1 ) {
-			continue; // The direction check is performed except for the last tile
-		}
 		// Since test_driver_t::check_next_tile cannot do the direction check, we need to do that.
-		const ribi_t::ribi dir = ribi_type(route[i], route[i+1]);
-		if( (gr->get_weg_ribi(tdriver->get_waytype())&dir) == 0 ) {
-			return false;
+		if( i<route.get_count()-1 ) {
+			const ribi_t::ribi dir = ribi_type(route[i], route[i+1]);
+			if( (gr->get_weg_ribi(tdriver->get_waytype())&dir) == 0 ) {
+				return false;
+			}
+		}
+		else if( i>0 ) {
+			const ribi_t::ribi dir = ribi_type(route[i-1], route[i]);
+			const weg_t *w = gr->get_weg(tdriver->get_waytype());
+			if( w  &&  w->get_ribi_maske()  &&  ribi_t::reverse_single(dir)==w->get_ribi() ) {
+				return false;
+			}
 		}
 	}
 	return true;

--- a/dataobj/route.cc
+++ b/dataobj/route.cc
@@ -812,13 +812,6 @@ bool route_t::is_passable(karte_t *welt, test_driver_t *tdriver, bool need_elect
 				return false;
 			}
 		}
-		else if( i>0 ) {
-			const ribi_t::ribi dir = ribi_type(route[i-1], route[i]);
-			const weg_t *w = gr->get_weg(tdriver->get_waytype());
-			if( w  &&  w->get_ribi_maske()  &&  ribi_t::reverse_single(dir)==w->get_ribi() ) {
-				return false;
-			}
-		}
 	}
 	return true;
 }

--- a/dataobj/route.cc
+++ b/dataobj/route.cc
@@ -805,6 +805,14 @@ bool route_t::is_passable(karte_t *welt, test_driver_t *tdriver, bool need_elect
 		if (!gr || !tdriver->check_next_tile(gr, need_electric)) {
 			return false;
 		}
+		if( i==route.get_count()-1 ) {
+			continue; // The direction check is performed except for the last tile
+		}
+		// Since test_driver_t::check_next_tile cannot do the direction check, we need to do that.
+		const ribi_t::ribi dir = ribi_type(route[i], route[i+1]);
+		if( (gr->get_weg_ribi(tdriver->get_waytype())&dir) == 0 ) {
+			return false;
+		}
 	}
 	return true;
 }


### PR DESCRIPTION
## 概要

道路の接続方向が変わってキャッシュ済み経路が通行不能になっている場合でも、そのキャッシュが採用されてしまう問題を修正しました。

`route_t::is_passable()` でキャッシュ経路を検証する際に、各タイルが通行可能かだけでなく、次タイル方向への道路接続が残っているかも確認するようにしています。

## 変更内容

- キャッシュ経路の検証時に、最後のタイル以外で次タイルへの `weg_ribi` 接続を確認
- 接続方向がなくなっている場合はキャッシュ経路を通行不能として破棄

## 確認

バスで以下を手動確認しました。

- 道路の接続が変わっていない時はキャッシュが使われること
- より最適な経路が出現しても旧来の経路が利用可能であれば旧来の経路のキャッシュを使うこと
- キャッシュの経路でoneway modeの接続方向を切り替え、通行不能にしたらキャッシュが破棄されたこと