### PR TITLE
Fix convoi freight list scrolling

### DIFF
--- a/gui/convoi_info_t.cc
+++ b/gui/convoi_info_t.cc
@@ -207,6 +207,7 @@ void convoi_info_t::init(convoihandle_t cnv)
 
 		sort_button.init(button_t::roundbox, sort_text[env_t::default_sortmode]);
 		sort_button.set_tooltip("Sort by");
+		sort_button.set_focusable(false);
 		sort_button.add_listener(this);
 		container_freight.add_component(&sort_button);
 	}


### PR DESCRIPTION
## 概要

編成情報ウィンドウの Freight タブで、貨物一覧が縦に長くなったときにスクロールバーをドラッグしても表示位置が先頭へ戻ってしまう問題を修正しました。

`container_freight` 先頭のソートボタンがフォーカスを持つと、スクロールペインの再レイアウト時に `show_focused()` がそのボタンを表示範囲へ戻そうとして、スクロール位置がトップへ戻っていました。

## 変更内容

- 編成情報の貨物ソートボタンをキーボードフォーカス対象から外すように変更
- マウスクリックによるソート切り替えは維持

## 確認

- `make -j8`
