### PR TITLE
Prohibit bridge pillars from landing on air_wt tiles

### DIFF
--- a/bauer/brueckenbauer.cc
+++ b/bauer/brueckenbauer.cc
@@ -862,8 +862,8 @@ void bridge_builder_t::build_bridge(player_t *player, const koord3d start, const
 		bruecke->calc_image();
 		br->finish_rd();
 //DBG_MESSAGE("bool bridge_builder_t::build_bridge()","at (%i,%i)",pos.x,pos.y);
-		if(desc->get_pillar()>0) {
-			// make a new pillar here
+		if(desc->get_pillar()>0  &&  !gr->hat_weg(air_wt)) {
+			// make a new pillar here (never on airways)
 			if(desc->get_pillar()==1  ||  (pos.x*zv.x+pos.y*zv.y)%desc->get_pillar()==0) {
 //DBG_MESSAGE("bool bridge_builder_t::build_bridge()","h1=%i, h2=%i",pos.z,gr->get_pos().z);
 				while(height-->0) {


### PR DESCRIPTION
Pillar placement was previously governed purely by pak data (pillars_every); there was no engine-side waytype restriction. Add an explicit veto so a bridge's pillar_t is never created on a tile that carries any air_wt way, complementing the existing "no bridges over runways" rule in the same file.