### PR TITLE
Add type_elevated_airway systemtype and is_elevated()/is_runway() helpers

### DIFF
--- a/bauer/brueckenbauer.cc
+++ b/bauer/brueckenbauer.cc
@@ -882,7 +882,7 @@ void bridge_builder_t::build_bridge(player_t *player, const koord3d start, const
 	bool need_auffahrt = pos.z != end_slope_height;
 	if(  need_auffahrt  ) {
 		if(  weg_t const* const w = welt->lookup(end)->get_weg( way_desc->get_wtyp() )  ) {
-			need_auffahrt &= w->get_desc()->get_styp() != type_elevated;
+			need_auffahrt &= !w->get_desc()->is_elevated();
 		}
 	}
 

--- a/bauer/wegbauer.cc
+++ b/bauer/wegbauer.cc
@@ -2191,7 +2191,7 @@ uint32 ms = dr_time();
 		route_reversed = false;
 		keep_existing_city_roads |= (bautyp&bot_flag)!=0;
 		sint32 cost2;
-		if(desc->get_styp() == type_elevated) {
+		if(desc->is_elevated()) {
 			cost2 = intern_calc_route_elevated(start[0], ziel[0]);
 			INT_CHECK("wegbauer 1165");
 			if(cost2 < 0) {
@@ -2217,7 +2217,7 @@ uint32 ms = dr_time();
 		swap(terraform_index, terraform_index2);
 		route_reversed = true;
 		sint32 cost;
-		if(desc->get_styp() == type_elevated) {
+		if(desc->is_elevated()) {
 			cost = intern_calc_route_elevated(start[0], ziel[0]);
 		}
 		else {

--- a/descriptor/way_desc.h
+++ b/descriptor/way_desc.h
@@ -102,6 +102,11 @@ public:
 
 	bool is_tram() const { return wtyp == track_wt  &&  styp == type_tram; }
 
+	// true for genuinely elevated ways; for air_wt this means an elevated airway, never a runway
+	bool is_elevated() const { return wtyp == air_wt ? styp == type_elevated_airway : styp == type_elevated; }
+
+	bool is_runway() const { return wtyp == air_wt  &&  styp == type_runway; }
+
 	bool is_clip_below() const { return clip_below; }
 
 	image_id get_image_id(ribi_t::ribi ribi, uint8 season, bool front = false) const

--- a/simtool.cc
+++ b/simtool.cc
@@ -2956,7 +2956,7 @@ bool tool_build_way_t::exit( player_t *player )
 
 void tool_build_way_t::draw_after(scr_coord k, bool dirty) const
 {
-	if(  desc  &&  (desc->get_waytype()==road_wt  ||  desc->get_styp()==type_elevated)  ) {
+	if(  desc  &&  (desc->get_waytype()==road_wt  ||  desc->is_elevated())  ) {
 		if(  icon!=IMG_EMPTY  &&  is_selected()  ) {
 			display_img_blend( icon, k.x, k.y, TRANSPARENT50_FLAG|OUTLINE_FLAG|color_idx_to_rgb(COL_BLACK), false, dirty );
 			char mode_str[8], offset_str[8];
@@ -2967,7 +2967,7 @@ void tool_build_way_t::draw_after(scr_coord k, bool dirty) const
 				display_proportional_rgb( k.x+4, k.y+4, mode_str, ALIGN_LEFT, color_idx_to_rgb(color), true );
 			}
 			// show height offset when height offset is set for this elevated way.
-			if(  desc->get_styp()==type_elevated  &&  height_offset!=0  ) {
+			if(  desc->is_elevated()  &&  height_offset!=0  ) {
 				sprintf(offset_str, "%d", height_offset);
 				display_proportional_rgb( k.x+28, k.y+4, offset_str, ALIGN_RIGHT, color_idx_to_rgb(COL_YELLOW), true );
 			}
@@ -2988,7 +2988,7 @@ waytype_t tool_build_way_t::get_waytype() const
 
 void tool_build_way_t::start_at( koord3d &new_start )
 {
-	if(  is_shift_pressed()  &&  (desc->get_styp() == type_elevated  &&  desc->get_wtyp() != air_wt)  ) {
+	if(  is_shift_pressed()  &&  desc->is_elevated()  ) {
 		grund_t *gr=welt->lookup(new_start);
 		if(  gr->get_weg( desc->get_waytype() )  ) {
 			new_start.z -= welt->get_settings().get_way_height_clearance();
@@ -3007,7 +3007,7 @@ uint8 tool_build_way_t::is_valid_pos( player_t *player, const koord3d &pos, cons
 		if(  gr->get_typ() == grund_t::tunnelboden  &&  !gr->ist_karten_boden()  && !( desc->is_tram()  && ( gr->hat_weg(track_wt) || gr->hat_weg(road_wt) || gr->hat_weg(monorail_wt) || gr->hat_weg(maglev_wt) || gr->hat_weg(narrowgauge_wt) ) )  ) {
 			return 0;
 		}
-		bool const elevated = desc->get_styp() == type_elevated  &&  desc->get_wtyp() != air_wt;
+		bool const elevated = desc->is_elevated();
 		// ignore water
 		if(  desc->get_wtyp() != water_wt  &&  gr->get_typ() == grund_t::wasser  ) {
 			if(  !elevated  ||  welt->lookup_hgt( pos.get_2d() ) < welt->get_water_hgt( pos.get_2d() )  ) {
@@ -3072,7 +3072,7 @@ bool tool_build_way_t::calc_route( way_builder_t &bauigel, const koord3d &start,
 		bautyp = way_builder_t::schiene_tram;
 	}
 	// elevated track?
-	if(desc->get_styp()==type_elevated  &&  desc->get_wtyp()!=air_wt) {
+	if(desc->is_elevated()) {
 		sint8 hf = height_offset;
 		tool_build_way_t* toolbar_tool;
 		if(  look_toolbar  &&  (toolbar_tool=get_build_way_tool_from_toolbar(desc))!=NULL  ) {
@@ -3097,7 +3097,7 @@ bool tool_build_way_t::calc_route( way_builder_t &bauigel, const koord3d &start,
 
 	koord3d my_end = end;
 	// ending point is applied that elevated ways with SHIFT selects the current layer, when already on an elevated way
-	if(  is_shift_pressed()  &&  (desc->get_styp() == type_elevated  &&  desc->get_wtyp() != air_wt)  ) {
+	if(  is_shift_pressed()  &&  desc->is_elevated()  ) {
 		grund_t *gr=welt->lookup(my_end);
 		if(  gr->get_weg( desc->get_waytype() )  ) {
 			my_end.z -= welt->get_settings().get_way_height_clearance();
@@ -3165,7 +3165,7 @@ void tool_build_way_t::mark_tiles(  player_t *player, const koord3d &start, cons
 		hf = toolbar_tool->get_height_offset();
 	}
 
-	uint8 offset = (desc->get_styp() == type_elevated  &&  desc->get_wtyp() != air_wt) ? welt->get_settings().get_way_height_clearance() + hf : 0;
+	uint8 offset = desc->is_elevated() ? welt->get_settings().get_way_height_clearance() + hf : 0;
 
 	if(  bauigel.get_count()>1  ) {
 		// Set tooltip first (no dummygrounds, if bauigel.calc_casts() is called).

--- a/simtool.h
+++ b/simtool.h
@@ -332,7 +332,7 @@ public:
 	bool is_init_network_safe() const OVERRIDE { return true; }
 	waytype_t get_waytype() const OVERRIDE;
 	// remove preview necessary while building elevated ways
-	bool remove_preview_necessary() const OVERRIDE { return !is_first_click()  &&  (desc  &&  (desc->get_styp() == type_elevated  &&  desc->get_wtyp() != air_wt)); }
+	bool remove_preview_necessary() const OVERRIDE { return !is_first_click()  &&  desc  &&  desc->is_elevated(); }
 	void set_overtaking_mode(overtaking_mode_t ov) { overtaking_mode = ov; }
 	overtaking_mode_t get_overtaking_mode() const { return overtaking_mode; }
 	void set_street_flag (uint8 a) { street_flag = a; }

--- a/simtypes.h
+++ b/simtypes.h
@@ -151,12 +151,13 @@ enum waytype_t {
  * System types for ways
  */
 enum systemtype_t {
-	type_flat     = 0,   ///< flat track
-	type_elevated = 1,   ///< flag for elevated ways
-	type_runway   = 1,   ///< flag for runway (only aircrafts)
-	type_tram     = 7,   ///< tram track (waytype = track_wt)
-	type_river    = 255, ///< flag for river
-	type_all      = 255  ///< special ?
+	type_flat            = 0,   ///< flat track
+	type_elevated        = 1,   ///< flag for elevated ways
+	type_runway          = 1,   ///< flag for runway (only aircrafts)
+	type_elevated_airway = 2,   ///< flag for elevated airway (only aircrafts, not runway)
+	type_tram            = 7,   ///< tram track (waytype = track_wt)
+	type_river           = 255, ///< flag for river
+	type_all             = 255  ///< special ?
 };
 
 /**


### PR DESCRIPTION
高架誘導路を導入します

type_elevated and type_runway share the same numeric value, so every "is this way elevated" check had to special-case wtyp!=air_wt to avoid treating a runway as an elevated way. Introduce a distinct type_elevated_airway value plus way_desc_t::is_elevated()/is_runway() helpers so air_wt way descriptors can express "flat airway", "runway", or "elevated airway" unambiguously, and use the helper wherever the old styp==type_elevated pattern was checked.