### PR TITLE
Gate aircraft entry onto a taxiway crossing tile

### DIFF
--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -5665,6 +5665,18 @@ bool air_vehicle_t::can_enter_tile(const grund_t *gr, sint32 &restart_speed, uin
 		return false;
 	}
 
+	if( leading ) {
+		// taxiway crossing a ground way: ask permission like any other vehicle
+		weg_t *w = gr->get_weg(air_wt);
+		if( w && w->is_crossing() ) {
+			crossing_t* cr = gr->find<crossing_t>();
+			if( !cr->request_crossing(this) ) {
+				restart_speed = 0;
+				return false;
+			}
+		}
+	}
+
 	if(  cnv->is_reversed()  ) {
 		ribi_t::ribi next_dir = ribi_type(cnv->get_route()->at(min(route_index+1,cnv->get_route()->get_count()-1)) - cnv->get_route()->at(route_index));
 		if( (next_dir & get_direction())==0 || route_index>=takeoff ) {


### PR DESCRIPTION
air_vehicle_t::can_enter_tile() never asked crossing_t for permission before moving onto a tile, unlike water_vehicle_t's equivalent check at a draw-bridge crossing. Add the same request_crossing() gate so an aircraft taxiing over a ground-way crossing waits its turn instead of ignoring the crossing's state. add_to_crossing()/release_crossing() already run generically from vehicle_t::hop()/vehicle_base_t::leave_tile() for every vehicle type, so no other change is needed; next_stop_index is rail-signal-only machinery and is intentionally left untouched.