### PR TITLE
Fix makeobj build dependency on simsys.h

### DIFF
--- a/io/raw_image_bmp.cc
+++ b/io/raw_image_bmp.cc
@@ -7,7 +7,11 @@
 
 #include "raw_image.h"
 
-#include "../sys/simsys.h"
+#ifdef MAKEOBJ
+#define dr_fopen fopen
+#else
+FILE *dr_fopen(const char *filename, const char *mode);
+#endif
 #include "../simdebug.h"
 #include "../simmem.h"
 #include "../tpl/array_tpl.h"
@@ -76,11 +80,7 @@ static bool is_format_supported(uint16 bpp, uint32 compression)
 
 bool raw_image_t::read_bmp(const char *filename)
 {
-#ifdef MAKEOBJ
-	FILE *file = fopen(filename, "rb");
-#else
 	FILE *file = dr_fopen(filename, "rb");
-#endif
 
 	bitmap_file_header_t bmp_header;
 

--- a/io/raw_image_png.cc
+++ b/io/raw_image_png.cc
@@ -14,8 +14,11 @@
 
 #include "../simmem.h"
 #include "../simdebug.h"
-#include "../sys/simsys.h"
-
+#ifdef MAKEOBJ
+#define dr_fopen fopen
+#else
+FILE *dr_fopen(const char *filename, const char *mode);
+#endif
 
 static std::string filename_;
 


### PR DESCRIPTION
## 概要

`makeobj` ディレクトリでの `make` が最後のリンク処理で失敗するようになっていた問題を修正しました。
原因は `io/raw_image_png.cc` および `io/raw_image_bmp.cc` が `sys/simsys.h` (および `dr_fopen`) に依存するようになったことですが、`makeobj` では `simsys.cc` がリンクされないためリンクエラーとなっていました。

## 変更内容

- `io/raw_image_png.cc` と `io/raw_image_bmp.cc` から `sys/simsys.h` のインクルードを完全に削除しました。
- 代わりに `FILE *dr_fopen(const char *filename, const char *mode);` を前方宣言し、Simutrans本体のビルド時はリンク時に `simsys.cc` の実装が使われるようにしました。
- `makeobj` のビルド時 (`MAKEOBJ` 定義時) は、マクロ置換によって `dr_fopen` が標準の `fopen` にフォールバックされるようにしました。
- これによりOS固有のヘッダに依存することなく、Windowsや他のすべてのOSで安全にビルドできるようになっています。

## 確認

- `makeobj` ディレクトリ内で `make` を実行し、リンクエラーが発生せず正常にビルドが完了することを確認しました。