### PR TITLE
do not show convoys in minimap

### DIFF
--- a/gui/map_frame.cc
+++ b/gui/map_frame.cc
@@ -201,7 +201,7 @@ map_frame_t::map_frame_t() :
 
 
 	// second row of controls
-	zoom_row = add_table(7,0);
+	zoom_row = add_table(8,0);
 	{
 		// zoom levels label
 		new_component<gui_label_t>("map zoom");
@@ -229,6 +229,13 @@ map_frame_t::map_frame_t() :
 		b_rotate45.add_listener(this);
 		b_rotate45.pressed = karte->is_isometric();
 		add_component(&b_rotate45);
+
+		// show convoy positions
+		b_show_convoi.init( button_t::square_state, "Show convois");
+		b_show_convoi.set_tooltip("Show convoi positions on the map");
+		b_show_convoi.add_listener(this);
+		b_show_convoi.pressed = minimap_t::get_show_convoi();
+		add_component(&b_show_convoi);
 
 		// show contour
 		c_show_outlines.new_component<gui_scrolled_list_t::const_text_scrollitem_t>( translator::translate( "Show contour" ), SYSCOL_TEXT );
@@ -518,6 +525,10 @@ bool map_frame_t::action_triggered( gui_action_creator_t *comp, value_t v )
 		scrolly.set_size( scrolly.get_size() );
 		zoomed = true;
 		old_ij = koord::invalid;
+	}
+	else if(  comp == &b_show_convoi  ) {
+		b_show_convoi.pressed ^= 1;
+		minimap_t::get_instance()->set_show_convoi( b_show_convoi.pressed );
 	}
 	else if(  comp == &b_overlay_networks  ) {
 		b_overlay_networks.pressed ^= 1;

--- a/gui/map_frame.h
+++ b/gui/map_frame.h
@@ -70,6 +70,7 @@ private:
 	button_t filter_buttons[MAP_MAX_BUTTONS];
 	button_t zoom_buttons[2];
 	button_t b_rotate45;
+	button_t b_show_convoi;
 	button_t b_show_legend;
 	button_t b_show_scale;
 	gui_combobox_t c_show_outlines;

--- a/gui/minimap.cc
+++ b/gui/minimap.cc
@@ -60,6 +60,7 @@ minimap_t::MAP_DISPLAY_MODE minimap_t::mode = MAP_TOWN;
 minimap_t::MAP_DISPLAY_MODE minimap_t::last_mode = MAP_TOWN;
 bool minimap_t::is_visible = false;
 bool minimap_t::circle_halts = false;
+bool minimap_t::show_convoi = true;
 
 #define MAX_MAP_TYPE_LAND 31
 #define MAX_MAP_TYPE_WATER 5
@@ -914,7 +915,7 @@ void minimap_t::calc_map_pixel(const koord k)
 	}
 	const grund_t *gr=plan->get_boden_bei(plan->get_boden_count()-1);
 
-	if(  mode!=MAP_PAX_DEST  &&  gr->get_convoi_vehicle()  ) {
+	if(  show_convoi  &&  mode!=MAP_PAX_DEST  &&  gr->get_convoi_vehicle()  ) {
 		set_map_color( k, COL_VEHICLE );
 		return;
 	}
@@ -1965,7 +1966,7 @@ void minimap_t::draw(scr_coord pos)
 	}
 
 	// draw convoy positions for the displayed line
-	if(  displayed_line.is_bound()  ) {
+	if(  show_convoi  &&  displayed_line.is_bound()  ) {
 		const skin_desc_t *waytype_icon = NULL;
 		switch(  displayed_line->get_schedule()->get_waytype()  ) {
 			case track_wt:        waytype_icon = skinverwaltung_t::zughaltsymbol;          break;

--- a/gui/minimap.h
+++ b/gui/minimap.h
@@ -176,6 +176,8 @@ private:
 
 	static bool circle_halts;
 
+	static bool show_convoi;
+
 	bool is_matching_freight_catg(const minivec_tpl<uint8> &goods_catg_index);
 
 	/// nonstatic, if we have someday many maps ...
@@ -196,6 +198,14 @@ public:
 	static bool is_visible;
 
 	void set_circle_halts(bool val) { circle_halts = val; };
+
+	static bool get_show_convoi() { return show_convoi; }
+	void set_show_convoi(bool val) {
+		if(  show_convoi != val  ) {
+			show_convoi = val;
+			calc_map();
+		}
+	};
 	bool is_cnv_schedule_bound() { return current_cnv.is_bound() || current_schedule != nullptr; }
 
 	uint8 network_color_mode;


### PR DESCRIPTION
地図の描画軽量化策として、地図上の編成を非表示とするモードを追加しました