### PR TITLE
Fix world history decade to accumulate flow-type fields over 10 years

### DIFF
--- a/simworld.cc
+++ b/simworld.cc
@@ -653,6 +653,9 @@ void karte_t::init_tiles()
 			finance_history_decade[decade][cost_type] = 0;
 		}
 	}
+	for (int cost_type=0; cost_type<MAX_WORLD_COST; cost_type++) {
+		finance_history_decade_acc[cost_type] = 0;
+	}
 	last_month_bev = 0;
 
 	tile_counter = 0;
@@ -4026,6 +4029,24 @@ void karte_t::new_month()
 }
 
 
+// Flow-type fields accumulate over the decade; snapshot/ratio fields just mirror year[0].
+// Order must match karte_t::player_cost enum.
+static const bool decade_flow_field[karte_t::MAX_WORLD_COST] = {
+	false, // WORLD_CITIZENS
+	true,  // WORLD_GROWTH
+	false, // WORLD_TOWNS
+	false, // WORLD_FACTORIES
+	false, // WORLD_CONVOIS
+	false, // WORLD_CITYCARS
+	false, // WORLD_PAS_RATIO
+	true,  // WORLD_PAS_GENERATED
+	false, // WORLD_MAIL_RATIO
+	true,  // WORLD_MAIL_GENERATED
+	false, // WORLD_GOODS_RATIO
+	true,  // WORLD_TRANSPORTED_GOODS
+	false  // WORLD_HALTS
+};
+
 void karte_t::new_year()
 {
 	last_year = current_month/12;
@@ -4037,16 +4058,28 @@ void karte_t::new_year()
 		}
 	}
 
-	// record decade snapshot at 0, 10, 20, ... years after map start
+	// Decade history update.
+	// At a decade boundary, decade[0] already holds the complete 10-year total
+	// (set by update_history() called earlier in new_month()), so we just shift
+	// and reset the accumulator for the new decade.
+	// At non-boundary years, add the just-completed year[1] to the accumulator
+	// for flow fields; update_history() will keep decade[0] live.
+	bool const is_decade_boundary = (last_year - settings.get_starting_year()) % 10 == 0;
 	for(  int hist=0;  hist<karte_t::MAX_WORLD_COST;  hist++  ) {
-		if(  (last_year - settings.get_starting_year()) % 10 == 0  ) {
-			// we record the old dates values once in 10 years.
+		if(  is_decade_boundary  ) {
 			for( int d=MAX_WORLD_HISTORY_DECADES-1; d>0; d--  ) {
 				finance_history_decade[d][hist] = finance_history_decade[d-1][hist];
 			}
+			if(  decade_flow_field[hist]  ) {
+				finance_history_decade_acc[hist] = 0;
+				finance_history_decade[0][hist] = 0;
+			}
 		}
-		// the 0 values of history_decade is the last year's values.
-		finance_history_decade[0][hist] = finance_history_year[1][hist];
+		else {
+			if(  decade_flow_field[hist]  ) {
+				finance_history_decade_acc[hist] += finance_history_year[1][hist];
+			}
+		}
 	}
 
 DBG_MESSAGE("karte_t::new_year()","speedbonus for %d %i, %i, %i, %i, %i, %i, %i, %i", last_year,
@@ -4586,6 +4619,17 @@ void karte_t::update_history()
 	}
 	finance_history_month[0][WORLD_TRANSPORTED_GOODS] = transported;
 	finance_history_year[0][WORLD_TRANSPORTED_GOODS] = transported_year;
+
+	// Keep decade[0] live: flow fields = accumulated completed years + current year;
+	// snapshot/ratio fields mirror year[0].
+	for(  int hist=0;  hist<MAX_WORLD_COST;  hist++  ) {
+		if(  decade_flow_field[hist]  ) {
+			finance_history_decade[0][hist] = finance_history_decade_acc[hist] + finance_history_year[0][hist];
+		}
+		else {
+			finance_history_decade[0][hist] = finance_history_year[0][hist];
+		}
+	}
 }
 
 
@@ -5601,9 +5645,24 @@ DBG_MESSAGE("karte_t::load()", "%d factories loaded", fab_list.get_count());
 		}
 	}
 	else {
-		// we set first decades values
+		// initialize decade history from year history for old saves
+		for (int decade = 0; decade<MAX_WORLD_HISTORY_DECADES; decade++) {
+			for (int cost_type = 0; cost_type<MAX_WORLD_COST; cost_type++) {
+				finance_history_decade[decade][cost_type] = 0;
+			}
+		}
+	}
+	// Reconstruct the decade flow accumulator from year history.
+	// decade_acc = sum of year[1..k] where k = completed years in current decade.
+	{
+		const int years_in_decade = (last_year - settings.get_starting_year()) % 10;
 		for (int cost_type = 0; cost_type<MAX_WORLD_COST; cost_type++) {
-			finance_history_decade[0][cost_type] = finance_history_year[1][cost_type];
+			finance_history_decade_acc[cost_type] = 0;
+			if(  decade_flow_field[cost_type]  ) {
+				for (int y = 1; y <= years_in_decade && y < MAX_WORLD_HISTORY_YEARS; y++) {
+					finance_history_decade_acc[cost_type] += finance_history_year[y][cost_type];
+				}
+			}
 		}
 	}
 

--- a/simworld.cc
+++ b/simworld.cc
@@ -4046,6 +4046,8 @@ static const bool decade_flow_field[karte_t::MAX_WORLD_COST] = {
 	true,  // WORLD_TRANSPORTED_GOODS
 	false  // WORLD_HALTS
 };
+static_assert(sizeof(decade_flow_field)/sizeof(bool) == karte_t::MAX_WORLD_COST,
+              "decade_flow_field must have one entry per MAX_WORLD_COST");
 
 void karte_t::new_year()
 {

--- a/simworld.h
+++ b/simworld.h
@@ -317,6 +317,12 @@ private:
 	sint64 finance_history_decade[MAX_WORLD_HISTORY_DECADES][MAX_WORLD_COST];
 
 	/**
+	 * Accumulator of completed years' flow-type values within the current decade.
+	 * Used to compute decade[0] = decade_acc + year[0] in update_history().
+	 */
+	sint64 finance_history_decade_acc[MAX_WORLD_COST];
+
+	/**
 	 * World record speed manager.
 	 * Keeps track of the fastest vehicles in game.
 	 */


### PR DESCRIPTION
## 概要

v57 で追加された `finance_history_decade` の挙動を、年・月の統計と統一します。

## 問題

従来の実装では `decade[0]` に直前年の値（`year[1]`）を毎年上書きするだけでした。
これは月・年の `[0]` が「現在進行中の期間のライブデータ」であるのと挙動が異なっていました。

## 変更内容

統計項目を2種に分けて処理します：

**フロー系**（期間中に積み上がる値）
- `WORLD_GROWTH` / `WORLD_PAS_GENERATED` / `WORLD_MAIL_GENERATED` / `WORLD_TRANSPORTED_GOODS`
- `decade[0]` = 今10年内の完了済み年の累計 ＋ 今年の年間累計（ライブ）
- `decade[1]` 以降 = その10年間の合計値

**スナップショット系**（時点での値）
- 上記以外（人口・都市数・比率など）
- `decade[0]` = `year[0]` と同じ現在値
- `decade[1]` 以降 = 10年区切り時点での値

## 実装

- `karte_t::finance_history_decade_acc[]` を追加（現10年内の完了済み年の累計）
- `update_history()` で `decade[0]` をライブ更新
- `new_year()` で年末に `decade_acc` へ積み上げ、10年区切りでシフト＆リセット
- セーブロード時は `year[1..k]` から `decade_acc` を再構築（フォーマット変更なし）
