### PR TITLE
FIX Correct the maximum values for show_names and show_month

### DIFF
--- a/gui/settings_stats.cc
+++ b/gui/settings_stats.cc
@@ -84,7 +84,6 @@ void settings_general_stats_t::init(settings_t const* const sets)
 	INIT_NUM( "fast_forward", env_t::max_acceleration, 1, 1000, gui_numberinput_t::AUTOLINEAR, false );
 	SEPERATOR
 	INIT_BOOL( "numbered_stations", sets->get_numbered_stations() );
-	INIT_NUM( "show_names", env_t::show_names, 0, 31, gui_numberinput_t::AUTOLINEAR, true );
 	SEPERATOR
 	INIT_NUM( "bits_per_month", sets->get_bits_per_month(), 16, 28, gui_numberinput_t::AUTOLINEAR, false );
 	INIT_NUM( "use_timeline", sets->get_use_timeline(), 0, 3, gui_numberinput_t::AUTOLINEAR, false );
@@ -131,7 +130,6 @@ void settings_general_stats_t::read(settings_t* const sets)
 	READ_NUM_VALUE( env_t::max_acceleration );
 
 	READ_BOOL_VALUE( sets->numbered_stations );
-	READ_NUM_VALUE( env_t::show_names );
 
 	READ_NUM_VALUE( sets->bits_per_month );
 	READ_NUM_VALUE( sets->use_timeline );

--- a/gui/settings_stats.cc
+++ b/gui/settings_stats.cc
@@ -84,13 +84,13 @@ void settings_general_stats_t::init(settings_t const* const sets)
 	INIT_NUM( "fast_forward", env_t::max_acceleration, 1, 1000, gui_numberinput_t::AUTOLINEAR, false );
 	SEPERATOR
 	INIT_BOOL( "numbered_stations", sets->get_numbered_stations() );
-	INIT_NUM( "show_names", env_t::show_names, 0, 3, gui_numberinput_t::AUTOLINEAR, true );
+	INIT_NUM( "show_names", env_t::show_names, 0, 31, gui_numberinput_t::AUTOLINEAR, true );
 	SEPERATOR
 	INIT_NUM( "bits_per_month", sets->get_bits_per_month(), 16, 28, gui_numberinput_t::AUTOLINEAR, false );
 	INIT_NUM( "use_timeline", sets->get_use_timeline(), 0, 3, gui_numberinput_t::AUTOLINEAR, false );
 	INIT_NUM_NEW( "starting_year", sets->get_starting_year(), 0, 2999, gui_numberinput_t::AUTOLINEAR, false );
 	INIT_NUM_NEW( "starting_month", sets->get_starting_month(), 0, 11, gui_numberinput_t::AUTOLINEAR, false );
-	INIT_NUM( "show_month", env_t::show_month, 0, 7, gui_numberinput_t::AUTOLINEAR, true );
+	INIT_NUM( "show_month", env_t::show_month, 0, 8, gui_numberinput_t::AUTOLINEAR, true );
 	INIT_NUM( "spacing_shift_divisor", sets->spacing_shift_divisor, 1, 60000, gui_numberinput_t::AUTOLINEAR, false );
 	SEPERATOR
 	INIT_NUM( "random_grounds_probability", env_t::ground_object_probability, 0, 0x7FFFFFFFul, gui_numberinput_t::POWER2, false );


### PR DESCRIPTION
高度な設定ウィンドウでは(以降内部数値)show_namesは31が最大値であるべきところが3、show_monthは8であるべきところが7となっています。
これより大きい内部数値の設定をしている状態(※)で高度な設定ウィンドウを開くと(不適切な)最大値まで減らされて表示設定が変わってしまいます。
この問題を修正します。

※show_names=3はデフォルトの駅名表示に貨物量を可視化したもので、それ以外のオプションを付けた状態だと(clampにより)必ずこれに変わります
　show_month=8はKUTA版から追加されたshow_month=2(日本式・季節あり)からデフォルトの時間表記を消したもので、高度な設定を開くとshow_month=7(ドイツ式・季節なし)になります