### PR TITLE
add headless stub for line color functions

### DIFF
--- a/display/simgraph0.cc
+++ b/display/simgraph0.cc
@@ -181,7 +181,15 @@ void display_color_img(const image_id, scr_coord_val, scr_coord_val, const sint8
 {
 }
 
+void display_color_img_line(const image_id, scr_coord_val, scr_coord_val, const uint8, const sint8, const bool, const bool  CLIP_NUM_DEF_NOUSE)
+{
+}
+
 void display_base_img(const image_id, scr_coord_val, scr_coord_val, const sint8, const bool, const bool  CLIP_NUM_DEF_NOUSE)
+{
+}
+
+void display_base_img_line(const image_id, scr_coord_val, scr_coord_val, const uint8, const sint8, const bool, const bool  CLIP_NUM_DEF_NOUSE)
 {
 }
 


### PR DESCRIPTION
`simgraph0.cc` に不足していた `display_color_img_line()` と `display_base_img_line()` のスタブを追加しました。