### PR TITLE
Fix uneven checkbox spacing in signal info window

### DIFF
--- a/gui/signal_info.cc
+++ b/gui/signal_info.cc
@@ -60,22 +60,22 @@ signal(s)
 		add_component(&bt_length_based);
 	}
 
-	add_table(2,0);
-	{
-		lb_tiles_margin.set_text("Margin");
-		lb_tiles_margin.set_tooltip(translator::translate("tiles length of the margin to stop when choosing. Set this margin to the stop side(advance to end->end side)"));
-		numinp_tiles_margin.set_width(50);
-		numinp_tiles_margin.set_height(5);
-		numinp_tiles_margin.set_limits(0,200);
-		numinp_tiles_margin.set_increment_mode(1);
-		numinp_tiles_margin.disable();
-		numinp_tiles_margin.add_listener(this);
-		if(signal->get_desc()->is_choose_sign()  &&  !welt->get_settings().get_advance_to_end()) {
+	lb_tiles_margin.set_text("Margin");
+	lb_tiles_margin.set_tooltip(translator::translate("tiles length of the margin to stop when choosing. Set this margin to the stop side(advance to end->end side)"));
+	numinp_tiles_margin.set_width(50);
+	numinp_tiles_margin.set_height(5);
+	numinp_tiles_margin.set_limits(0,200);
+	numinp_tiles_margin.set_increment_mode(1);
+	numinp_tiles_margin.disable();
+	numinp_tiles_margin.add_listener(this);
+	if(signal->get_desc()->is_choose_sign()  &&  !welt->get_settings().get_advance_to_end()) {
+		add_table(2,0);
+		{
 			add_component(&lb_tiles_margin);
 			add_component(&numinp_tiles_margin);
 		}
+		end_table();
 	}
-	end_table();
 
 	bt_two_ways.init( button_t::square_state, translator::translate("allow reverse passage") );
 	bt_two_ways.set_tooltip(translator::translate("Allow reverse passage for convoys"));


### PR DESCRIPTION
## 概要

信号機を選択した際に表示される詳細ウィンドウで、チェックボックス間の間隔が不均等になっていた問題を修正します。

## 原因

`add_table(2,0)` / `end_table()` の呼び出しが、マージン入力欄の表示条件（choose signal かつ advance_to_end 無効）に関わらず常に実行されていました。そのため、条件を満たさない信号では空の sub-table が生成され、`bt_length_based` と `bt_two_ways` の間に余分な空白が生じていました。

## 修正内容

`add_table` / `end_table` の呼び出しを条件ブロックの内側に移動し、マージン入力欄が必要な場合にのみ sub-table を生成するようにしました。
動作確認済です。