### PR TITLE
BUG FIX: route pre-reservation process update during loading

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -317,7 +317,10 @@ void convoi_t::reserve_route()
 					const koord3d prev = reserved_tiles[max(1u,idx)-1u];
 					const koord3d curr = reserved_tiles[idx];
 					const koord3d next = reserved_tiles[min(reserved_tiles.get_count()-1u,idx+1u)];
-					sch->reserve( self, ribi_t::backward(ribi_type(prev,curr)) | ribi_type(curr,next) );
+					if (!sch->reserve( self, ribi_t::backward(ribi_type(prev,curr)) | ribi_type(curr,next) )) {
+						// reservation invalid! do not continue reservation more!
+						break;
+					}
 				}
 			}
 		}
@@ -352,7 +355,12 @@ void convoi_t::reserve_route()
 					const koord3d prev = route.at(max(1u,(uint32)idx)-1u);
 					const koord3d curr = route.at(idx);
 					const koord3d next = route.at(min(route.get_count()-1u,(uint32)idx+1u));
-					sch->reserve( self, ribi_t::backward(ribi_type(prev,curr)) | ribi_type(curr,next) );
+					if(!sch->reserve( self, ribi_t::backward(ribi_type(prev,curr)) | ribi_type(curr,next) )) {
+						next_stop_index = idx + 1;
+						next_reservation_index = idx + 1;
+						// reservation invalid! do not continue reservation more!
+						break;
+					}
 				}
 			}
 		}

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -345,7 +345,7 @@ void convoi_t::reserve_route()
 			}
 		}
 	}
-	else if(  !route.empty()  &&  anz_vehikel>0  &&  (is_waiting()  ||  state==DRIVING  ||  state==LEAVING_DEPOT)  ){
+	else if(  !is_coupled()  &&  !route.empty()  &&  anz_vehikel>0  &&  (is_waiting()  ||  state==DRIVING  ||  state==LEAVING_DEPOT)  ){
 		// reservation is controlled by next_reservation_index.
 		// Start one step back so the rear car's current tile is also reserved with
 		// the correct ribi direction (individual loading only uses ribi_t::none).
@@ -356,8 +356,8 @@ void convoi_t::reserve_route()
 					const koord3d curr = route.at(idx);
 					const koord3d next = route.at(min(route.get_count()-1u,(uint32)idx+1u));
 					if(!sch->reserve( self, ribi_t::backward(ribi_type(prev,curr)) | ribi_type(curr,next) )) {
-						next_stop_index = idx + 1;
-						next_reservation_index = idx + 1;
+						next_stop_index = idx;
+						next_reservation_index = idx;
 						// reservation invalid! do not continue reservation more!
 						break;
 					}

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -319,7 +319,7 @@ void convoi_t::reserve_route()
 					const koord3d next = reserved_tiles[min(reserved_tiles.get_count()-1u,idx+1u)];
 					if (!sch->reserve( self, ribi_t::backward(ribi_type(prev,curr)) | ribi_type(curr,next) )) {
 						// reservation invalid! do not continue reservation more!
-						dbg->error("convoi_t::reserve_route()","%s cannot reserve %s",get_name(),curr.get_str());
+						dbg->error("convoi_t::reserve_route()","%s cannot reserve (%s)",get_name(),curr.get_str());
 						break;
 					}
 				}
@@ -360,7 +360,7 @@ void convoi_t::reserve_route()
 						next_stop_index = idx;
 						next_reservation_index = idx;
 						// reservation invalid! do not continue reservation more!
-						dbg->error("convoi_t::reserve_route()","%s cannot reserve %s",get_name(),curr.get_str());
+						dbg->error("convoi_t::reserve_route()","%s cannot reserve (%s)",get_name(),curr.get_str());
 						break;
 					}
 				}

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -319,6 +319,7 @@ void convoi_t::reserve_route()
 					const koord3d next = reserved_tiles[min(reserved_tiles.get_count()-1u,idx+1u)];
 					if (!sch->reserve( self, ribi_t::backward(ribi_type(prev,curr)) | ribi_type(curr,next) )) {
 						// reservation invalid! do not continue reservation more!
+						dbg->error("convoi_t::reserve_route()","%s cannot reserve %s",get_name(),curr.get_str());
 						break;
 					}
 				}
@@ -359,6 +360,7 @@ void convoi_t::reserve_route()
 						next_stop_index = idx;
 						next_reservation_index = idx;
 						// reservation invalid! do not continue reservation more!
+						dbg->error("convoi_t::reserve_route()","%s cannot reserve %s",get_name(),curr.get_str());
 						break;
 					}
 				}


### PR DESCRIPTION
セーブデータロード中の線路予約について、先行列車を追い越して予約した場合に予約動作が止まるようにしました。これにより、仮に予約を割り込まれても割り込まれた状態で運行再開できます