### PR TITLE
BUG FIX: couple convoy's reservation

### DIFF
--- a/boden/wege/schiene.cc
+++ b/boden/wege/schiene.cc
@@ -94,30 +94,37 @@ void schiene_t::info(cbuffer_t & buf) const
 /**
  * true, if this rail can be reserved
  */
-bool schiene_t::reserve(convoihandle_t c, ribi_t::ribi dir)
+bool schiene_t::reserve(convoihandle_t const cnv, ribi_t::ribi dir)
 {
-	if(c == reserved) {
-		// Allow direction restoration when reserved_dir is still none (e.g. after
-		// save/load before reserve_route() has run).  Do NOT overwrite a valid
-		// corner_set: enter_tile passes get_direction() which may be a wrong diagonal
-		// (e.g. SW=12 for a N→W turn) that would corrupt the PBS corner_set.
-		if(reserved_dir == ribi_t::none  &&  dir != ribi_t::none) {
-			reserved_dir = dir;
-		}
-		if(schiene_t::show_reservations) {
-			set_flag( obj_t::dirty );
-		}
-		return true;
+	if(!cnv.is_bound()) {
+		return false;
 	}
-	if(c == reserved2) {
-		// Same: restore direction only when not yet set.
-		if(reserved2_dir == ribi_t::none  &&  dir != ribi_t::none) {
-			reserved2_dir = dir;
+	convoihandle_t c = cnv->get_most_parent_convoi();
+	while(  c.is_bound()  ) {
+		if(c == reserved) {
+			// Allow direction restoration when reserved_dir is still none (e.g. after
+			// save/load before reserve_route() has run).  Do NOT overwrite a valid
+			// corner_set: enter_tile passes get_direction() which may be a wrong diagonal
+			// (e.g. SW=12 for a N→W turn) that would corrupt the PBS corner_set.
+			if(reserved_dir == ribi_t::none  &&  dir != ribi_t::none) {
+				reserved_dir = dir;
+			}
+			if(schiene_t::show_reservations) {
+				set_flag( obj_t::dirty );
+			}
+			return true;
 		}
-		if(schiene_t::show_reservations) {
-			set_flag( obj_t::dirty );
+		if(c == reserved2) {
+			// Same: restore direction only when not yet set.
+			if(reserved2_dir == ribi_t::none  &&  dir != ribi_t::none) {
+				reserved2_dir = dir;
+			}
+			if(schiene_t::show_reservations) {
+				set_flag( obj_t::dirty );
+			}
+			return true;
 		}
-		return true;
+		c = c->get_coupling_convoi();
 	}
 	// for safety
 	if(!reserved.is_bound()&&reserved2.is_bound()) {
@@ -128,7 +135,7 @@ bool schiene_t::reserve(convoihandle_t c, ribi_t::ribi dir)
 	}
 	if(!reserved.is_bound()) {
 		// fresh reservation
-		reserved     = c;
+		reserved     = cnv;
 		reserved_dir = dir;
 		/* for threeway and fourway switches we may need to alter graphic, if
 		 * direction is a diagonal (i.e. on the switching part)
@@ -149,7 +156,7 @@ bool schiene_t::reserve(convoihandle_t c, ribi_t::ribi dir)
 	}
 	// tile is reserved by a different convoy — try co-reservation for non-crossing bends
 	if(!reserved2.is_bound()  &&  get_ribi_unmasked()==ribi_t::all  &&  can_co_reserve_dirs(reserved_dir, dir)) {
-		reserved2     = c;
+		reserved2     = cnv;
 		reserved2_dir = dir;
 		if(schiene_t::show_reservations) {
 			set_flag( obj_t::dirty );
@@ -177,24 +184,32 @@ bool schiene_t::unreserve(vehicle_t* v)
 
 bool schiene_t::unreserve(convoihandle_t c)
 {
-	if(reserved.is_bound()  &&  reserved == c) {
-		// promote co-reservation to primary slot (if any)
-		reserved      = reserved2;
-		reserved_dir  = reserved2_dir;
-		reserved2     = convoihandle_t();
-		reserved2_dir = ribi_t::none;
-		if(schiene_t::show_reservations) {
-			set_flag( obj_t::dirty );
-		}
-		return true;
+	if(  !c.is_bound()  ) {
+		return false;
 	}
-	if(reserved2.is_bound()  &&  reserved2 == c) {
-		reserved2     = convoihandle_t();
-		reserved2_dir = ribi_t::none;
-		if(schiene_t::show_reservations) {
-			set_flag( obj_t::dirty );
+	c = c->get_most_parent_convoi();
+	while(  c.is_bound()  )
+	{
+		if(reserved.is_bound()  &&  reserved == c) {
+			// promote co-reservation to primary slot (if any)
+			reserved      = reserved2;
+			reserved_dir  = reserved2_dir;
+			reserved2     = convoihandle_t();
+			reserved2_dir = ribi_t::none;
+			if(schiene_t::show_reservations) {
+				set_flag( obj_t::dirty );
+			}
+			return true;
 		}
-		return true;
+		if(reserved2.is_bound()  &&  reserved2 == c) {
+			reserved2     = convoihandle_t();
+			reserved2_dir = ribi_t::none;
+			if(schiene_t::show_reservations) {
+				set_flag( obj_t::dirty );
+			}
+			return true;
+		}
+		c = c->get_coupling_convoi();
 	}
 	return false;
 }

--- a/boden/wege/schiene.h
+++ b/boden/wege/schiene.h
@@ -63,7 +63,7 @@ public:
 	/**
 	* true, then this rail was reserved
 	*/
-	bool reserve(convoihandle_t c, ribi_t::ribi dir);
+	bool reserve(convoihandle_t const cnv, ribi_t::ribi dir);
 
 	/**
 	* releases previous reservation

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -317,7 +317,10 @@ void convoi_t::reserve_route()
 					const koord3d prev = reserved_tiles[max(1u,idx)-1u];
 					const koord3d curr = reserved_tiles[idx];
 					const koord3d next = reserved_tiles[min(reserved_tiles.get_count()-1u,idx+1u)];
-					sch->reserve( self, ribi_t::backward(ribi_type(prev,curr)) | ribi_type(curr,next) );
+					if (!sch->reserve( self, ribi_t::backward(ribi_type(prev,curr)) | ribi_type(curr,next) )) {
+						// reservation invalid! do not continue reservation more!
+						break;
+					}
 				}
 			}
 		}
@@ -352,7 +355,12 @@ void convoi_t::reserve_route()
 					const koord3d prev = route.at(max(1u,(uint32)idx)-1u);
 					const koord3d curr = route.at(idx);
 					const koord3d next = route.at(min(route.get_count()-1u,(uint32)idx+1u));
-					sch->reserve( self, ribi_t::backward(ribi_type(prev,curr)) | ribi_type(curr,next) );
+					if(!sch->reserve( self, ribi_t::backward(ribi_type(prev,curr)) | ribi_type(curr,next) )) {
+						next_stop_index = idx + 1;
+						next_reservation_index = idx + 1;
+						// reservation invalid! do not continue reservation more!
+						break;
+					}
 				}
 			}
 		}

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -2976,10 +2976,10 @@ void convoi_t::clear_reserved_tile_if_not_matching_route()
 	if(  get_reserved_tiles().get_count()==0 || route.get_count()==0  ) {
 		return;
 	}
-	// dbg->message("convoi_t::clear_reserved_tile_if_not_matching_route()","reserved tile from %i,%i,%i, route from %i,%i,%i, count: %i vs %i",
-	// 	reserved_tiles[0].x, reserved_tiles[0].y, (int)reserved_tiles[0].z,
-	// 	route.at(0).x, route.at(0).y, (int)route.at(0).z,
-	// 	reserved_tiles.get_count(), route.get_count());
+	dbg->message("convoi_t::clear_reserved_tile_if_not_matching_route()","reserved tile from %i,%i,%i, route from %i,%i,%i, count: %i vs %i",
+		reserved_tiles[0].x, reserved_tiles[0].y, (int)reserved_tiles[0].z,
+		route.at(0).x, route.at(0).y, (int)route.at(0).z,
+		reserved_tiles.get_count(), route.get_count());
 	// reserved_tiles[i] corresponds to route[i+1]:
 	// route[0] (the departure stop) is never added to reserved_tiles by block_reserver
 	// because it starts from next_block+1 and target_rt from index 1, both skipping route[0].

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -345,7 +345,7 @@ void convoi_t::reserve_route()
 			}
 		}
 	}
-	else if(  !route.empty()  &&  anz_vehikel>0  &&  (is_waiting()  ||  state==DRIVING  ||  state==LEAVING_DEPOT)  ){
+	else if(  !is_coupled()  &&  !route.empty()  &&  anz_vehikel>0  &&  (is_waiting()  ||  state==DRIVING  ||  state==LEAVING_DEPOT)  ){
 		// reservation is controlled by next_reservation_index.
 		// Start one step back so the rear car's current tile is also reserved with
 		// the correct ribi direction (individual loading only uses ribi_t::none).
@@ -356,8 +356,8 @@ void convoi_t::reserve_route()
 					const koord3d curr = route.at(idx);
 					const koord3d next = route.at(min(route.get_count()-1u,(uint32)idx+1u));
 					if(!sch->reserve( self, ribi_t::backward(ribi_type(prev,curr)) | ribi_type(curr,next) )) {
-						next_stop_index = idx + 1;
-						next_reservation_index = idx + 1;
+						next_stop_index = idx;
+						next_reservation_index = idx;
 						// reservation invalid! do not continue reservation more!
 						break;
 					}

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -319,7 +319,7 @@ void convoi_t::reserve_route()
 					const koord3d next = reserved_tiles[min(reserved_tiles.get_count()-1u,idx+1u)];
 					if (!sch->reserve( self, ribi_t::backward(ribi_type(prev,curr)) | ribi_type(curr,next) )) {
 						// reservation invalid! do not continue reservation more!
-						dbg->error("convoi_t::reserve_route()","%s cannot reserve %s",get_name(),curr.get_str());
+						dbg->error("convoi_t::reserve_route()","%s cannot reserve (%s)",get_name(),curr.get_str());
 						break;
 					}
 				}
@@ -360,7 +360,7 @@ void convoi_t::reserve_route()
 						next_stop_index = idx;
 						next_reservation_index = idx;
 						// reservation invalid! do not continue reservation more!
-						dbg->error("convoi_t::reserve_route()","%s cannot reserve %s",get_name(),curr.get_str());
+						dbg->error("convoi_t::reserve_route()","%s cannot reserve (%s)",get_name(),curr.get_str());
 						break;
 					}
 				}

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -6414,6 +6414,7 @@ void convoi_t::reverse_convoy_coupling()
 	if (  !new_parent_convoy.is_bound()  ) {
 		return;	
 	}
+	// here, we do need to change reservation tiles.
 	uncouple_convoi(false);
 	if (new_parent_convoy->get_coupling_convoi().is_bound()) {
 		new_parent_convoy->reverse_convoy_coupling();

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -6097,7 +6097,7 @@ convoihandle_t convoi_t::uncouple_convoi(  bool need_reservation_update  ) {
 	// finally, we need to change reservation!
 	route_t const *r = get_route();
 	if(  need_reservation_update  &&  r  &&  r->get_count()>0  ) {
-		for(  uint16 i = min(ret->find_most_child_convoi()->back()->get_route_index(),1u)-1; i < min(min(ret->front()->get_route_index(),back()->get_route_index()-1),r->get_count()); i++  ) {
+		for(  uint16 i = max(ret->find_most_child_convoi()->back()->get_route_index(),1u)-1; i < min(min(ret->front()->get_route_index(),max(back()->get_route_index(),1u)-1),r->get_count()); i++  ) {
 			koord3d const pos = r->at(i);
 			grund_t const *gr = welt->lookup(pos);
 			schiene_t * sch1 = gr ? (schiene_t *)gr->get_weg(front()->get_waytype()) : NULL;

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -6097,7 +6097,7 @@ convoihandle_t convoi_t::uncouple_convoi(  bool need_reservation_update  ) {
 	// finally, we need to change reservation!
 	route_t const *r = get_route();
 	if(  need_reservation_update  &&  r  &&  r->get_count()>0  ) {
-		for(  uint16 i = ret->find_most_child_convoi()->back()->get_route_index()-1; i < min(min(ret->front()->get_route_index(),back()->get_route_index()-1),r->get_count()); i++  ) {
+		for(  uint16 i = min(ret->find_most_child_convoi()->back()->get_route_index(),1u)-1; i < min(min(ret->front()->get_route_index(),back()->get_route_index()-1),r->get_count()); i++  ) {
 			koord3d const pos = r->at(i);
 			grund_t const *gr = welt->lookup(pos);
 			schiene_t * sch1 = gr ? (schiene_t *)gr->get_weg(front()->get_waytype()) : NULL;
@@ -6414,7 +6414,7 @@ void convoi_t::reverse_convoy_coupling()
 	if (  !new_parent_convoy.is_bound()  ) {
 		return;	
 	}
-	// here, we do need to change reservation tiles.
+	// here, we do NOT need to change reservation tiles.
 	uncouple_convoi(false);
 	if (new_parent_convoy->get_coupling_convoi().is_bound()) {
 		new_parent_convoy->reverse_convoy_coupling();

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -319,6 +319,7 @@ void convoi_t::reserve_route()
 					const koord3d next = reserved_tiles[min(reserved_tiles.get_count()-1u,idx+1u)];
 					if (!sch->reserve( self, ribi_t::backward(ribi_type(prev,curr)) | ribi_type(curr,next) )) {
 						// reservation invalid! do not continue reservation more!
+						dbg->error("convoi_t::reserve_route()","%s cannot reserve %s",get_name(),curr.get_str());
 						break;
 					}
 				}
@@ -359,6 +360,7 @@ void convoi_t::reserve_route()
 						next_stop_index = idx;
 						next_reservation_index = idx;
 						// reservation invalid! do not continue reservation more!
+						dbg->error("convoi_t::reserve_route()","%s cannot reserve %s",get_name(),curr.get_str());
 						break;
 					}
 				}

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -2976,10 +2976,10 @@ void convoi_t::clear_reserved_tile_if_not_matching_route()
 	if(  get_reserved_tiles().get_count()==0 || route.get_count()==0  ) {
 		return;
 	}
-	dbg->message("convoi_t::clear_reserved_tile_if_not_matching_route()","reserved tile from %i,%i,%i, route from %i,%i,%i, count: %i vs %i",
-		reserved_tiles[0].x, reserved_tiles[0].y, (int)reserved_tiles[0].z,
-		route.at(0).x, route.at(0).y, (int)route.at(0).z,
-		reserved_tiles.get_count(), route.get_count());
+	// dbg->message("convoi_t::clear_reserved_tile_if_not_matching_route()","reserved tile from %i,%i,%i, route from %i,%i,%i, count: %i vs %i",
+	// 	reserved_tiles[0].x, reserved_tiles[0].y, (int)reserved_tiles[0].z,
+	// 	route.at(0).x, route.at(0).y, (int)route.at(0).z,
+	// 	reserved_tiles.get_count(), route.get_count());
 	// reserved_tiles[i] corresponds to route[i+1]:
 	// route[0] (the departure stop) is never added to reserved_tiles by block_reserver
 	// because it starts from next_block+1 and target_rt from index 1, both skipping route[0].
@@ -6070,7 +6070,7 @@ bool convoi_t::couple_convoi(convoihandle_t coupled) {
 	return true;
 }
 
-convoihandle_t convoi_t::uncouple_convoi() {
+convoihandle_t convoi_t::uncouple_convoi(  bool need_reservation_update  ) {
 	if(  !coupling_convoi.is_bound()  ) {
 		return convoihandle_t();
 	}
@@ -6093,6 +6093,24 @@ convoihandle_t convoi_t::uncouple_convoi() {
 	get_most_parent_convoi()->must_recalc_min_top_speed();
 	get_most_parent_convoi()->check_electrification();
 	get_most_parent_convoi()->must_recalc_friction_weight();
+	
+	// finally, we need to change reservation!
+	route_t const *r = get_route();
+	if(  need_reservation_update  &&  r  &&  r->get_count()>0  ) {
+		for(  uint16 i = ret->find_most_child_convoi()->back()->get_route_index()-1; i < min(min(ret->front()->get_route_index(),back()->get_route_index()-1),r->get_count()); i++  ) {
+			koord3d const pos = r->at(i);
+			grund_t const *gr = welt->lookup(pos);
+			schiene_t * sch1 = gr ? (schiene_t *)gr->get_weg(front()->get_waytype()) : NULL;
+			if(  sch1  ) {
+				sch1->unreserve(get_most_parent_convoi());
+				get_most_parent_convoi()->unreserve_pos(pos);
+				const ribi_t::ribi corner_set =
+				ribi_t::backward(ribi_type(r->at(max(1u,i)-1u), pos))
+					| ribi_type(pos, r->at(min(r->get_count()-1u,i+1u)));
+				sch1->reserve(ret,corner_set);
+			}
+		}
+	}
 	return ret;
 }
 
@@ -6396,7 +6414,7 @@ void convoi_t::reverse_convoy_coupling()
 	if (  !new_parent_convoy.is_bound()  ) {
 		return;	
 	}
-	uncouple_convoi();
+	uncouple_convoi(false);
 	if (new_parent_convoy->get_coupling_convoi().is_bound()) {
 		new_parent_convoy->reverse_convoy_coupling();
 	}

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -1152,7 +1152,7 @@ public:
 
 	// Couple with given convoy
 	bool couple_convoi(convoihandle_t coupled);
-	convoihandle_t uncouple_convoi();
+	convoihandle_t uncouple_convoi(  bool need_reservation_update = true  );
 
 	bool is_coupled() const { return state==COUPLED  ||  state==COUPLED_LOADING; }
 	bool is_waiting_for_coupling() const;

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -4921,7 +4921,7 @@ void rail_vehicle_t::leave_tile()
 				sch0->unreserve(self_cnv);
 				// we should not unreserve this tile if there are other vehicles on this tile.
 				if(  other_convoy.is_bound()  ) {
-					sch0->reserve(other_convoy,other_convoy_dir);
+					sch0->reserve(other_convoy->get_most_parent_convoi(),other_convoy_dir);
 				}
 				// tell next signal?
 				// and switch to red


### PR DESCRIPTION
連結運転時の予約プロセスを修正しました
- 連結時の予約タイルについて、`reserved`および`reserved2`を子編成まで呼びに行き、連結順序反転や停車中に予約したタイルの予約・予約解除処理を改善します。
- 連結解除時(連結順序反転を除く)、子編成側の停車中のタイルについては子編成に予約権限を渡します。これにより、子編成側が運転再開時に停車中タイルが予約解除できない不具合を修正します。