### PR TITLE
FIX: test runner never sees a test finish while sim is running

### DIFF
--- a/tests/run-automated-tests.sh
+++ b/tests/run-automated-tests.sh
@@ -30,6 +30,31 @@ SCENARIO_DIR="$WORKDIR/pak/scenario/automated-tests"
 mkdir -p "$SCENARIO_DIR"
 cp -r "$TEST_SRC"/* "$SCENARIO_DIR/"
 
+# Terminate a running sim instance.
+#
+# On Windows/MSYS2 the plain `kill` sends an MSYS signal, but sim.exe is a native Win32 GUI
+# binary: the signal takes about 10 seconds to land, and while a modal dialog owns the message
+# loop it never lands at all -- the window then has to be closed by hand before the run
+# continues. taskkill on the Win32 pid (the WINPID column of `ps`) terminates it immediately.
+# Falls back to `kill` on macOS/Linux, where taskkill does not exist.
+kill_sim() {
+	local pid=$1
+
+	if command -v taskkill > /dev/null 2>&1; then
+		local winpid
+		winpid=$(ps -p "$pid" 2>/dev/null | awk 'NR==2 {print $4}')
+		# only ever target this one pid, never `taskkill //IM sim.exe`:
+		# the developer may well have their own Simutrans open next to the test run
+		if [ -n "$winpid" ] && taskkill //PID "$winpid" //F > /dev/null 2>&1; then
+			wait "$pid" 2>/dev/null || true
+			return
+		fi
+	fi
+
+	kill "$pid" 2>/dev/null || true
+	wait "$pid" 2>/dev/null || true
+}
+
 # Helper function to run a single test
 run_single_test() {
 	local test_name=$1
@@ -49,6 +74,16 @@ EOF
 	# Use temporary file for monitoring
 	local temp_log=$(mktemp)
 
+	# sim block-buffers its stdout once it is redirected to a file and only flushes on a clean
+	# exit, so the completion banner never shows up there while the game is still running. On
+	# Windows that meant the run sat here for the full timeout unless the window was closed by
+	# hand -- closing it was what flushed the buffer and let the test be recognised as passed.
+	# The scenario VM writes its own log as it goes (dataobj/scenario.cc: "script-scenario.log"),
+	# so watch that for progress and keep the stdout capture only for the failure dump.
+	# Delete the previous run's copy first, or the first grep would match the test before this one.
+	local scenario_log="$WORKDIR/script-scenario.log"
+	rm -f "$scenario_log"
+
 	# Start sim in background and redirect output
 	$SIM_BINARY -set_workdir "$WORKDIR" -objects pak -scenario automated-tests -debug 2 -lang en -fps 100 > "$temp_log" 2>&1 &
 	local pid=$!
@@ -63,8 +98,8 @@ EOF
 
 		# Check if process is still running (macOS compatible)
 		if ! ps -p $pid > /dev/null 2>&1; then
-			# Check if tests completed successfully before process ended
-			if grep -q 'Tests completed successfully.' "$temp_log" 2>/dev/null; then
+			# exiting flushes the stdout buffer, so by now either log may carry the banner
+			if grep -q 'Tests completed successfully.' "$scenario_log" "$temp_log" 2>/dev/null; then
 				result=0
 			else
 				result=1
@@ -73,27 +108,26 @@ EOF
 		fi
 
 		# Check for successful completion
-		if grep -q 'Tests completed successfully.' "$temp_log" 2>/dev/null; then
-			kill $pid 2>/dev/null || true
-			wait $pid 2>/dev/null || true
+		if grep -q 'Tests completed successfully.' "$scenario_log" 2>/dev/null; then
+			kill_sim $pid
 			result=0
 			break
 		fi
 
 		# Check for test failures (assertions failed but test runner completed)
-		if grep -q 'Failed tests:' "$temp_log" 2>/dev/null; then
-			kill $pid 2>/dev/null || true
-			wait $pid 2>/dev/null || true
+		if grep -q 'Failed tests:' "$scenario_log" 2>/dev/null; then
+			kill_sim $pid
 			result=1
 			break
 		fi
 
-		# Check for errors
+		# Check for errors. These are dbg->warning() output and therefore land on the buffered
+		# stdout, so this rarely fires before the process exits -- the checks above and the
+		# timeout are what actually end a broken run.
 		if grep -q 'error \[Call function failed\] calling' "$temp_log" 2>/dev/null || \
 		   grep -q 'error \[Reading / compiling script failed\] calling' "$temp_log" 2>/dev/null || \
 		   grep -q '</error>' "$temp_log" 2>/dev/null; then
-			kill $pid 2>/dev/null || true
-			wait $pid 2>/dev/null || true
+			kill_sim $pid
 			result=1
 			break
 		fi
@@ -101,15 +135,18 @@ EOF
 
 	# Timeout check
 	if [ $elapsed -ge $timeout ]; then
-		kill $pid 2>/dev/null || true
-		wait $pid 2>/dev/null || true
+		kill_sim $pid
 		result=1
 	fi
 
 	# If test failed, show the last 30 lines
 	if [ $result -ne 0 ]; then
 		echo "  ✗ FAILED"
-		echo "  Last 30 lines of output:"
+		echo "  Last 30 lines of scenario log:"
+		echo "  ----------------------------------------"
+		tail -30 "$scenario_log" 2>/dev/null | sed 's/^/  /'
+		echo "  ----------------------------------------"
+		echo "  Last 30 lines of sim output:"
 		echo "  ----------------------------------------"
 		tail -30 "$temp_log" 2>/dev/null | sed 's/^/  /'
 		echo "  ----------------------------------------"


### PR DESCRIPTION
Win32 GUI ビルドで run-automated-tests が自動で終了せず手動でウインドウを閉じる必要があった問題の修正です。