### PR TITLE
do not remove all vehicles when trailer is any

### DIFF
--- a/gui/depot_frame.cc
+++ b/gui/depot_frame.cc
@@ -2127,7 +2127,7 @@ void depot_frame_t::image_from_convoi_list(uint nr, bool to_end)
 		while(  start_nr > 0  ) {
 			start_nr--;
 			const vehicle_desc_t *info = cnv->get_vehikel(start_nr)->get_desc();
-			if(  info->get_trailer_count() != 1 || cnv->is_invalid_convoy()  ) {
+			if(  info->get_trailer_count() != 1 || info->get_trailer(0)==vehicle_desc_t::any_vehicle || cnv->is_invalid_convoy()  ) {
 				start_nr++;
 				break;
 			}

--- a/simtool.cc
+++ b/simtool.cc
@@ -10395,13 +10395,15 @@ bool tool_change_depot_t::init( player_t *player )
 						while(nr<cnv->get_vehicle_count()) {
 							const vehicle_desc_t *info = cnv->get_vehikel(nr)->get_desc();
 							nr ++;
-							if(info->get_trailer_count()!=1) {
+							if(info->get_trailer_count()==1) {
 								vehicle_desc_t const* const veh = info->get_trailer(0);
 								// the leading is any, we should keep it.
 								if(  veh!=vehicle_desc_t::any_vehicle  )
 								{
 									break;
 								}
+							} else {
+								break;
 							}
 						}
 					}

--- a/simtool.cc
+++ b/simtool.cc
@@ -10398,7 +10398,7 @@ bool tool_change_depot_t::init( player_t *player )
 							if(info->get_trailer_count()==1) {
 								vehicle_desc_t const* const veh = info->get_trailer(0);
 								// the leading is any, we should keep it.
-								if(  veh!=vehicle_desc_t::any_vehicle  )
+								if(  veh==vehicle_desc_t::any_vehicle  )
 								{
 									break;
 								}

--- a/simtool.cc
+++ b/simtool.cc
@@ -10396,7 +10396,12 @@ bool tool_change_depot_t::init( player_t *player )
 							const vehicle_desc_t *info = cnv->get_vehikel(nr)->get_desc();
 							nr ++;
 							if(info->get_trailer_count()!=1) {
-								break;
+								vehicle_desc_t const* const veh = info->get_trailer(0);
+								// the leading is any, we should keep it.
+								if(  veh!=vehicle_desc_t::any_vehicle  )
+								{
+									break;
+								}
 							}
 						}
 					}

--- a/simtool.cc
+++ b/simtool.cc
@@ -10395,14 +10395,7 @@ bool tool_change_depot_t::init( player_t *player )
 						while(nr<cnv->get_vehicle_count()) {
 							const vehicle_desc_t *info = cnv->get_vehikel(nr)->get_desc();
 							nr ++;
-							if(info->get_trailer_count()==1) {
-								vehicle_desc_t const* const veh = info->get_trailer(0);
-								// the leading is any, we should keep it.
-								if(  veh==vehicle_desc_t::any_vehicle  )
-								{
-									break;
-								}
-							} else {
+							if(info->get_trailer_count()!=1 || info->get_trailer(0)==vehicle_desc_t::any_vehicle) {
 								break;
 							}
 						}


### PR DESCRIPTION
`Next`の連結条件が`any`の場合、1パターンしか連結されないものとして扱われ車庫における編成から車両を抜き取った際にまとめて撤去される問題を修正しました