### PR TITLE
keep journey time during small changes

### DIFF
--- a/dataobj/schedule.cc
+++ b/dataobj/schedule.cc
@@ -623,6 +623,12 @@ void schedule_t::sprintf_schedule( cbuffer_t &buf ) const
 bool schedule_t::sscanf_schedule( const char *ptr )
 {
 	const char *p = ptr;
+	// keep a copy of the old entries so we can preserve their recorded journey/waiting/stopping
+	// times for stops whose position did not move (i.e. only flags/orders were edited)
+	minivec_tpl<schedule_entry_t> old_entries(entries.get_count());
+	FOR(minivec_tpl<schedule_entry_t>, const& i, entries) {
+		old_entries.append(i);
+	}
 	// first: clear current schedule
 	while (!entries.empty()) {
 		remove();
@@ -711,6 +717,12 @@ bool schedule_t::sscanf_schedule( const char *ptr )
 		// ok, now we have a complete entry
 		schedule_entry_t entry = schedule_entry_t(koord3d(values[0], values[1], values[2]), values[3], values[4], values[5], values[6], values[10], values[11], values[12]);
 		entry.set_spacing(values[7], values[8], values[9]);
+		// if this stop is still at the same position in the schedule (stops/order unchanged,
+		// only flags or other attributes may have changed), keep its recorded times
+		const uint8 index = entries.get_count();
+		if(  index < old_entries.get_count()  &&  old_entries[index].pos == entry.pos  ) {
+			entry.copy_time_records_from( old_entries[index] );
+		}
 		entries.append(entry);
 	}
 	return true;

--- a/dataobj/schedule.cc
+++ b/dataobj/schedule.cc
@@ -720,7 +720,7 @@ bool schedule_t::sscanf_schedule( const char *ptr )
 		// if this stop is still at the same position in the schedule (stops/order unchanged,
 		// only flags or other attributes may have changed), keep its recorded times
 		const uint8 index = entries.get_count();
-		if(  index < old_entries.get_count()  &&  old_entries[index].pos == entry.pos  ) {
+		if(  index < old_entries.get_count()  &&  old_entries[index].pos == entry.pos  &&  (  index==0  ||  old_entries[index-1].pos == entries[index-1].pos)  ) {
 			entry.copy_time_records_from( old_entries[index] );
 		}
 		entries.append(entry);

--- a/dataobj/schedule.cc
+++ b/dataobj/schedule.cc
@@ -725,7 +725,7 @@ bool schedule_t::sscanf_schedule( const char *ptr )
 		if(  j>=entries.get_count()  ) {
 			break;
 		}
-		if(  (entries[j==0?entries.get_count()-1:j-1].pos == old_entries[i==0?entries.get_count()-1:i-1].pos)  &&  (entries[j].pos == old_entries[i].pos)  ) {
+		if(  (entries[j==0?entries.get_count()-1:j-1].pos == old_entries[i==0?old_entries.get_count()-1:i-1].pos)  &&  (entries[j].pos == old_entries[i].pos)  ) {
 			entries[j].copy_time_records_from(old_entries[i]);
 			j++;
 		}

--- a/dataobj/schedule.cc
+++ b/dataobj/schedule.cc
@@ -717,13 +717,18 @@ bool schedule_t::sscanf_schedule( const char *ptr )
 		// ok, now we have a complete entry
 		schedule_entry_t entry = schedule_entry_t(koord3d(values[0], values[1], values[2]), values[3], values[4], values[5], values[6], values[10], values[11], values[12]);
 		entry.set_spacing(values[7], values[8], values[9]);
-		// if this stop is still at the same position in the schedule (stops/order unchanged,
-		// only flags or other attributes may have changed), keep its recorded times
-		const uint8 index = entries.get_count();
-		if(  index < old_entries.get_count()  &&  old_entries[index].pos == entry.pos  &&  (  index==0  ||  old_entries[index-1].pos == entries[index-1].pos)  ) {
-			entry.copy_time_records_from( old_entries[index] );
-		}
 		entries.append(entry);
+	}
+	// check entry changes and set old journey time record if stop does not changed
+	uint8 j=0;
+	for(  uint8 i=0; i<old_entries.get_count(); i++  ) {
+		if(  j>=entries.get_count()  ) {
+			break;
+		}
+		if(  (entries[j==0?entries.get_count()-1:j-1].pos == old_entries[i==0?entries.get_count()-1:i-1].pos)  &&  (entries[j].pos == old_entries[i].pos)  ) {
+			entries[j].copy_time_records_from(old_entries[i]);
+			j++;
+		}
 	}
 	return true;
 }

--- a/dataobj/schedule_entry.h
+++ b/dataobj/schedule_entry.h
@@ -210,6 +210,22 @@ public:
 	void push_journey_time(uint32 time);
 	void push_waiting_time(uint32 time);
 	void push_convoy_stopping_time(uint32 time);
+
+	// preserve recorded times when re-applying a schedule whose stops/order did not change
+	void copy_time_records_from(const schedule_entry_t &other) {
+		jt_at_index = other.jt_at_index;
+		wt_at_index = other.wt_at_index;
+		cs_at_index = other.cs_at_index;
+		for(uint8 i = 0; i < NUM_ARRIVAL_TIME_STORED; i++) {
+			journey_time[i] = other.journey_time[i];
+		}
+		for(uint8 i = 0; i < NUM_WAITING_TIME_STORED; i++) {
+			waiting_time[i] = other.waiting_time[i];
+		}
+		for(uint8 i = 0; i < NUM_STOPPING_TIME_STORED; i++) {
+			convoy_stopping_time[i] = other.convoy_stopping_time[i];
+		}
+	}
 	
 	uint32 get_median_journey_time() const;
 	uint32 get_average_waiting_time() const;


### PR DESCRIPTION
スケジュールの小規模な修正に対して、`journey_time`を保持します。
※本来はフラグの修正等に対しても`journey_time`に影響が出ますが、その影響は運行を続けることで修正されるため従来とほとんど同じ挙動を維持できます。