### PR TITLE
FIX: avoid pure virtual call when removing halt ground

### DIFF
--- a/simhalt.cc
+++ b/simhalt.cc
@@ -4861,7 +4861,7 @@ bool haltestelle_t::rem_grund(grund_t *gr)
 	// first tile => remove name from this tile ...
 	char buf[256];
 	const char* station_name_to_transfer = NULL;
-	if (i == tiles.begin() && i->grund->get_name()) {
+	if (i == tiles.begin()) {
 		tstrncpy(buf, get_name(), lengthof(buf));
 		station_name_to_transfer = buf;
 		set_name(NULL);


### PR DESCRIPTION
## 概要

停留所に属する地面の破棄中に、`haltestelle_t::rem_grund()` から純粋仮想関数 `grund_t::get_name()` が呼び出され、`__cxa_pure_virtual` でクラッシュする問題を修正しました。

`grund_t` のデストラクタ実行中は派生クラス部分がすでに破棄されているため、`monorailboden_t` などの `get_name()` 実装へは仮想ディスパッチされません。

## 変更内容

- 停留所の先頭タイルを削除する際の `grund_t::get_name()` 呼び出しを削除
- 先頭タイルの停留所名を次のタイルへ移す既存処理は維持

`grund_t::get_name()` は停留所名の有無ではなく、`"Monorailboden"` などの地面種別名を返す関数のため、該当条件の削除による通常時の動作変更はありません。

## 確認

- `make -j8`
- `git diff --check`
