### PR TITLE
add and update tile length

### DIFF
--- a/dataobj/settings.cc
+++ b/dataobj/settings.cc
@@ -32,6 +32,13 @@
 #define NEVER 0xFFFFU
 
 
+// TODO: define the actual default value for tile_length
+sint32 settings_t::calc_default_tile_length()
+{
+	return 1000;
+}
+
+
 settings_t::settings_t() :
 	filename(""),
 	heightfield("")
@@ -63,6 +70,8 @@ settings_t::settings_t() :
 
 	world_maximum_height = 32;
 	world_minimum_height = -12;
+
+	tile_length = calc_default_tile_length();
 
 	// default climate zones
 	set_default_climates( );
@@ -1147,6 +1156,11 @@ void settings_t::rdwr(loadsave_t *file)
 			penalty_wait_for_two_month = false;
 			base_revenue_from_halt = 0;
 		}
+		if(  file->get_OTRP_version() >= 60  ) {
+			file->rdwr_long(tile_length);
+		} else {
+			tile_length = calc_default_tile_length();
+		}
  		if(  file->is_version_atleast(122, 1)  ) {
 			file->rdwr_enum(climate_generator);
 			file->rdwr_byte( wind_direction );
@@ -1991,6 +2005,8 @@ void settings_t::parse_simuconf( tabfile_t& simuconf, sint16& disp_width, sint16
 	// note: no need to check for min_height < max_height, since -12 < 16
 	world_maximum_height = contents.get_int_clamped("world_maximum_height", world_maximum_height, 16, 127);
 	world_minimum_height = contents.get_int_clamped("world_minimum_height", world_minimum_height, -127, -12);
+
+	tile_length = contents.get_int("tile_length", tile_length);
 
 	citycar_max_look_forward = contents.get_int("citycar_max_look_forward", citycar_max_look_forward);
 	citycar_route_weight_crowded = contents.get_int("citycar_route_weight_crowded", citycar_route_weight_crowded);

--- a/dataobj/settings.h
+++ b/dataobj/settings.h
@@ -134,6 +134,12 @@ private:
 	sint8 world_maximum_height;
 	sint8 world_minimum_height;
 
+	/**
+	 * length of one map tile, in meters (not km); used to convert tile-based
+	 * distance counters into real-world distance
+	 */
+	sint32 tile_length;
+
 	 /**
 	 * waterlevel, climate borders, lowest snow in winter
 	 */
@@ -528,6 +534,11 @@ public:
 
 	sint8 get_maximumheight() const { return world_maximum_height; }
 	sint8 get_minimumheight() const { return world_minimum_height; }
+
+	sint32 get_tile_length() const { return tile_length; }
+
+	// computes the default value for tile_length (meters)
+	static sint32 calc_default_tile_length();
 
 	sint8 get_groundwater() const {return (sint8)groundwater;}
 

--- a/gui/convoi_info_t.cc
+++ b/gui/convoi_info_t.cc
@@ -34,7 +34,7 @@
 
 static const char cost_type[convoi_t::MAX_CONVOI_COST][64] =
 {
-	"Free Capacity", "Transported", "Revenue", "Operation", "Profit", "Distance", "Maxspeed", "Way toll", "Freight ton-kilo"
+	"Free Capacity", "Transported", "Revenue", "Operation", "Profit", "Distance", "Maxspeed", "Way toll", "Freight ton-kilo", "Distance (m)"
 };
 
 static const uint8 cost_type_color[convoi_t::MAX_CONVOI_COST] =
@@ -47,12 +47,13 @@ static const uint8 cost_type_color[convoi_t::MAX_CONVOI_COST] =
 	COL_DISTANCE,
 	COL_MAXSPEED,
 	COL_TOLL,
-	COL_TONKILO
+	COL_TONKILO,
+	COL_DISTANCE
 };
 
 static const bool cost_type_money[convoi_t::MAX_CONVOI_COST] =
 {
-	false, false, true, true, true, false, false, true, false
+	false, false, true, true, true, false, false, true, false, false
 };
 
 

--- a/gui/schedule_list.cc
+++ b/gui/schedule_list.cc
@@ -65,6 +65,7 @@ static const char *cost_type[schedule_list_gui_t::MAX_LINE_COST_GUI] =
 	"Maxspeed",
 	"Road toll",
 	"Freight ton-kilo",
+	"Distance (m)",
 	"Avg. density" // not recorded in financial_history
 };
 
@@ -80,6 +81,7 @@ const uint8 cost_type_color[schedule_list_gui_t::MAX_LINE_COST_GUI] =
 	COL_MAXSPEED,
 	COL_TOLL,
 	COL_TONKILO,
+	COL_DISTANCE,
 	COL_TRANSPORT_DENSITY // not recorded in financial_history
 };
 
@@ -96,7 +98,8 @@ static uint8 statistic[MAX_LINE_COST] = {
 	LINE_DISTANCE,
 	LINE_MAXSPEED,
 	LINE_WAYTOLL,
-	LINE_TONKILO
+	LINE_TONKILO,
+	LINE_DISTANCE_NEW
 };
 
 static uint8 statistic_type[MAX_LINE_COST] = {
@@ -109,6 +112,7 @@ static uint8 statistic_type[MAX_LINE_COST] = {
 	STANDARD,
 	STANDARD,
 	MONEY,
+	STANDARD,
 	STANDARD
 };
 

--- a/gui/schedule_list.cc
+++ b/gui/schedule_list.cc
@@ -99,7 +99,7 @@ static uint8 statistic[MAX_LINE_COST] = {
 	LINE_MAXSPEED,
 	LINE_WAYTOLL,
 	LINE_TONKILO,
-	LINE_DISTANCE_NEW
+	LINE_DISTANCE_METERS
 };
 
 static uint8 statistic_type[MAX_LINE_COST] = {

--- a/gui/settings_frame.cc
+++ b/gui/settings_frame.cc
@@ -156,7 +156,7 @@ bool settings_frame_t::infowin_event(const event_t *ev)
 			world()->set_schedule_counter();
 		}
 
-		// tile_length changed: rescale all stored *_DISTANCE_NEW records for convois and lines
+		// tile_length changed: rescale all stored *_DISTANCE_METERS records for convois and lines
 		if(  sets->get_tile_length() != old_tile_length  ) {
 			world()->recalc_distance_new_records( old_tile_length, sets->get_tile_length() );
 		}

--- a/gui/settings_frame.cc
+++ b/gui/settings_frame.cc
@@ -137,6 +137,7 @@ bool settings_frame_t::infowin_event(const event_t *ev)
 		const bool   old_transit_by_foot     = sets->is_transit_by_foot();
 		const uint32 old_foot_path_weight    = sets->get_foot_path_weight();
 		const uint32 old_foot_path_time_ticks = sets->get_foot_path_time_ticks();
+		const sint32 old_tile_length          = sets->get_tile_length();
 		general.read( sets );
 		display.read( sets );
 		routing.read( sets );
@@ -153,6 +154,11 @@ bool settings_frame_t::infowin_event(const event_t *ev)
 		     sets->get_foot_path_weight() != old_foot_path_weight  ||
 		     sets->get_foot_path_time_ticks() != old_foot_path_time_ticks  ) {
 			world()->set_schedule_counter();
+		}
+
+		// tile_length changed: rescale all stored *_DISTANCE_NEW records for convois and lines
+		if(  sets->get_tile_length() != old_tile_length  ) {
+			world()->recalc_distance_new_records( old_tile_length, sets->get_tile_length() );
 		}
 	}
 	return gui_frame_t::infowin_event(ev);

--- a/gui/settings_stats.cc
+++ b/gui/settings_stats.cc
@@ -107,6 +107,11 @@ void settings_general_stats_t::init(settings_t const* const sets)
 	INIT_NUM( "world_maximum_height", sets->get_maximumheight(), 16, 127, gui_numberinput_t::AUTOLINEAR, false );
 	INIT_NUM( "world_minimum_height", sets->get_minimumheight(), -127, -12, gui_numberinput_t::AUTOLINEAR, false );
 	INIT_NUM( "tile_length", sets->get_tile_length(), 1, 0x7FFFFFFFul, gui_numberinput_t::AUTOLINEAR, false );
+	if(  env_t::networkmode  ) {
+		// changing tile_length mid-game rescales all convoy/line distance records,
+		// which is not safe to do independently on each client in network mode
+		numinp.back()->disable();
+	}
 
 	INIT_END
 	clear_dirty();

--- a/gui/settings_stats.cc
+++ b/gui/settings_stats.cc
@@ -106,6 +106,7 @@ void settings_general_stats_t::init(settings_t const* const sets)
 	SEPERATOR
 	INIT_NUM( "world_maximum_height", sets->get_maximumheight(), 16, 127, gui_numberinput_t::AUTOLINEAR, false );
 	INIT_NUM( "world_minimum_height", sets->get_minimumheight(), -127, -12, gui_numberinput_t::AUTOLINEAR, false );
+	INIT_NUM( "tile_length", sets->get_tile_length(), 1, 0x7FFFFFFFul, gui_numberinput_t::AUTOLINEAR, false );
 
 	INIT_END
 	clear_dirty();
@@ -152,6 +153,7 @@ void settings_general_stats_t::read(settings_t* const sets)
 
 	READ_NUM_VALUE( sets->world_maximum_height );
 	READ_NUM_VALUE( sets->world_minimum_height );
+	READ_NUM_VALUE( sets->tile_length );
 }
 
 void settings_display_stats_t::init(settings_t const* const)

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -861,7 +861,7 @@ void convoi_t::add_running_cost( const weg_t *weg )
 	book( 1, CONVOI_DISTANCE );
 	ribi_t::ribi dir = get_most_parent_convoi()->front()->get_direction();
 	sint32 const tile_length_base = ribi_t::is_bend(dir)?welt->get_settings().get_pak_diagonal_multiplier():1024;
-	book( welt->get_settings().get_tile_length()*tile_length_base/1024, CONVOI_DISTANCE_NEW );
+	book( welt->get_settings().get_tile_length()*tile_length_base/1024, CONVOI_DISTANCE_METERS );
 	for (uint16 i=0; i<anz_vehikel; i++) {
 		book( fahr[i]->get_total_cargo(), CONVOI_TONKILO );
 	}
@@ -3444,19 +3444,19 @@ void convoi_t::rdwr(loadsave_t *file)
 		}
 		for (size_t k = MAX_MONTHS; k-- != 0;) {
 			financial_history[k][CONVOI_TONKILO] = 0;
-			financial_history[k][CONVOI_DISTANCE_NEW] = 0;
+			financial_history[k][CONVOI_DISTANCE_METERS] = 0;
 		}
 	}
 	else if (  file->get_OTRP_version()<60  )
 	{
 		// load statistics
-		for (int j = 0; j<CONVOI_DISTANCE_NEW; j++) {
+		for (int j = 0; j<CONVOI_DISTANCE_METERS; j++) {
 			for (size_t k = MAX_MONTHS; k-- != 0;) {
 				file->rdwr_longlong(financial_history[k][j]);
 			}
 		}
 		for (size_t k = MAX_MONTHS; k-- != 0;) {
-			financial_history[k][CONVOI_DISTANCE_NEW] = financial_history[k][CONVOI_DISTANCE] * welt->get_settings().get_tile_length();
+			financial_history[k][CONVOI_DISTANCE_METERS] = financial_history[k][CONVOI_DISTANCE] * welt->get_settings().get_tile_length();
 		}
 	}
 	else

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -859,6 +859,9 @@ void convoi_t::add_running_cost( const weg_t *weg )
 
 	sum_speed_limit += speed_to_kmh( min( min_top_speed, speed_limit ));
 	book( 1, CONVOI_DISTANCE );
+	ribi_t::ribi dir = get_most_parent_convoi()->front()->get_direction();
+	sint32 const tile_length_base = ribi_t::is_bend(dir)?welt->get_settings().get_pak_diagonal_multiplier():1024;
+	book( welt->get_settings().get_tile_length()*tile_length_base/1024, CONVOI_DISTANCE_NEW );
 	for (uint16 i=0; i<anz_vehikel; i++) {
 		book( fahr[i]->get_total_cargo(), CONVOI_TONKILO );
 	}
@@ -3431,7 +3434,7 @@ void convoi_t::rdwr(loadsave_t *file)
 			financial_history[k][CONVOI_TONKILO] = 0;
 		}
 	}
-	else if (  file->get_OTRP_version()<53  ) 
+	else if (  file->get_OTRP_version()<53  )
 	{
 		// load statistics
 		for (int j = 0; j<CONVOI_TONKILO; j++) {
@@ -3441,6 +3444,19 @@ void convoi_t::rdwr(loadsave_t *file)
 		}
 		for (size_t k = MAX_MONTHS; k-- != 0;) {
 			financial_history[k][CONVOI_TONKILO] = 0;
+			financial_history[k][CONVOI_DISTANCE_NEW] = 0;
+		}
+	}
+	else if (  file->get_OTRP_version()<60  )
+	{
+		// load statistics
+		for (int j = 0; j<CONVOI_DISTANCE_NEW; j++) {
+			for (size_t k = MAX_MONTHS; k-- != 0;) {
+				file->rdwr_longlong(financial_history[k][j]);
+			}
+		}
+		for (size_t k = MAX_MONTHS; k-- != 0;) {
+			financial_history[k][CONVOI_DISTANCE_NEW] = financial_history[k][CONVOI_DISTANCE] * welt->get_settings().get_tile_length();
 		}
 	}
 	else

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -64,6 +64,7 @@ public:
 		CONVOI_MAXSPEED,           // average max. possible speed
 		CONVOI_WAYTOLL,			   // waytoll
 		CONVOI_TONKILO,			   // the amount of transported ware integrated by transported distance.
+		CONVOI_DISTANCE_NEW,       // total distance traveled this month, in meters (CONVOI_DISTANCE * settings_t::tile_length)
 		MAX_CONVOI_COST            // Total number of cost items
 	};
 
@@ -1017,6 +1018,7 @@ public:
 	* return a specified element from the financial history
 	*/
 	sint64 get_finance_history(int month, int cost_type) const { return financial_history[month][cost_type]; }
+	void set_finance_history(int month, int cost_type, sint64 value) { financial_history[month][cost_type] = value; }
 	sint64 get_stat_converted(int month, int cost_type) const;
 
 	/**

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -64,7 +64,7 @@ public:
 		CONVOI_MAXSPEED,           // average max. possible speed
 		CONVOI_WAYTOLL,			   // waytoll
 		CONVOI_TONKILO,			   // the amount of transported ware integrated by transported distance.
-		CONVOI_DISTANCE_NEW,       // total distance traveled this month, in meters (CONVOI_DISTANCE * settings_t::tile_length)
+		CONVOI_DISTANCE_METERS,       // total distance traveled this month, in meters (CONVOI_DISTANCE * settings_t::tile_length)
 		MAX_CONVOI_COST            // Total number of cost items
 	};
 

--- a/simline.cc
+++ b/simline.cc
@@ -25,7 +25,7 @@
 
 
 uint8 convoi_to_line_catgory_[convoi_t::MAX_CONVOI_COST] = {
-	LINE_CAPACITY, LINE_TRANSPORTED_GOODS, LINE_REVENUE, LINE_OPERATIONS, LINE_PROFIT, LINE_DISTANCE, LINE_MAXSPEED, LINE_WAYTOLL, LINE_TONKILO, LINE_DISTANCE_NEW
+	LINE_CAPACITY, LINE_TRANSPORTED_GOODS, LINE_REVENUE, LINE_OPERATIONS, LINE_PROFIT, LINE_DISTANCE, LINE_MAXSPEED, LINE_WAYTOLL, LINE_TONKILO, LINE_DISTANCE_METERS
 };
 
 
@@ -333,17 +333,17 @@ void simline_t::rdwr(loadsave_t *file)
 		}
 		for (size_t k = MAX_MONTHS; k-- != 0;) {
 			financial_history[k][LINE_TONKILO] = 0;
-			financial_history[k][LINE_DISTANCE_NEW] = 0;
+			financial_history[k][LINE_DISTANCE_METERS] = 0;
 		}
 	}
 	else if(  file->get_OTRP_version()<60  ) {
-		for (int j = 0; j<LINE_DISTANCE_NEW; j++) {
+		for (int j = 0; j<LINE_DISTANCE_METERS; j++) {
 			for (size_t k = MAX_MONTHS; k-- != 0;) {
 				file->rdwr_longlong(financial_history[k][j]);
 			}
 		}
 		for (size_t k = MAX_MONTHS; k-- != 0;) {
-			financial_history[k][LINE_DISTANCE_NEW] = financial_history[k][LINE_DISTANCE] * welt->get_settings().get_tile_length();
+			financial_history[k][LINE_DISTANCE_METERS] = financial_history[k][LINE_DISTANCE] * welt->get_settings().get_tile_length();
 		}
 	}
 	else {

--- a/simline.cc
+++ b/simline.cc
@@ -25,7 +25,7 @@
 
 
 uint8 convoi_to_line_catgory_[convoi_t::MAX_CONVOI_COST] = {
-	LINE_CAPACITY, LINE_TRANSPORTED_GOODS, LINE_REVENUE, LINE_OPERATIONS, LINE_PROFIT, LINE_DISTANCE, LINE_MAXSPEED, LINE_WAYTOLL, LINE_TONKILO
+	LINE_CAPACITY, LINE_TRANSPORTED_GOODS, LINE_REVENUE, LINE_OPERATIONS, LINE_PROFIT, LINE_DISTANCE, LINE_MAXSPEED, LINE_WAYTOLL, LINE_TONKILO, LINE_DISTANCE_NEW
 };
 
 
@@ -333,6 +333,17 @@ void simline_t::rdwr(loadsave_t *file)
 		}
 		for (size_t k = MAX_MONTHS; k-- != 0;) {
 			financial_history[k][LINE_TONKILO] = 0;
+			financial_history[k][LINE_DISTANCE_NEW] = 0;
+		}
+	}
+	else if(  file->get_OTRP_version()<60  ) {
+		for (int j = 0; j<LINE_DISTANCE_NEW; j++) {
+			for (size_t k = MAX_MONTHS; k-- != 0;) {
+				file->rdwr_longlong(financial_history[k][j]);
+			}
+		}
+		for (size_t k = MAX_MONTHS; k-- != 0;) {
+			financial_history[k][LINE_DISTANCE_NEW] = financial_history[k][LINE_DISTANCE] * welt->get_settings().get_tile_length();
 		}
 	}
 	else {

--- a/simline.h
+++ b/simline.h
@@ -28,7 +28,8 @@
 #define LINE_MAXSPEED          7 // maximum speed for bonus calculation of all convois
 #define LINE_WAYTOLL           8 // way toll paid by vehicles of line
 #define LINE_TONKILO		   9 // the amount of transported ware integrated by distance.
-#define MAX_LINE_COST          10 // Total number of cost items
+#define LINE_DISTANCE_NEW      10 // distance covered by all convois, in meters (LINE_DISTANCE * settings_t::tile_length)
+#define MAX_LINE_COST          11 // Total number of cost items
 
 class karte_ptr_t;
 class loadsave_t;
@@ -198,6 +199,7 @@ public:
 	sint64* get_finance_history() { return *financial_history; }
 
 	sint64 get_finance_history(int month, int cost_type) const { return financial_history[month][cost_type]; }
+	void set_finance_history(int month, int cost_type, sint64 value) { financial_history[month][cost_type] = value; }
 	sint64 get_stat_converted(int month, int cost_type) const;
 
 	void book(sint64 amount, int cost_type) { financial_history[0][cost_type] += amount; }

--- a/simline.h
+++ b/simline.h
@@ -28,7 +28,7 @@
 #define LINE_MAXSPEED          7 // maximum speed for bonus calculation of all convois
 #define LINE_WAYTOLL           8 // way toll paid by vehicles of line
 #define LINE_TONKILO		   9 // the amount of transported ware integrated by distance.
-#define LINE_DISTANCE_NEW      10 // distance covered by all convois, in meters (LINE_DISTANCE * settings_t::tile_length)
+#define LINE_DISTANCE_METERS      10 // distance covered by all convois, in meters (LINE_DISTANCE * settings_t::tile_length)
 #define MAX_LINE_COST          11 // Total number of cost items
 
 class karte_ptr_t;

--- a/simversion.h
+++ b/simversion.h
@@ -30,9 +30,9 @@
 #define SIM_SERVER_MINOR    0
 // NOTE: increment before next release to enable save/load of new features
 
-#define OTRP_VERSION_MAJOR 59
+#define OTRP_VERSION_MAJOR 60
 #define OTRP_VERSION_MINOR 0
-#define OTRP_VERSION_PATCH 2
+#define OTRP_VERSION_PATCH 0
 // NOTE: increment OTRP_VERSION_MAJOR when the save data structure changes.
 
 #define MAKEOBJ_VERSION "60.5"

--- a/simversion.h
+++ b/simversion.h
@@ -30,9 +30,9 @@
 #define SIM_SERVER_MINOR    0
 // NOTE: increment before next release to enable save/load of new features
 
-#define OTRP_VERSION_MAJOR 60
+#define OTRP_VERSION_MAJOR 59
 #define OTRP_VERSION_MINOR 0
-#define OTRP_VERSION_PATCH 0
+#define OTRP_VERSION_PATCH 2
 // NOTE: increment OTRP_VERSION_MAJOR when the save data structure changes.
 
 #define MAKEOBJ_VERSION "60.5"

--- a/simworld.cc
+++ b/simworld.cc
@@ -25,6 +25,7 @@
 #include "display/simimg.h"
 #include "siminteraction.h"
 #include "simintr.h"
+#include "simline.h"
 #include "simlinemgmt.h"
 #include "simloadingscreen.h"
 #include "simmenu.h"
@@ -538,6 +539,28 @@ void karte_t::add_convoi(convoihandle_t const cnv)
 void karte_t::rem_convoi(convoihandle_t const cnv)
 {
 	convoi_array.remove(cnv);
+}
+
+
+void karte_t::recalc_distance_new_records(sint32 old_tile_length, sint32 new_tile_length)
+{
+	FOR(vector_tpl<convoihandle_t>, const cnv, convoi_array) {
+		for (size_t k = 0; k < MAX_MONTHS; k++) {
+			const sint64 old_value = cnv->get_finance_history(k, convoi_t::CONVOI_DISTANCE_NEW);
+			cnv->set_finance_history( k, convoi_t::CONVOI_DISTANCE_NEW, old_value * new_tile_length / old_tile_length );
+		}
+	}
+
+	for (uint8 i = 0; i < PLAYER_UNOWNED; i++) {
+		if (player_t* pl = players[i]) {
+			FOR(vector_tpl<linehandle_t>, const line, pl->simlinemgmt.get_line_list()) {
+				for (size_t k = 0; k < MAX_MONTHS; k++) {
+					const sint64 old_value = line->get_finance_history(k, LINE_DISTANCE_NEW);
+					line->set_finance_history( k, LINE_DISTANCE_NEW, old_value * new_tile_length / old_tile_length );
+				}
+			}
+		}
+	}
 }
 
 

--- a/simworld.cc
+++ b/simworld.cc
@@ -546,8 +546,8 @@ void karte_t::recalc_distance_new_records(sint32 old_tile_length, sint32 new_til
 {
 	FOR(vector_tpl<convoihandle_t>, const cnv, convoi_array) {
 		for (size_t k = 0; k < MAX_MONTHS; k++) {
-			const sint64 old_value = cnv->get_finance_history(k, convoi_t::CONVOI_DISTANCE_NEW);
-			cnv->set_finance_history( k, convoi_t::CONVOI_DISTANCE_NEW, old_value * new_tile_length / old_tile_length );
+			const sint64 old_value = cnv->get_finance_history(k, convoi_t::CONVOI_DISTANCE_METERS);
+			cnv->set_finance_history( k, convoi_t::CONVOI_DISTANCE_METERS, old_value * new_tile_length / old_tile_length );
 		}
 	}
 
@@ -555,8 +555,8 @@ void karte_t::recalc_distance_new_records(sint32 old_tile_length, sint32 new_til
 		if (player_t* pl = players[i]) {
 			FOR(vector_tpl<linehandle_t>, const line, pl->simlinemgmt.get_line_list()) {
 				for (size_t k = 0; k < MAX_MONTHS; k++) {
-					const sint64 old_value = line->get_finance_history(k, LINE_DISTANCE_NEW);
-					line->set_finance_history( k, LINE_DISTANCE_NEW, old_value * new_tile_length / old_tile_length );
+					const sint64 old_value = line->get_finance_history(k, LINE_DISTANCE_METERS);
+					line->set_finance_history( k, LINE_DISTANCE_METERS, old_value * new_tile_length / old_tile_length );
 				}
 			}
 		}

--- a/simworld.h
+++ b/simworld.h
@@ -1577,6 +1577,10 @@ public:
 	void rem_convoi(convoihandle_t);
 	vector_tpl<convoihandle_t> const& convoys() const { return convoi_array; }
 
+	// rescales the stored CONVOI_DISTANCE_NEW/LINE_DISTANCE_NEW history for all convois and
+	// lines by new_tile_length/old_tile_length; called whenever the tile_length setting changes
+	void recalc_distance_new_records(sint32 old_tile_length, sint32 new_tile_length);
+
 	void load_convoy_templates();
 	const vector_tpl<convoi_template_t>& get_convoy_templates() const { return convoy_templates; }
 

--- a/simworld.h
+++ b/simworld.h
@@ -1577,7 +1577,7 @@ public:
 	void rem_convoi(convoihandle_t);
 	vector_tpl<convoihandle_t> const& convoys() const { return convoi_array; }
 
-	// rescales the stored CONVOI_DISTANCE_NEW/LINE_DISTANCE_NEW history for all convois and
+	// rescales the stored CONVOI_DISTANCE_METERS/LINE_DISTANCE_METERS history for all convois and
 	// lines by new_tile_length/old_tile_length; called whenever the tile_length setting changes
 	void recalc_distance_new_records(sint32 old_tile_length, sint32 new_tile_length);
 


### PR DESCRIPTION
編成および路線の走行距離について、1タイルあたりの走行距離をsimuconf.tab等で定義し記録するようにしました。

また、斜めタイルにおける走行距離の加算を1タイル分から`pak_diagonal_multiplier`分に修正しました