### PR TITLE
update toolbar

### DIFF
--- a/dataobj/environment.cc
+++ b/dataobj/environment.cc
@@ -89,6 +89,7 @@ bool env_t::mute_midi = false;
 bool env_t::shuffle_midi = true;
 sint16 env_t::window_snap_distance = 8;
 scr_size env_t::iconsize( 32, 32 );
+bool env_t::iconsize_set_by_pak = false;
 uint8 env_t::chat_window_transparency = 100;
 bool env_t::hide_rail_return_ticket = true;
 bool env_t::show_delete_buttons = false;

--- a/dataobj/environment.h
+++ b/dataobj/environment.h
@@ -231,6 +231,13 @@ public:
 
 	static scr_size iconsize;
 
+	/**
+	 * thickness (in pixels) of the scrollbar strip drawn just outside the
+	 * main menu bar's icon row/column (below for MENU_TOP/BOTTOM, beside for
+	 * MENU_LEFT/RIGHT); the menu bar's on-screen footprint is iconsize plus this
+	 */
+	static const scr_coord_val menu_scrollbar_thickness = 10;
+
 	/// customize your tooltips
 	static bool show_tooltips;
 	static uint32 tooltip_color_rgb;

--- a/dataobj/environment.h
+++ b/dataobj/environment.h
@@ -232,6 +232,13 @@ public:
 	static scr_size iconsize;
 
 	/**
+	 * once tool_t::read_menu() has applied the pak-specific icon_height from
+	 * menuconf.tab to iconsize, this is set so later theme (re)loads don't
+	 * reset iconsize back to the theme's icon_width
+	 */
+	static bool iconsize_set_by_pak;
+
+	/**
 	 * thickness (in pixels) of the scrollbar strip drawn just outside the
 	 * main menu bar's icon row/column (below for MENU_TOP/BOTTOM, beside for
 	 * MENU_LEFT/RIGHT); the menu bar's on-screen footprint is iconsize plus this

--- a/display/simgraph16.cc
+++ b/display/simgraph16.cc
@@ -5504,7 +5504,7 @@ void display_flush_buffer()
 #ifdef USE_SOFTPOINTER
 	ex_ord_update_mx_my();
 
-	const scr_coord_val ticker_ypos_bottom = display_get_height() - win_get_statusbar_height() - (env_t::menupos == MENU_BOTTOM) * (env_t::iconsize.h + env_t::menu_scrollbar_thickness);
+	const scr_coord_val ticker_ypos_bottom = display_get_height() - win_get_statusbar_height() - (env_t::menupos == MENU_BOTTOM) * (env_t::iconsize.h + get_main_menu_scrollbar_extra());
 	const scr_coord_val ticker_ypos_top = ticker_ypos_bottom - TICKER_HEIGHT;
 
 	// use mouse pointer image if available

--- a/display/simgraph16.cc
+++ b/display/simgraph16.cc
@@ -5504,7 +5504,7 @@ void display_flush_buffer()
 #ifdef USE_SOFTPOINTER
 	ex_ord_update_mx_my();
 
-	const scr_coord_val ticker_ypos_bottom = display_get_height() - win_get_statusbar_height() - (env_t::menupos == MENU_BOTTOM) * env_t::iconsize.h;
+	const scr_coord_val ticker_ypos_bottom = display_get_height() - win_get_statusbar_height() - (env_t::menupos == MENU_BOTTOM) * (env_t::iconsize.h + env_t::menu_scrollbar_thickness);
 	const scr_coord_val ticker_ypos_top = ticker_ypos_bottom - TICKER_HEIGHT;
 
 	// use mouse pointer image if available

--- a/display/simview.cc
+++ b/display/simview.cc
@@ -116,7 +116,7 @@ void main_view_t::display(bool force_dirty)
 		autojump(); // If autojump is needed, do it.
 	}
 
-	scr_rect clip_rr(0, env_t::iconsize.w, disp_width, disp_height - env_t::iconsize.h);
+	scr_rect clip_rr(0, env_t::iconsize.h + env_t::menu_scrollbar_thickness, disp_width, disp_height - env_t::iconsize.h - env_t::menu_scrollbar_thickness);
 	switch (env_t::menupos) {
 	case MENU_TOP:
 		// rect default
@@ -125,10 +125,10 @@ void main_view_t::display(bool force_dirty)
 		clip_rr.y = win_get_statusbar_height() + (!ticker::empty() ? TICKER_HEIGHT : 0);
 		break;
 	case MENU_LEFT:
-		clip_rr = scr_rect(env_t::iconsize.w, 0, disp_width - env_t::iconsize.w, disp_height);
+		clip_rr = scr_rect(env_t::iconsize.w + env_t::menu_scrollbar_thickness, 0, disp_width - env_t::iconsize.w - env_t::menu_scrollbar_thickness, disp_height);
 		break;
 	case MENU_RIGHT:
-		clip_rr = scr_rect(0, 0, disp_width - env_t::iconsize.w, disp_height);
+		clip_rr = scr_rect(0, 0, disp_width - env_t::iconsize.w - env_t::menu_scrollbar_thickness, disp_height);
 		break;
 	}
 	display_set_clip_wh(clip_rr.x, clip_rr.y, clip_rr.w, clip_rr.h);

--- a/display/simview.cc
+++ b/display/simview.cc
@@ -30,6 +30,7 @@
 #include "../simconvoi.h"
 
 uint16 win_get_statusbar_height(); // simwin.h
+scr_coord_val get_main_menu_scrollbar_extra(); // simwin.h
 
 main_view_t::main_view_t(karte_t *welt)
 {
@@ -116,7 +117,11 @@ void main_view_t::display(bool force_dirty)
 		autojump(); // If autojump is needed, do it.
 	}
 
-	scr_rect clip_rr(0, env_t::iconsize.h + env_t::menu_scrollbar_thickness, disp_width, disp_height - env_t::iconsize.h - env_t::menu_scrollbar_thickness);
+	// the extra strip is only actually reserved (by simwin.cc) when the menubar's
+	// icons overflow and need a scrollbar; otherwise draw the map right up to the
+	// icon row/column like usual, instead of leaving an unused gap
+	const scr_coord_val menu_extra = get_main_menu_scrollbar_extra();
+	scr_rect clip_rr(0, env_t::iconsize.h + menu_extra, disp_width, disp_height - env_t::iconsize.h - menu_extra);
 	switch (env_t::menupos) {
 	case MENU_TOP:
 		// rect default
@@ -125,10 +130,10 @@ void main_view_t::display(bool force_dirty)
 		clip_rr.y = win_get_statusbar_height() + (!ticker::empty() ? TICKER_HEIGHT : 0);
 		break;
 	case MENU_LEFT:
-		clip_rr = scr_rect(env_t::iconsize.w + env_t::menu_scrollbar_thickness, 0, disp_width - env_t::iconsize.w - env_t::menu_scrollbar_thickness, disp_height);
+		clip_rr = scr_rect(env_t::iconsize.w + menu_extra, 0, disp_width - env_t::iconsize.w - menu_extra, disp_height);
 		break;
 	case MENU_RIGHT:
-		clip_rr = scr_rect(0, 0, disp_width - env_t::iconsize.w - env_t::menu_scrollbar_thickness, disp_height);
+		clip_rr = scr_rect(0, 0, disp_width - env_t::iconsize.w - menu_extra, disp_height);
 		break;
 	}
 	display_set_clip_wh(clip_rr.x, clip_rr.y, clip_rr.w, clip_rr.h);

--- a/gui/enlarge_map_frame_t.cc
+++ b/gui/enlarge_map_frame_t.cc
@@ -248,7 +248,7 @@ bool enlarge_map_frame_t::action_triggered( gui_action_creator_t *comp,value_t v
 			sets->heightfield = "";
 			load_relief_frame_t* lrf = new load_relief_frame_t(sets);
 			create_win(lrf, w_info, magic_load_t );
-			win_set_pos(lrf, (display_get_width() - lrf->get_windowsize().w-10), env_t::iconsize.h + env_t::menu_scrollbar_thickness);
+			win_set_pos(lrf, (display_get_width() - lrf->get_windowsize().w-10), env_t::iconsize.h + get_main_menu_scrollbar_extra());
 			loaded_heightfield = true;
 		} else {
 			inp_x_size.enable();

--- a/gui/enlarge_map_frame_t.cc
+++ b/gui/enlarge_map_frame_t.cc
@@ -248,7 +248,7 @@ bool enlarge_map_frame_t::action_triggered( gui_action_creator_t *comp,value_t v
 			sets->heightfield = "";
 			load_relief_frame_t* lrf = new load_relief_frame_t(sets);
 			create_win(lrf, w_info, magic_load_t );
-			win_set_pos(lrf, (display_get_width() - lrf->get_windowsize().w-10), env_t::iconsize.h);
+			win_set_pos(lrf, (display_get_width() - lrf->get_windowsize().w-10), env_t::iconsize.h + env_t::menu_scrollbar_thickness);
 			loaded_heightfield = true;
 		} else {
 			inp_x_size.enable();

--- a/gui/gui_theme.cc
+++ b/gui/gui_theme.cc
@@ -491,8 +491,11 @@ bool gui_theme_t::themes_init(const char *file_name, bool init_fonts, bool init_
 		gui_theme_t::gui_button_text_offset_right = scr_coord(button_text_offsets[2], 0);
 	}
 
-	// default iconsize (square for now)
-	env_t::iconsize.h = env_t::iconsize.w = contents.get_int("icon_width",env_t::iconsize.w );
+	// default iconsize (square for now); once the pak's menuconf.tab has set this
+	// (see tool_t::read_menu()), later theme (re)loads must not reset it
+	if(  !env_t::iconsize_set_by_pak  ) {
+		env_t::iconsize.h = env_t::iconsize.w = contents.get_int("icon_width",env_t::iconsize.w );
+	}
 
 	// maybe not the best place, rather use simwin for the static defines?
 	gui_theme_t::gui_color_text                         = (PIXVAL)contents.get_color("gui_color_text", SYSCOL_TEXT);

--- a/gui/simwin.cc
+++ b/gui/simwin.cc
@@ -1779,8 +1779,13 @@ void win_display_flush(double konto)
 
 	// display main menu
 	tool_selector_t *main_menu = tool_t::toolbar_tool[0]->get_tool_selector();
+	const uint32 menu_tool_count = main_menu->get_tool_count();
+	// reserve the scrollbar strip only if the icons actually overflow the
+	// available space, so a short/empty menubar doesn't grow for nothing
+	bool menu_scrollbar = env_t::iconsize.w > 0  &&  (uint32)disp_width < menu_tool_count * (uint32)env_t::iconsize.w;
+	scr_coord_val extra = menu_scrollbar ? env_t::menu_scrollbar_thickness : 0;
 	scr_coord menu_pos(0,0);
-	scr_size menu_size(disp_width, env_t::iconsize.h + env_t::menu_scrollbar_thickness);
+	scr_size menu_size(disp_width, env_t::iconsize.h + extra);
 	scr_rect clip_rr(0, menu_size.h, disp_width, disp_height - menu_size.h);
 	switch (env_t::menupos) {
 		case MENU_TOP:
@@ -1793,16 +1798,24 @@ void win_display_flush(double konto)
 			// size default
 			clip_rr.y = 0;
 			break;
-		case MENU_LEFT:
+		case MENU_LEFT: {
 			// pos default (see above)
-			menu_size = scr_size(env_t::iconsize.w + env_t::menu_scrollbar_thickness, disp_height-win_get_statusbar_height()-show_ticker*TICKER_HEIGHT);
+			const scr_coord_val avail_h = disp_height-win_get_statusbar_height()-show_ticker*TICKER_HEIGHT;
+			menu_scrollbar = env_t::iconsize.h > 0  &&  (uint32)avail_h < menu_tool_count * (uint32)env_t::iconsize.h;
+			extra = menu_scrollbar ? env_t::menu_scrollbar_thickness : 0;
+			menu_size = scr_size(env_t::iconsize.w + extra, avail_h);
 			clip_rr = scr_rect(menu_size.w, 0, disp_width - menu_size.w, disp_height);
 			break;
-		case MENU_RIGHT:
-			menu_size = scr_size(env_t::iconsize.w + env_t::menu_scrollbar_thickness, disp_height - win_get_statusbar_height()-show_ticker*TICKER_HEIGHT );
+		}
+		case MENU_RIGHT: {
+			const scr_coord_val avail_h = disp_height-win_get_statusbar_height()-show_ticker*TICKER_HEIGHT;
+			menu_scrollbar = env_t::iconsize.h > 0  &&  (uint32)avail_h < menu_tool_count * (uint32)env_t::iconsize.h;
+			extra = menu_scrollbar ? env_t::menu_scrollbar_thickness : 0;
+			menu_size = scr_size(env_t::iconsize.w + extra, avail_h);
 			menu_pos.x = disp_width - menu_size.w;
 			clip_rr = scr_rect(0, 0, disp_width - menu_size.w, disp_height);
 			break;
+		}
 	}
 
 	display_set_clip_wh( menu_pos.x, menu_pos.y, menu_size.w, menu_size.h );

--- a/gui/simwin.cc
+++ b/gui/simwin.cc
@@ -710,8 +710,9 @@ int create_win(gui_frame_t* const gui, wintype const wt, ptrdiff_t const magic)
  */
 void win_clamp_xywh_position( scr_coord_val &x, scr_coord_val &y, scr_size wh, bool move_topleft )
 {
-	scr_coord_val add_menuwidth = env_t::iconsize.w + env_t::menu_scrollbar_thickness;
-	scr_coord_val add_menuheight = env_t::iconsize.h + env_t::menu_scrollbar_thickness;
+	const scr_coord_val menu_extra = get_main_menu_scrollbar_extra();
+	scr_coord_val add_menuwidth = env_t::iconsize.w + menu_extra;
+	scr_coord_val add_menuheight = env_t::iconsize.h + menu_extra;
 
 	scr_rect clip_rr(0, add_menuheight, display_get_width(), display_get_height() - add_menuwidth - win_get_statusbar_height());
 	switch (env_t::menupos) {
@@ -758,7 +759,7 @@ void calculate_window_pos(scr_coord_val &x, scr_coord_val &y, bool &move_to_full
 		return;
 	}
 
-	sint16 const menu_height = env_t::iconsize.h + env_t::menu_scrollbar_thickness;
+	sint16 const menu_height = env_t::iconsize.h + get_main_menu_scrollbar_extra();
 	// try to keep the toolbar below all other toolbars
 	// we go for left
 	x = 0;
@@ -872,7 +873,7 @@ int create_win(scr_coord_val x, scr_coord_val y, gui_frame_t* const gui, wintype
 		// use default width
 		stored.clip_lefttop(scr_size(D_DEFAULT_WIDTH, D_DEFAULT_HEIGHT));
 		// clip to display size
-		stored.clip_rightbottom( scr_size(display_get_width(), display_get_height() - env_t::iconsize.h - env_t::menu_scrollbar_thickness - win_get_statusbar_height() ) );
+		stored.clip_rightbottom( scr_size(display_get_width(), display_get_height() - env_t::iconsize.h - get_main_menu_scrollbar_extra() - win_get_statusbar_height() ) );
 
 		if (stored != gui->get_windowsize()) {
 			// send tailored resize event
@@ -1264,10 +1265,13 @@ void snap_check_win( const int win, scr_coord *r, const scr_coord from_pos, cons
 
 		if(  i==wins_count  ) {
 			// Allow snap to screen edge
-			other_pos.x = (env_t::menupos==MENU_LEFT)*(env_t::iconsize.w+env_t::menu_scrollbar_thickness);
-			other_pos.y = (env_t::menupos==MENU_TOP)*(env_t::iconsize.h+env_t::menu_scrollbar_thickness) + (env_t::menupos==MENU_BOTTOM)*win_get_statusbar_height();
-			other_size.x = display_get_width() - other_pos.x - (env_t::menupos==MENU_RIGHT)*(env_t::iconsize.w+env_t::menu_scrollbar_thickness);
-			other_size.y = display_get_height()-win_get_statusbar_height()-env_t::iconsize.h-env_t::menu_scrollbar_thickness;
+			{
+				const scr_coord_val menu_extra = get_main_menu_scrollbar_extra();
+				other_pos.x = (env_t::menupos==MENU_LEFT)*(env_t::iconsize.w+menu_extra);
+				other_pos.y = (env_t::menupos==MENU_TOP)*(env_t::iconsize.h+menu_extra) + (env_t::menupos==MENU_BOTTOM)*win_get_statusbar_height();
+				other_size.x = display_get_width() - other_pos.x - (env_t::menupos==MENU_RIGHT)*(env_t::iconsize.w+menu_extra);
+				other_size.y = display_get_height()-win_get_statusbar_height()-env_t::iconsize.h-menu_extra;
+			}
 			if(  show_ticker  ) {
 				other_size.y -= TICKER_HEIGHT;
 			}
@@ -1518,7 +1522,8 @@ bool check_pos_win(event_t *ev)
 	}
 
 	// click in main menu?
-	scr_coord menuoffset((env_t::menupos == MENU_RIGHT) * (display_get_width() - env_t::iconsize.w - env_t::menu_scrollbar_thickness), (env_t::menupos == MENU_BOTTOM) * (display_get_height() - env_t::iconsize.h - env_t::menu_scrollbar_thickness) - D_TITLEBAR_HEIGHT);
+	const scr_coord_val menu_click_extra = get_main_menu_scrollbar_extra();
+	scr_coord menuoffset((env_t::menupos == MENU_RIGHT) * (display_get_width() - env_t::iconsize.w - menu_click_extra), (env_t::menupos == MENU_BOTTOM) * (display_get_height() - env_t::iconsize.h - menu_click_extra) - D_TITLEBAR_HEIGHT);
 	if (!tool_t::toolbar_tool.empty()  &&
 		tool_t::toolbar_tool[0]->get_tool_selector()  &&
 		tool_t::toolbar_tool[0]->get_tool_selector()->is_hit(x-menuoffset.x, y-menuoffset.y)  &&
@@ -1772,6 +1777,29 @@ uint16 win_get_statusbar_height()
 }
 
 // finally updates the display
+// see declaration in simwin.h
+scr_coord_val get_main_menu_scrollbar_extra()
+{
+	if(  env_t::iconsize.w <= 0  ||  env_t::iconsize.h <= 0  ||  tool_t::toolbar_tool.empty()  ) {
+		return 0;
+	}
+	tool_selector_t *main_menu = tool_t::toolbar_tool[0]->get_tool_selector();
+	if(  !main_menu  ) {
+		return 0;
+	}
+	const uint32 menu_tool_count = main_menu->get_tool_count();
+	bool menu_scrollbar;
+	if(  env_t::menupos==MENU_TOP  ||  env_t::menupos==MENU_BOTTOM  ) {
+		menu_scrollbar = (uint32)display_get_width() < menu_tool_count * (uint32)env_t::iconsize.w;
+	}
+	else {
+		const scr_coord_val avail_h = display_get_height()-win_get_statusbar_height()-show_ticker*TICKER_HEIGHT;
+		menu_scrollbar = (uint32)avail_h < menu_tool_count * (uint32)env_t::iconsize.h;
+	}
+	return menu_scrollbar ? env_t::menu_scrollbar_thickness : 0;
+}
+
+
 void win_display_flush(double konto)
 {
 	const sint16 disp_width = display_get_width();
@@ -1779,11 +1807,9 @@ void win_display_flush(double konto)
 
 	// display main menu
 	tool_selector_t *main_menu = tool_t::toolbar_tool[0]->get_tool_selector();
-	const uint32 menu_tool_count = main_menu->get_tool_count();
 	// reserve the scrollbar strip only if the icons actually overflow the
 	// available space, so a short/empty menubar doesn't grow for nothing
-	bool menu_scrollbar = env_t::iconsize.w > 0  &&  (uint32)disp_width < menu_tool_count * (uint32)env_t::iconsize.w;
-	scr_coord_val extra = menu_scrollbar ? env_t::menu_scrollbar_thickness : 0;
+	const scr_coord_val extra = get_main_menu_scrollbar_extra();
 	scr_coord menu_pos(0,0);
 	scr_size menu_size(disp_width, env_t::iconsize.h + extra);
 	scr_rect clip_rr(0, menu_size.h, disp_width, disp_height - menu_size.h);
@@ -1801,16 +1827,12 @@ void win_display_flush(double konto)
 		case MENU_LEFT: {
 			// pos default (see above)
 			const scr_coord_val avail_h = disp_height-win_get_statusbar_height()-show_ticker*TICKER_HEIGHT;
-			menu_scrollbar = env_t::iconsize.h > 0  &&  (uint32)avail_h < menu_tool_count * (uint32)env_t::iconsize.h;
-			extra = menu_scrollbar ? env_t::menu_scrollbar_thickness : 0;
 			menu_size = scr_size(env_t::iconsize.w + extra, avail_h);
 			clip_rr = scr_rect(menu_size.w, 0, disp_width - menu_size.w, disp_height);
 			break;
 		}
 		case MENU_RIGHT: {
 			const scr_coord_val avail_h = disp_height-win_get_statusbar_height()-show_ticker*TICKER_HEIGHT;
-			menu_scrollbar = env_t::iconsize.h > 0  &&  (uint32)avail_h < menu_tool_count * (uint32)env_t::iconsize.h;
-			extra = menu_scrollbar ? env_t::menu_scrollbar_thickness : 0;
 			menu_size = scr_size(env_t::iconsize.w + extra, avail_h);
 			menu_pos.x = disp_width - menu_size.w;
 			clip_rr = scr_rect(0, 0, disp_width - menu_size.w, disp_height);
@@ -1852,7 +1874,7 @@ void win_display_flush(double konto)
 	}
 
 	if(  skinverwaltung_t::compass_iso  &&  env_t::compass_screen_position  ) {
-		display_img_aligned( skinverwaltung_t::compass_iso->get_image_id( wl->get_settings().get_rotation() ), scr_rect(D_MARGIN_LEFT, env_t::iconsize.h+env_t::menu_scrollbar_thickness+D_MARGIN_TOP,disp_width-2*4,disp_height- env_t::iconsize.h -env_t::menu_scrollbar_thickness -D_MARGIN_TOP-D_MARGIN_BOTTOM-win_get_statusbar_height()-(TICKER_HEIGHT)*show_ticker), env_t::compass_screen_position, false );
+		display_img_aligned( skinverwaltung_t::compass_iso->get_image_id( wl->get_settings().get_rotation() ), scr_rect(D_MARGIN_LEFT, env_t::iconsize.h+extra+D_MARGIN_TOP,disp_width-2*4,disp_height- env_t::iconsize.h -extra -D_MARGIN_TOP-D_MARGIN_BOTTOM-win_get_statusbar_height()-(TICKER_HEIGHT)*show_ticker), env_t::compass_screen_position, false );
 	}
 
 	{

--- a/gui/simwin.cc
+++ b/gui/simwin.cc
@@ -710,8 +710,8 @@ int create_win(gui_frame_t* const gui, wintype const wt, ptrdiff_t const magic)
  */
 void win_clamp_xywh_position( scr_coord_val &x, scr_coord_val &y, scr_size wh, bool move_topleft )
 {
-	scr_coord_val add_menuwidth = env_t::iconsize.w;
-	scr_coord_val add_menuheight = env_t::iconsize.h;
+	scr_coord_val add_menuwidth = env_t::iconsize.w + env_t::menu_scrollbar_thickness;
+	scr_coord_val add_menuheight = env_t::iconsize.h + env_t::menu_scrollbar_thickness;
 
 	scr_rect clip_rr(0, add_menuheight, display_get_width(), display_get_height() - add_menuwidth - win_get_statusbar_height());
 	switch (env_t::menupos) {
@@ -758,7 +758,7 @@ void calculate_window_pos(scr_coord_val &x, scr_coord_val &y, bool &move_to_full
 		return;
 	}
 
-	sint16 const menu_height = env_t::iconsize.h;
+	sint16 const menu_height = env_t::iconsize.h + env_t::menu_scrollbar_thickness;
 	// try to keep the toolbar below all other toolbars
 	// we go for left
 	x = 0;
@@ -872,7 +872,7 @@ int create_win(scr_coord_val x, scr_coord_val y, gui_frame_t* const gui, wintype
 		// use default width
 		stored.clip_lefttop(scr_size(D_DEFAULT_WIDTH, D_DEFAULT_HEIGHT));
 		// clip to display size
-		stored.clip_rightbottom( scr_size(display_get_width(), display_get_height() - env_t::iconsize.h - win_get_statusbar_height() ) );
+		stored.clip_rightbottom( scr_size(display_get_width(), display_get_height() - env_t::iconsize.h - env_t::menu_scrollbar_thickness - win_get_statusbar_height() ) );
 
 		if (stored != gui->get_windowsize()) {
 			// send tailored resize event
@@ -1264,10 +1264,10 @@ void snap_check_win( const int win, scr_coord *r, const scr_coord from_pos, cons
 
 		if(  i==wins_count  ) {
 			// Allow snap to screen edge
-			other_pos.x = (env_t::menupos==MENU_LEFT)*env_t::iconsize.w;
-			other_pos.y = (env_t::menupos==MENU_TOP)*env_t::iconsize.h + (env_t::menupos==MENU_BOTTOM)*win_get_statusbar_height();
-			other_size.x = display_get_width() - other_pos.x - (env_t::menupos==MENU_RIGHT)*env_t::iconsize.w;
-			other_size.y = display_get_height()-win_get_statusbar_height()-env_t::iconsize.h;
+			other_pos.x = (env_t::menupos==MENU_LEFT)*(env_t::iconsize.w+env_t::menu_scrollbar_thickness);
+			other_pos.y = (env_t::menupos==MENU_TOP)*(env_t::iconsize.h+env_t::menu_scrollbar_thickness) + (env_t::menupos==MENU_BOTTOM)*win_get_statusbar_height();
+			other_size.x = display_get_width() - other_pos.x - (env_t::menupos==MENU_RIGHT)*(env_t::iconsize.w+env_t::menu_scrollbar_thickness);
+			other_size.y = display_get_height()-win_get_statusbar_height()-env_t::iconsize.h-env_t::menu_scrollbar_thickness;
 			if(  show_ticker  ) {
 				other_size.y -= TICKER_HEIGHT;
 			}
@@ -1518,7 +1518,7 @@ bool check_pos_win(event_t *ev)
 	}
 
 	// click in main menu?
-	scr_coord menuoffset((env_t::menupos == MENU_RIGHT) * (display_get_width() - env_t::iconsize.w), (env_t::menupos == MENU_BOTTOM) * (display_get_height() - env_t::iconsize.h) - D_TITLEBAR_HEIGHT);
+	scr_coord menuoffset((env_t::menupos == MENU_RIGHT) * (display_get_width() - env_t::iconsize.w - env_t::menu_scrollbar_thickness), (env_t::menupos == MENU_BOTTOM) * (display_get_height() - env_t::iconsize.h - env_t::menu_scrollbar_thickness) - D_TITLEBAR_HEIGHT);
 	if (!tool_t::toolbar_tool.empty()  &&
 		tool_t::toolbar_tool[0]->get_tool_selector()  &&
 		tool_t::toolbar_tool[0]->get_tool_selector()->is_hit(x-menuoffset.x, y-menuoffset.y)  &&
@@ -1780,8 +1780,8 @@ void win_display_flush(double konto)
 	// display main menu
 	tool_selector_t *main_menu = tool_t::toolbar_tool[0]->get_tool_selector();
 	scr_coord menu_pos(0,0);
-	scr_size menu_size(disp_width, env_t::iconsize.h);
-	scr_rect clip_rr(0, env_t::iconsize.h, disp_width, disp_height - env_t::iconsize.h);
+	scr_size menu_size(disp_width, env_t::iconsize.h + env_t::menu_scrollbar_thickness);
+	scr_rect clip_rr(0, menu_size.h, disp_width, disp_height - menu_size.h);
 	switch (env_t::menupos) {
 		case MENU_TOP:
 			// pos default (see above)
@@ -1789,19 +1789,19 @@ void win_display_flush(double konto)
 			// rect default
 			break;
 		case MENU_BOTTOM:
-			menu_pos = scr_coord(0, disp_height - env_t::iconsize.h);
+			menu_pos = scr_coord(0, disp_height - menu_size.h);
 			// size default
 			clip_rr.y = 0;
 			break;
 		case MENU_LEFT:
 			// pos default (see above)
-			menu_size = scr_size(env_t::iconsize.w, disp_height-win_get_statusbar_height()-show_ticker*TICKER_HEIGHT);
-			clip_rr = scr_rect(env_t::iconsize.h, 0, disp_width - env_t::iconsize.w, disp_height);
+			menu_size = scr_size(env_t::iconsize.w + env_t::menu_scrollbar_thickness, disp_height-win_get_statusbar_height()-show_ticker*TICKER_HEIGHT);
+			clip_rr = scr_rect(menu_size.w, 0, disp_width - menu_size.w, disp_height);
 			break;
 		case MENU_RIGHT:
-			menu_pos.x = disp_width - env_t::iconsize.w;
-			menu_size = scr_size(env_t::iconsize.w, disp_height - win_get_statusbar_height()-show_ticker*TICKER_HEIGHT );
-			clip_rr = scr_rect(0, 0, disp_width - env_t::iconsize.w, disp_height);
+			menu_size = scr_size(env_t::iconsize.w + env_t::menu_scrollbar_thickness, disp_height - win_get_statusbar_height()-show_ticker*TICKER_HEIGHT );
+			menu_pos.x = disp_width - menu_size.w;
+			clip_rr = scr_rect(0, 0, disp_width - menu_size.w, disp_height);
 			break;
 	}
 
@@ -1839,7 +1839,7 @@ void win_display_flush(double konto)
 	}
 
 	if(  skinverwaltung_t::compass_iso  &&  env_t::compass_screen_position  ) {
-		display_img_aligned( skinverwaltung_t::compass_iso->get_image_id( wl->get_settings().get_rotation() ), scr_rect(D_MARGIN_LEFT, env_t::iconsize.h+D_MARGIN_TOP,disp_width-2*4,disp_height- env_t::iconsize.h -D_MARGIN_TOP-D_MARGIN_BOTTOM-win_get_statusbar_height()-(TICKER_HEIGHT)*show_ticker), env_t::compass_screen_position, false );
+		display_img_aligned( skinverwaltung_t::compass_iso->get_image_id( wl->get_settings().get_rotation() ), scr_rect(D_MARGIN_LEFT, env_t::iconsize.h+env_t::menu_scrollbar_thickness+D_MARGIN_TOP,disp_width-2*4,disp_height- env_t::iconsize.h -env_t::menu_scrollbar_thickness -D_MARGIN_TOP-D_MARGIN_BOTTOM-win_get_statusbar_height()-(TICKER_HEIGHT)*show_ticker), env_t::compass_screen_position, false );
 	}
 
 	{

--- a/gui/simwin.h
+++ b/gui/simwin.h
@@ -199,6 +199,12 @@ void win_display_flush(double konto); // draw the frame and all windows
 
 uint16 win_get_statusbar_height();
 
+// extra thickness (0 or env_t::menu_scrollbar_thickness) currently reserved for the
+// main menubar's scrollbar strip on the given side, i.e. whether the icons actually
+// overflow the available space for the current env_t::menupos; shared by win_display_flush()
+// and main_view_t::display() so the map view and the menu/window clip stay in sync
+scr_coord_val get_main_menu_scrollbar_extra();
+
 void win_poll_event(event_t*);
 
 bool win_change_zoom_factor(bool magnify);

--- a/gui/tool_selector.cc
+++ b/gui/tool_selector.cc
@@ -163,6 +163,22 @@ void tool_selector_t::get_scroll_metrics(bool &horizontal, sint32 &unit, sint32 
 
 bool tool_selector_t::infowin_event(const event_t *ev)
 {
+	// mouse-wheel scrolling anywhere over the toolbar moves the scrollbar by one unit
+	if(  has_prev_next  &&  (IS_WHEELUP(ev)  ||  IS_WHEELDOWN(ev))  ) {
+		bool horizontal;
+		sint32 unit, visible_units, total_units;
+		get_scroll_metrics( horizontal, unit, visible_units, total_units );
+		sint32 cur_unit = unit>0 ? tool_icon_disp_start/unit : 0;
+		cur_unit += IS_WHEELDOWN(ev) ? 1 : -1;
+		cur_unit = clamp( cur_unit, 0, max(0,total_units-visible_units) );
+		tool_icon_disp_start = (uint16)(cur_unit*unit);
+		offset.x = 0;
+		offset.y = 0;
+		tool_icon_disp_end = min( (uint32)tool_icon_disp_start + (uint32)tool_icon_width*tool_icon_height, (uint32)tools.get_count() );
+		dirty = true;
+		return true;
+	}
+
 	// every toolbar (main menubar and popup icon-list windows alike) shows a thin,
 	// continuously draggable scrollbar strip outside the icon area when it overflows
 	// (see get_scrollbar_rect()); handle clicks/drags on it here

--- a/gui/tool_selector.cc
+++ b/gui/tool_selector.cc
@@ -32,6 +32,7 @@ tool_selector_t::tool_selector_t(const char* title, const char *help_file, uint3
 	this->title = title;
 	has_prev_next = false;
 	is_dragging = false;
+	is_scrollbar_dragging = false;
 	offset = scr_coord( 0, 0 );
 	set_windowsize( scr_size(max(env_t::iconsize.w,MIN_WIDTH), D_TITLEBAR_HEIGHT) );
 	dirty = true;
@@ -74,10 +75,21 @@ DBG_DEBUG4("tool_selector_t::add_tool()","ww=%i, rows=%i",ww,rows);
 		tool_icon_height = min(tool_icon_height, env_t::toolbar_max_height);
 	}
 	dirty = true;
-	set_windowsize( scr_size( tool_icon_width*env_t::iconsize.w, min(tool_icon_height, ((tools.get_count()-1)/tool_icon_width)+1)*env_t::iconsize.h+D_TITLEBAR_HEIGHT ) );
+	has_prev_next = ((uint32)tool_icon_width*tool_icon_height < tools.get_count());
+	scr_size winsize( tool_icon_width*env_t::iconsize.w, min(tool_icon_height, ((tools.get_count()-1)/tool_icon_width)+1)*env_t::iconsize.h+D_TITLEBAR_HEIGHT );
+	if(  has_prev_next  ) {
+		// reserve space for a scrollbar strip just outside the icon grid:
+		// below it for a single row, beside it for a column/multi-row grid
+		if(  tool_icon_height == 1  ) {
+			winsize.h += env_t::menu_scrollbar_thickness;
+		}
+		else {
+			winsize.w += env_t::menu_scrollbar_thickness;
+		}
+	}
+	set_windowsize( winsize );
 	tool_icon_disp_start = 0;
 	tool_icon_disp_end = min( tool_icon_disp_start+tool_icon_width*tool_icon_height, tools.get_count() );
-	has_prev_next = ((uint32)tool_icon_width*tool_icon_height < tools.get_count());
 
 DBG_DEBUG4("tool_selector_t::add_tool()", "at position %i (width %i)", tools.get_count(), tool_icon_width);
 }
@@ -92,11 +104,16 @@ void tool_selector_t::reset_tools()
 	tool_icon_disp_start = 0;
 	tool_icon_disp_end = 0;
 	offset = scr_coord( 0, 0 );
+	is_scrollbar_dragging = false;
 }
 
 
 bool tool_selector_t::is_hit(int x, int y)
 {
+	if(  has_prev_next  &&  get_scrollbar_rect().contains( scr_coord(x,y) )  ) {
+		return true;
+	}
+
 	int dx = (x-offset.x)/env_t::iconsize.w;
 	int dy = (y-D_TITLEBAR_HEIGHT-offset.y)/env_t::iconsize.h;
 
@@ -108,8 +125,84 @@ bool tool_selector_t::is_hit(int x, int y)
 }
 
 
+// window-relative rect of the scrollbar strip: below the icon row for a single-row
+// toolbar, or beside the icon column(s) otherwise. Only meaningful when has_prev_next.
+scr_rect tool_selector_t::get_scrollbar_rect() const
+{
+	const scr_size sz = get_windowsize();
+	if(  tool_icon_height == 1  ) {
+		return scr_rect( 0, D_TITLEBAR_HEIGHT + env_t::iconsize.h, sz.w, env_t::menu_scrollbar_thickness );
+	}
+	else {
+		return scr_rect( tool_icon_width*env_t::iconsize.w, D_TITLEBAR_HEIGHT, env_t::menu_scrollbar_thickness, sz.h - D_TITLEBAR_HEIGHT );
+	}
+}
+
+
+void tool_selector_t::get_scroll_metrics(bool &horizontal, sint32 &unit, sint32 &visible_units, sint32 &total_units) const
+{
+	horizontal = (tool_icon_height == 1);
+	if(  horizontal  ) {
+		unit = 1;
+		visible_units = tool_icon_width;
+		total_units = (sint32)tools.get_count();
+	}
+	else if(  tool_icon_width == 1  ) {
+		unit = 1;
+		visible_units = tool_icon_height;
+		total_units = (sint32)tools.get_count();
+	}
+	else {
+		// a multi-column grid scrolls by whole rows, so columns stay aligned
+		unit = tool_icon_width;
+		visible_units = tool_icon_height;
+		total_units = ((sint32)tools.get_count() + tool_icon_width - 1) / tool_icon_width;
+	}
+}
+
+
 bool tool_selector_t::infowin_event(const event_t *ev)
 {
+	// every toolbar (main menubar and popup icon-list windows alike) shows a thin,
+	// continuously draggable scrollbar strip outside the icon area when it overflows
+	// (see get_scrollbar_rect()); handle clicks/drags on it here
+	if(  has_prev_next  &&  (IS_LEFTCLICK(ev)  ||  IS_LEFTDRAG(ev)  ||  is_scrollbar_dragging)  ) {
+		const scr_rect track = get_scrollbar_rect();
+		bool horizontal;
+		sint32 unit, visible_units, total_units;
+		get_scroll_metrics( horizontal, unit, visible_units, total_units );
+
+		bool hit_now = false;
+		if(  !is_scrollbar_dragging  ) {
+			hit_now = track.contains( scr_coord(ev->cx, ev->cy) );
+		}
+		if(  is_scrollbar_dragging  ||  hit_now  ) {
+			is_scrollbar_dragging = true;
+			sint32 cur_unit;
+			if(  horizontal  ) {
+				const scr_coord_val thumb_w = max( (scr_coord_val)8, (scr_coord_val)( (sint64)track.w * visible_units / max(1,total_units) ) );
+				const scr_coord_val avail = track.w - thumb_w;
+				const scr_coord_val target_x = clamp( (scr_coord_val)(ev->mx - track.x - thumb_w/2), (scr_coord_val)0, max((scr_coord_val)0,avail) );
+				cur_unit = (avail>0  &&  total_units>visible_units) ? (sint32)( (sint64)target_x * (total_units-visible_units) / avail ) : 0;
+			}
+			else {
+				const scr_coord_val thumb_h = max( (scr_coord_val)8, (scr_coord_val)( (sint64)track.h * visible_units / max(1,total_units) ) );
+				const scr_coord_val avail = track.h - thumb_h;
+				const scr_coord_val target_y = clamp( (scr_coord_val)(ev->my - track.y - thumb_h/2), (scr_coord_val)0, max((scr_coord_val)0,avail) );
+				cur_unit = (avail>0  &&  total_units>visible_units) ? (sint32)( (sint64)target_y * (total_units-visible_units) / avail ) : 0;
+			}
+			cur_unit = clamp( cur_unit, 0, max(0,total_units-visible_units) );
+			tool_icon_disp_start = (uint16)(cur_unit*unit);
+			offset.x = 0;
+			offset.y = 0;
+			tool_icon_disp_end = min( (uint32)tool_icon_disp_start + (uint32)tool_icon_width*tool_icon_height, (uint32)tools.get_count() );
+			if(  !IS_LEFTRELEASE(ev)  &&  ev->button_state != 1  ) {
+				is_scrollbar_dragging = false;
+			}
+			return true;
+		}
+	}
+
 	if(  has_prev_next  &&  (IS_LEFTDRAG(ev)  ||  is_dragging)  ) {
 		if( !is_dragging ) {
 			old_offset = offset;
@@ -294,7 +387,7 @@ void tool_selector_t::draw(scr_coord pos, scr_size sz)
 			tool_icon_width = 1;
 			// only single column for title bar
 			tool_icon_height = (display_get_height() - win_get_statusbar_height() + env_t::iconsize.h - 1) / env_t::iconsize.h;
-			set_windowsize(scr_size(env_t::iconsize.w, display_get_height() - win_get_statusbar_height()));
+			set_windowsize(scr_size(env_t::iconsize.w + env_t::menu_scrollbar_thickness, display_get_height() - win_get_statusbar_height()));
 
 			if ( display_get_height() >= (int)tools.get_count() * env_t::iconsize.h  ) {
 				tool_icon_disp_start = 0;
@@ -367,7 +460,35 @@ void tool_selector_t::draw(scr_coord pos, scr_size sz)
 		display_color_img( gui_theme_t::arrow_button_right_img[0], pos.x+sz.w-D_ARROW_UP_WIDTH, pos.y+D_TITLEBAR_HEIGHT, 0, false, false );
 	}
 	if(  tool_icon_width == 1  &&  (tool_icon_disp_start+tool_icon_height < tools.get_count()  ||  (-offset.y) < env_t::iconsize.h*tool_icon_height-get_windowsize().h)  ) {
-		display_color_img(gui_theme_t::arrow_button_down_img[0], pos.x+sz.w-D_ARROW_DOWN_WIDTH, pos.y+D_TITLEBAR_HEIGHT+sz.h-D_ARROW_DOWN_HEIGHT, 0, false, false);
+		// anchored to the icon column's own width, not sz.w, since sz.w may now
+		// include the extra scrollbar strip reserved beside a vertical toolbar
+		display_color_img(gui_theme_t::arrow_button_down_img[0], pos.x+tool_icon_width*env_t::iconsize.w-D_ARROW_DOWN_WIDTH, pos.y+D_TITLEBAR_HEIGHT+sz.h-D_ARROW_DOWN_HEIGHT, 0, false, false);
+	}
+
+	// scrollbar strip, drawn just outside the icon area (below a single row,
+	// beside a column/grid) rather than overlaid on the icons themselves;
+	// shown for both the main menubar and popup icon-list windows
+	if(  has_prev_next  ) {
+		const scr_rect track = get_scrollbar_rect();
+		bool horizontal;
+		sint32 unit, visible_units, total_units;
+		get_scroll_metrics( horizontal, unit, visible_units, total_units );
+		const sint32 cur_unit = unit>0 ? tool_icon_disp_start/unit : 0;
+
+		if(  horizontal  ) {
+			const scr_coord_val thumb_w = max( (scr_coord_val)8, (scr_coord_val)( (sint64)track.w * visible_units / max(1,total_units) ) );
+			const scr_coord_val avail = track.w - thumb_w;
+			const scr_coord_val thumb_x = (avail>0  &&  total_units>visible_units) ? clamp( (scr_coord_val)( (sint64)avail * cur_unit / (total_units-visible_units) ), (scr_coord_val)0, avail ) : 0;
+			display_fillbox_wh_clip_rgb( pos.x+track.x, pos.y+track.y, track.w, track.h, color_idx_to_rgb(MN_GREY1), true );
+			display_fillbox_wh_clip_rgb( pos.x+track.x+thumb_x, pos.y+track.y, thumb_w, track.h, color_idx_to_rgb(MN_GREY4), true );
+		}
+		else {
+			const scr_coord_val thumb_h = max( (scr_coord_val)8, (scr_coord_val)( (sint64)track.h * visible_units / max(1,total_units) ) );
+			const scr_coord_val avail = track.h - thumb_h;
+			const scr_coord_val thumb_y = (avail>0  &&  total_units>visible_units) ? clamp( (scr_coord_val)( (sint64)avail * cur_unit / (total_units-visible_units) ), (scr_coord_val)0, avail ) : 0;
+			display_fillbox_wh_clip_rgb( pos.x+track.x, pos.y+track.y, track.w, track.h, color_idx_to_rgb(MN_GREY1), true );
+			display_fillbox_wh_clip_rgb( pos.x+track.x, pos.y+track.y+thumb_y, track.w, thumb_h, color_idx_to_rgb(MN_GREY4), true );
+		}
 	}
 
 	if(  !is_dragging  ) {

--- a/gui/tool_selector.cc
+++ b/gui/tool_selector.cc
@@ -45,6 +45,12 @@ tool_selector_t::tool_selector_t(const char* title, const char *help_file, uint3
  */
 void tool_selector_t::add_tool_selector(tool_t *tool_in)
 {
+	if(  env_t::iconsize.w <= 0  ||  env_t::iconsize.h <= 0  ) {
+		// icons disabled (icon_height<=0 in menuconf.tab): do not add anything,
+		// bail out before any division by iconsize below
+		return;
+	}
+
 	image_id tool_img = tool_in->get_icon(welt->get_active_player());
 	if(  tool_img == IMG_EMPTY  &&  tool_in!=tool_t::dummy  ) {
 		return;
@@ -110,6 +116,11 @@ void tool_selector_t::reset_tools()
 
 bool tool_selector_t::is_hit(int x, int y)
 {
+	if(  env_t::iconsize.w <= 0  ||  env_t::iconsize.h <= 0  ) {
+		// icons disabled: nothing to hit besides the (icon-less) titlebar
+		return x>=0  &&  y>=0  &&  y<D_TITLEBAR_HEIGHT  &&  x<get_windowsize().w;
+	}
+
 	if(  has_prev_next  &&  get_scrollbar_rect().contains( scr_coord(x,y) )  ) {
 		return true;
 	}
@@ -163,6 +174,16 @@ void tool_selector_t::get_scroll_metrics(bool &horizontal, sint32 &unit, sint32 
 
 bool tool_selector_t::infowin_event(const event_t *ev)
 {
+	if(  env_t::iconsize.w <= 0  ||  env_t::iconsize.h <= 0  ) {
+		// icons disabled (icon_height<=0): skip all icon-grid math below, since it
+		// divides by iconsize and would otherwise crash (or hang, for the sanity-check
+		// loops) with a zero or negative value
+		if(  ev->ev_class==INFOWIN  &&  (ev->ev_code==WIN_TOP  ||  ev->ev_code==WIN_OPEN)  ) {
+			set_name( translator::translate(title) );
+		}
+		return false;
+	}
+
 	// mouse-wheel scrolling anywhere over the toolbar moves the scrollbar by one unit
 	if(  has_prev_next  &&  (IS_WHEELUP(ev)  ||  IS_WHEELDOWN(ev))  ) {
 		bool horizontal;
@@ -373,6 +394,17 @@ bool tool_selector_t::infowin_event(const event_t *ev)
 
 void tool_selector_t::draw(scr_coord pos, scr_size sz)
 {
+	if(  env_t::iconsize.w <= 0  ||  env_t::iconsize.h <= 0  ) {
+		// icons disabled (icon_height<=0): skip all layout/draw math below, since
+		// it divides by iconsize and would otherwise crash. This runs every frame
+		// for the main menubar (toolbar_id==0), regardless of how many tools were
+		// ever added, so the guard must be unconditional and come first.
+		has_prev_next = false;
+		dirty = false;
+		unset_dirty();
+		return;
+	}
+
 	player_t *player = welt->get_active_player();
 
 	if( toolbar_id == 0 ) {

--- a/gui/tool_selector.h
+++ b/gui/tool_selector.h
@@ -45,6 +45,18 @@ private:
 
 	bool has_prev_next, is_dragging;
 
+	bool is_scrollbar_dragging;
+
+	// window-relative rect of the scrollbar strip (drawn just outside the icon
+	// area: below it for single-row toolbars, beside it otherwise); valid
+	// whenever has_prev_next is true
+	scr_rect get_scrollbar_rect() const;
+
+	// scroll axis and units for the scrollbar: horizontal iff a single icon row
+	// (menubar or a one-row popup), else vertical; for a multi-column grid, one
+	// unit is a whole row (tool_icon_width icons) so the columns stay aligned
+	void get_scroll_metrics(bool &horizontal, sint32 &unit, sint32 &visible_units, sint32 &total_units) const;
+
 	/**
 	 * Window title
 	 */

--- a/gui/tool_selector.h
+++ b/gui/tool_selector.h
@@ -86,6 +86,11 @@ public:
 	// untranslated title
 	const char *get_internal_name() const {return title;}
 
+	// number of (non-empty-icon) tools currently in this toolbar; used by simwin.cc
+	// to decide, before drawing, whether the main menubar needs to reserve space
+	// for a scrollbar strip
+	uint32 get_tool_count() const { return tools.get_count(); }
+
 	bool has_title() const OVERRIDE { return toolbar_id!=0; }
 
 	const char *get_help_filename() const OVERRIDE {return help_file;}

--- a/gui/welt.cc
+++ b/gui/welt.cc
@@ -465,7 +465,7 @@ bool welt_gui_t::action_triggered( gui_action_creator_t *comp,value_t v)
 		sets->heightfield = "";
 		load_relief_frame_t* lrf = new load_relief_frame_t(sets);
 		create_win(lrf, w_info, magic_load_t );
-		win_set_pos(lrf, (display_get_width() - lrf->get_windowsize().w-10), env_t::iconsize.h + env_t::menu_scrollbar_thickness);
+		win_set_pos(lrf, (display_get_width() - lrf->get_windowsize().w-10), env_t::iconsize.h + get_main_menu_scrollbar_extra());
 		knr = sets->get_map_number(); // otherwise using cancel would not show the normal generated map again
 	}
 	else if(comp==&use_intro_dates) {

--- a/gui/welt.cc
+++ b/gui/welt.cc
@@ -465,7 +465,7 @@ bool welt_gui_t::action_triggered( gui_action_creator_t *comp,value_t v)
 		sets->heightfield = "";
 		load_relief_frame_t* lrf = new load_relief_frame_t(sets);
 		create_win(lrf, w_info, magic_load_t );
-		win_set_pos(lrf, (display_get_width() - lrf->get_windowsize().w-10), env_t::iconsize.h);
+		win_set_pos(lrf, (display_get_width() - lrf->get_windowsize().w-10), env_t::iconsize.h + env_t::menu_scrollbar_thickness);
 		knr = sets->get_map_number(); // otherwise using cancel would not show the normal generated map again
 	}
 	else if(comp==&use_intro_dates) {

--- a/simmain.cc
+++ b/simmain.cc
@@ -1282,17 +1282,6 @@ int simu_main(int argc, char** argv)
 		script_tool_manager_t::load_scripts(("addons/" + env_t::objfilename + "tool/").c_str());
 	}
 
-	dbg->message("simu_main()","Reading menu configuration ...");
-	dr_chdir( env_t::data_dir );
-	if (!tool_t::read_menu(env_t::pak_dir + "config/menuconf.tab")) {
-		// Fatal error while reading menuconf.tab, we cannot continue!
-		dbg->fatal(
-			"Could not read %sconfig/menuconf.tab.\n"
-			"This file is required for a valid pak set (graphics).\n"
-			"Please install and select a valid pak set.",
-			env_t::pak_dir.c_str());
-	}
-
 #if COLOUR_DEPTH != 0
 	// reread theme
 	dr_chdir( env_t::user_dir );
@@ -1306,6 +1295,21 @@ int simu_main(int argc, char** argv)
 	}
 #endif
 	dr_chdir( env_t::data_dir );
+
+	// read_menu() must come after the theme (re)reads above: it overrides
+	// env_t::iconsize with the pak-specific icon_height from menuconf.tab
+	// (see tool_t::read_menu()), and it also builds the toolbar windows,
+	// which must use the final iconsize
+	dbg->message("simu_main()","Reading menu configuration ...");
+	dr_chdir( env_t::data_dir );
+	if (!tool_t::read_menu(env_t::pak_dir + "config/menuconf.tab")) {
+		// Fatal error while reading menuconf.tab, we cannot continue!
+		dbg->fatal(
+			"Could not read %sconfig/menuconf.tab.\n"
+			"This file is required for a valid pak set (graphics).\n"
+			"Please install and select a valid pak set.",
+			env_t::pak_dir.c_str());
+	}
 
 	if(  translator::get_language()==-1  ) {
 		// try current language

--- a/simmenu.cc
+++ b/simmenu.cc
@@ -681,8 +681,10 @@ bool tool_t::read_menu(const std::string &menuconf_path)
 	menuconf.read(contents);
 
 	// pak-specific icon size overrides the theme default; width is always equal
-	// to height, so only icon_height is read (icon_width in menuconf.tab, if present, is ignored)
-	env_t::iconsize.h = env_t::iconsize.w = contents.get_int("icon_height", env_t::iconsize.h);
+	// to height, so only icon_height is read (icon_width in menuconf.tab, if present, is ignored).
+	// once set here, later theme (re)loads must not reset it back to the theme's icon_width
+	env_t::iconsize.h = env_t::iconsize.w = contents.get_int_clamped("icon_height", env_t::iconsize.h, 0, 64);
+	env_t::iconsize_set_by_pak = true;
 
 	// structure to hold information for iterating through different tool types
 	struct tool_class_info_t {

--- a/simmenu.cc
+++ b/simmenu.cc
@@ -680,6 +680,10 @@ bool tool_t::read_menu(const std::string &menuconf_path)
 	tabfileobj_t contents;
 	menuconf.read(contents);
 
+	// pak-specific icon size overrides the theme default; width is always equal
+	// to height, so only icon_height is read (icon_width in menuconf.tab, if present, is ignored)
+	env_t::iconsize.h = env_t::iconsize.w = contents.get_int("icon_height", env_t::iconsize.h);
+
 	// structure to hold information for iterating through different tool types
 	struct tool_class_info_t {
 		const char* type;


### PR DESCRIPTION
ツールバー一覧の表示を改善しました
- ツールバー一覧にスクロールバーを設置し、表示範囲からはみ出している場合は従来の不安定なドラッグと左右ボタン以外にスクロールバーによる移動を可能に
- `menuconf.tab`に定義された`icon_height`を読み込み、アイコンの描画サイズを変更（これにより、環境に合わせてアイコンのサイズを修正できます）