### PR TITLE
BUG FIX: push stopping time and another values when next stop button pressed during loading

### DIFF
--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -6719,6 +6719,13 @@ void convoi_t::next_stop_button_pressed() {
 		if( !c->can_continue_coupling() || schedule->get_current_entry().is_uncouple_child() ) {
 			c->uncouple_convoi();
 		}
+		if(  c->is_loading()  ) {
+			c->push_goods_waiting_time_if_needed();
+			c->push_convoy_stopping_time();
+			c->set_coupling_done(false);
+			c->set_waiting_for_departure_allowance_by_other_convoy(false);
+			c->reset_departure_time();
+		}
 		c->change_line_to_next_if_needed();
 		c->schedule->advance();
 		dbg->message("convoi_t::next_stop_button_pressed()","the next stop is %i",schedule->get_current_entry());


### PR DESCRIPTION
駅停車中に`next stop`を押された場合に、駅の停車時間等の挿入処理を実行し、一部のフラグを上書きします。
これにより、所要時間ベース等への影響を減らし、フラグ書き換え忘れによる次駅発車不可などの不具合の危険性を防止します