### PR TITLE
Fix Windows GDI resize handling under DPI scaling

### DIFF
--- a/simevent.cc
+++ b/simevent.cc
@@ -293,5 +293,23 @@ void display_poll_event(event_t* const ev)
 
 void queue_event(event_t *events)
 {
+	// A window resize is current state, not history: only the newest client
+	// size is meaningful and an older one must never be applied after it. The
+	// loading screen stores the resizes it consumes and flushes them back here
+	// when destroyed, and the next loading screen consumes and stores them
+	// again, so without this an obsolete size is replayed and can be applied
+	// after the real one, leaving the renderer smaller than the window.
+	if(  events->ev_class == EVENT_SYSTEM  &&  events->ev_code == SYSTEM_RESIZE  ) {
+		for(  slist_tpl<event_t *>::iterator i = queued_events.begin();  i != queued_events.end();  ) {
+			event_t *old_ev = *i;
+			if(  old_ev->ev_class == EVENT_SYSTEM  &&  old_ev->ev_code == SYSTEM_RESIZE  ) {
+				i = queued_events.erase(i);
+				delete old_ev;
+			}
+			else {
+				++i;
+			}
+		}
+	}
 	queued_events.append(events);
 }

--- a/sys/simsys_w.cc
+++ b/sys/simsys_w.cc
@@ -319,8 +319,14 @@ int dr_textur_resize(unsigned short** const textur, int w, int const h)
 
 	AllDib->bmiHeader.biWidth  = img_w;
 	AllDib->bmiHeader.biHeight = img_h;
-	WindowSize.right           = (w*32)/x_scale;
-	WindowSize.bottom          = (h*32)/y_scale;
+	// WindowSize is in physical client pixels: dr_os_open fills it that way and
+	// WM_PAINT consumes it that way, both as the blit destination and to derive
+	// the framebuffer height. w and h arrive here in logical pixels, so they have
+	// to be scaled up, not down. Dividing by the scale only matched at 100%;
+	// above it every repaint after a resize painted into a rectangle smaller than
+	// the client area and overwrote biHeight with a framebuffer height too small.
+	WindowSize.right           = (w * x_scale) / 32;
+	WindowSize.bottom          = (h * y_scale) / 32;
 
 #ifdef MULTI_THREAD
 	LeaveCriticalSection( &redraw_underway );
@@ -484,6 +490,16 @@ static inline unsigned int ModifierKeys()
 }
 
 
+// The client size is state, not history. sys_event holds a single pending
+// event and one message retrieval can dispatch several messages (the sent
+// ones, WM_SIZE among them, before the posted one is returned), so a resize
+// written into the slot is lost when a later message of the same retrieval
+// overwrites it. Keep only the newest client size here and let GetEvents()
+// hand it to the slot as soon as the slot is free.
+static bool   resize_pending = false;
+static uint16 resize_pending_w = 0;
+static uint16 resize_pending_h = 0;
+
 /* Windows eventhandler: does most of the work */
 LRESULT WINAPI WindowProc(HWND this_hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
@@ -610,18 +626,20 @@ LRESULT WINAPI WindowProc(HWND this_hwnd, UINT msg, WPARAM wParam, LPARAM lParam
 
 		case WM_SIZE: // resize client area
 			if(lParam!=0) {
-				sys_event.type = SIM_SYSTEM;
-				sys_event.code = SYSTEM_RESIZE;
-
-				sys_event.new_window_size_w = (LOWORD(lParam)*32)/x_scale;
-				if (sys_event.new_window_size_w <= 0) {
-					sys_event.new_window_size_w = 4;
+				// only the newest size matters; GetEvents() delivers it
+				int w = (LOWORD(lParam)*32)/x_scale;
+				if (w <= 0) {
+					w = 4;
 				}
 
-				sys_event.new_window_size_h = (HIWORD(lParam)*32)/y_scale;
-				if (sys_event.new_window_size_h <= 1) {
-					sys_event.new_window_size_h = 64;
+				int h = (HIWORD(lParam)*32)/y_scale;
+				if (h <= 1) {
+					h = 64;
 				}
+
+				resize_pending_w = (uint16)w;
+				resize_pending_h = (uint16)h;
+				resize_pending   = true;
 			}
 			break;
 
@@ -942,6 +960,15 @@ static void internal_GetEvents(bool const wait)
 
 void GetEvents()
 {
+	if (sys_event.type==SIM_NOEVENT  &&  resize_pending) {
+		// the newest client size goes out before anything else is fetched
+		sys_event.type = SIM_SYSTEM;
+		sys_event.code = SYSTEM_RESIZE;
+		sys_event.new_window_size_w = resize_pending_w;
+		sys_event.new_window_size_h = resize_pending_h;
+		resize_pending = false;
+		return;
+	}
 	if (sys_event.type==SIM_NOEVENT  &&  PeekMessage(&msg, NULL, 0, 0, PM_NOREMOVE)) {
 		internal_GetEvents(false);
 	}


### PR DESCRIPTION
## Summary

This fixes two independent issues in the Windows GDI resize path that become visible when Windows
display scaling is used:

1. `WindowSize` is produced in a different unit space from the one `WM_PAINT` consumes.
2. Resize events can be lost before the resize is applied.

Related to the behaviour discussed in Simutrans forum topic
[23805](https://forum.simutrans.com/index.php/topic,23805.0.html).

OTRP reproduces the same user-visible symptom as Standard, but the producer-side DPI bug is
different, so this patch was derived and tested against OTRP's own code rather than copied from
Standard.

## DPI unit mismatch

`WM_PAINT` consumes `WindowSize` as physical client pixels: it is the `StretchDIBits` destination
extent, and `AllDib->bmiHeader.biHeight` is derived from it by converting back down to logical rows.
`dr_os_open` fills it that way.

`dr_textur_resize` does not. It receives `w` and `h` already in logical pixels and stores
`(w*32)/x_scale`, dividing by the scale a second time. At 150 % the stored value is about four
ninths of the physical size, so with a maximized 3440x1369 client it held 1536x608, and the next
repaint rewrote `biHeight` to 405 while the framebuffer had 912 rows.

The patch makes the producer use the same physical-pixel convention as the consumer:
`(w * x_scale) / 32`.

The problem is hidden at 100 % scaling, where `x_scale == 32` makes the current expression an
identity, and becomes visible at non-100 % DPI.

## Resize event delivery

The second part makes resize delivery reliable. `WM_SIZE` writes the single pending `sys_event`
slot, but one message retrieval can dispatch several messages, so `WM_MOUSEMOVE` — which Windows
sends when the window grows under the pointer — can overwrite it before the game polls. The loading
screen can also replay a resize it stored earlier, applying an obsolete size after the real one.

`WM_SIZE` now keeps only the newest client size, `GetEvents()` hands it to the slot as soon as the
slot is free, and `queue_event()` drops already queued `SYSTEM_RESIZE` events.

This is independent from the unit fix: at 100 % scaling the DPI mismatch disappears, but the
event-loss condition still reproduces.

## Validation

Tested with positive and negative controls, against this branch's base commit.

At 150 % scaling:

- full patch: PASS
- without the dimension correction: FAIL (producers 1 of 3 physical, `biHeight 912 -> 405`)
- without the event-delivery correction: resize loss reproduced, 2 of 5 runs

At 100 %:

- full patch: PASS
- removing only the DPI correction no longer fails, as expected
- removing the event-delivery correction still loses resizes, 3 of 5 runs

With the event-delivery fix present: 0 lost resize events in 10 runs across 100 % and 150 %.
The event loss is a race rather than a deterministic failure, which is why those arms were run
five times each.

Builds from the same OTRP HEAD, fresh and non-incremental:

- GDI: 0 errors, 364 objects
- SDL2: 0 errors, 364 objects
- SDL3: 0 errors, 364 objects
- no new warnings; two existing `-Wconversion` warnings are removed, because `WM_SIZE` now computes
  in `int` and casts explicitly instead of assigning `long` expressions into `uint16` fields

Runtime smoke: SDL2 and SDL3 both reach a live game, 0 fatal errors.

Official OTRP test suite, run in its supported one-test-per-invocation mode
(`tests/run-automated-tests.sh` on `tests/simutrans-test-base.zip`):

- HEAD: 271 tests, 7 failures
- this branch: 271 tests, the same 7 failures
- new failures: 0, and the PASS/FAIL sequence is identical across all 271

Those seven are the pre-existing `test_transport_pax_*` failures. They are unrelated to this patch
and are **not** fixed by it.

## Scope

Only `simevent.cc` and `sys/simsys_w.cc`. No new dependencies.

`sys/simsys_w.cc` is Windows/GDI only; `simevent.cc` is shared by every backend, which is why SDL2
and SDL3 are included in the build and smoke checks above.
