### PR TITLE
shipping

### DIFF
--- a/bauer/goods_manager.cc
+++ b/bauer/goods_manager.cc
@@ -4,6 +4,7 @@
  */
 
 #include "../simdebug.h"
+#include "../macros.h"
 #include "../descriptor/goods_desc.h"
 #include "../descriptor/spezial_obj_tpl.h"
 #include "../simware.h"
@@ -17,6 +18,8 @@ stringhashtable_tpl<const goods_desc_t *> goods_manager_t::desc_table;
 vector_tpl<goods_desc_t *> goods_manager_t::goods;
 
 uint8 goods_manager_t::max_catg_index = 0;
+
+const goods_desc_t *goods_manager_t::shipping_goods[16] = { NULL };
 
 const goods_desc_t *goods_manager_t::passengers = NULL;
 const goods_desc_t *goods_manager_t::mail = NULL;
@@ -101,9 +104,63 @@ bool goods_manager_t::successfully_loaded()
 	// however, some place do need the dummy ...
 	ware_t::index_to_desc[2] = NULL;
 
+	// Convoy shipping: resolve the dummy goods once, by name, so that nothing on a hot path
+	// ever has to compare strings. A pakset that defines none of them simply cannot ship
+	// convoys - every entry stays NULL and get_shipping_capacity() returns 0 everywhere.
+	{
+		struct { waytype_t wt; const char *name; } const shipping_names[] = {
+			{ road_wt,        "SHIPPING_ROAD"        },
+			{ track_wt,       "SHIPPING_TRACK"       },
+			// trams share the rail dummy good, as they share the rail loading gauge
+			{ tram_wt,        "SHIPPING_TRACK"       },
+			{ monorail_wt,    "SHIPPING_MONORAIL"    },
+			{ maglev_wt,      "SHIPPING_MAGLEV"      },
+			{ narrowgauge_wt, "SHIPPING_NARROWGAUGE" },
+			{ water_wt,       "SHIPPING_WATER"       }
+		};
+		for(  uint32 i = 0;  i < lengthof(shipping_names);  i++  ) {
+			// Deliberately NOT get_info(): that never returns NULL - it falls back to the
+			// "None" good and logs a warning. Storing "None" here would be actively harmful,
+			// because every vehicle without freight (every locomotive, for one) has "None" as
+			// its freight type and would then be counted as shipping capacity.
+			const goods_desc_t *g = desc_table.get( shipping_names[i].name );
+			if(  g == none  ) {
+				g = NULL;
+			}
+			shipping_goods[ shipping_names[i].wt ] = g;
+			if(  g  ) {
+				DBG_MESSAGE("goods_manager_t::successfully_loaded()","shipping good '%s' registered for waytype %i", shipping_names[i].name, (int)shipping_names[i].wt );
+			}
+		}
+	}
+
 	DBG_MESSAGE("goods_manager_t::successfully_loaded()","total goods %i, different kind of categories %i", goods.get_count(), max_catg_index );
 
 	return true;
+}
+
+
+const goods_desc_t *goods_manager_t::get_shipping_goods(waytype_t wt)
+{
+	// air_wt (16) and everything above is deliberately out of range: aircraft are never shipped.
+	if(  wt <= ignore_wt  ||  (uint32)wt >= lengthof(shipping_goods)  ) {
+		return NULL;
+	}
+	return shipping_goods[wt];
+}
+
+
+bool goods_manager_t::is_shipping_goods(const goods_desc_t *desc)
+{
+	if(  desc == NULL  ) {
+		return false;
+	}
+	for(  uint32 i = 0;  i < lengthof(shipping_goods);  i++  ) {
+		if(  shipping_goods[i] == desc  ) {
+			return true;
+		}
+	}
+	return false;
 }
 
 

--- a/bauer/goods_manager.h
+++ b/bauer/goods_manager.h
@@ -9,6 +9,7 @@
 
 #include "../tpl/vector_tpl.h"
 #include "../tpl/stringhashtable_tpl.h"
+#include "../simtypes.h"
 
 class goods_desc_t;
 
@@ -27,6 +28,14 @@ private:
 
 	// number of different good classes;
 	static uint8 max_catg_index;
+
+	/**
+	 * Convoy shipping: the dummy good that represents "space aboard a carrier convoy for a
+	 * convoy of waytype wt", indexed by waytype. Resolved once from the pakset by name in
+	 * successfully_loaded(); NULL for every waytype the pakset does not define a good for,
+	 * in which case convoys of that waytype simply cannot be shipped.
+	 */
+	static const goods_desc_t *shipping_goods[16];
 
 public:
 	enum {
@@ -62,6 +71,16 @@ public:
 
 	// good by catg_index
 	static const goods_desc_t *get_info_catg_index(const uint8 catg_index);
+
+	/**
+	 * Convoy shipping: the dummy good representing space for a convoy of waytype `wt` aboard
+	 * a carrier convoy, or NULL when this pakset cannot ship that waytype.
+	 * A vehicle whose freight type is this good contributes its capacity as shipping space.
+	 */
+	static const goods_desc_t *get_shipping_goods(waytype_t wt);
+
+	/// true if `desc` is one of the shipping dummy goods (never real cargo)
+	static bool is_shipping_goods(const goods_desc_t *desc);
 
 	/*
 	 * allow to multiply all prices, 1000=1.0

--- a/dataobj/schedule.cc
+++ b/dataobj/schedule.cc
@@ -819,6 +819,10 @@ void construct_schedule_entry_attributes(cbuffer_t& buf, schedule_entry_t const&
 		str[cnt] = 'o';
 		cnt++;
 	}
+	if(  entry.is_start_shipped()  ) {
+		str[cnt] = 'S';
+		cnt++;
+	}
 	// there are at least one attributes.
 	if(  cnt>1  ) {
 		str[cnt] = ']';

--- a/dataobj/schedule_entry.h
+++ b/dataobj/schedule_entry.h
@@ -66,7 +66,13 @@ public:
 		TEMP_UNLOAD_ALL   = 1U << 18,// unload all only for goods routing
 		BALANCE_SPEED_KMH_OF_CONVOI= 1U<<19,// Overwrite balance speed of convoy here.
 		WAIT_FOR_OTHER_CONVOY= 1U<<20,// The convoy waits here until another convoy (of allow_depart_line) grants departure.
-		WAIT_ALLOW_DEPARTURE = 1U<<21 // Wait until make other convoy depart. (only allow_departure_line exist)
+		WAIT_ALLOW_DEPARTURE = 1U<<21,// Wait until make other convoy depart. (only allow_departure_line exist)
+		// Convoy shipping needs only this one flag. Whether a convoy can carry others, which
+		// waytypes it can carry and where it will call are all already known - from its
+		// vehicles' shipping capacity and from its schedule - so a carrier needs no flag of
+		// its own. Only the carried convoy has to declare itself, because otherwise it would
+		// simply drive off. (NO_LOAD on a carrier's entry doubles as "do not pick up here".)
+		START_SHIPPED     = 1U<<22 // This convoy waits here to be taken aboard a carrier convoy.
 	};
 
 	/**
@@ -210,6 +216,9 @@ public:
 	void set_allow_depart_line(linehandle_t l) { allow_depart_line = l; }
 	bool is_wait_allow_convoy_departure() const { return (stop_flags&WAIT_ALLOW_DEPARTURE)>0; }
 	void set_wait_allow_convoy_departure(bool y) { y ? stop_flags |= WAIT_ALLOW_DEPARTURE : stop_flags &= ~WAIT_ALLOW_DEPARTURE; }
+	// convoy shipping (a convoy carried aboard another convoy)
+	bool is_start_shipped() const { return (stop_flags&START_SHIPPED)>0; }
+	void set_start_shipped(bool y) { y ? stop_flags |= START_SHIPPED : stop_flags &= ~START_SHIPPED; }
 
 
 	void set_spacing(uint16 a, uint16 b, uint16 c) {

--- a/gui/convoi_detail_t.cc
+++ b/gui/convoi_detail_t.cc
@@ -16,6 +16,8 @@
 #include "../simworld.h"
 #include "../simware.h"
 #include "simwin.h"
+#include "convoi_info_t.h"
+#include "../simhalt.h"
 #include "depot_picker.h"
 
 #include "../dataobj/translator.h"
@@ -211,6 +213,18 @@ void convoi_detail_t::init(convoihandle_t cnv)
 
 	add_component(&label_length);
 
+	// convoy shipping: only shown while this convoy actually carries or is carried
+	add_table(2,1);
+	{
+		add_component(&label_shipping);
+		show_carrier_button.init(button_t::roundbox, "Show carrier");
+		show_carrier_button.set_tooltip(translator::translate("Open the window of the convoy that is carrying this one."));
+		show_carrier_button.add_listener(this);
+		add_component(&show_carrier_button);
+	}
+	end_table();
+	add_component(&label_shipping_list);
+
 	set_table_layout(1,0);
 	add_table(4,1);
 	{
@@ -356,6 +370,54 @@ void convoi_detail_t::update_labels()
 		label_length.buf().printf( "%s %i %s %.4f", translator::translate( "Vehicle count:" ), cnv->get_vehicle_count(), translator::translate( "Station tiles:" ), (double)(cnv->get_length()) / CARUNITS_PER_TILE );
 	}
 	label_length.update();
+
+	// ---- convoy shipping ----
+	{
+		const bool shipped  = cnv->is_shipped();
+		const bool carrying = cnv->is_carrying_convoys();
+		if(  shipped  ) {
+			convoihandle_t carrier = cnv->get_shipping_carrier();
+			label_shipping.buf().printf( "%s %s", translator::translate("Aboard:"),
+				carrier.is_bound() ? carrier->get_name() : translator::translate("unknown") );
+			const halthandle_t dest = cnv->get_shipping_dest_halt();
+			if(  dest.is_bound()  ) {
+				label_shipping_list.buf().printf( "%s %s", translator::translate("Put ashore at:"), dest->get_name() );
+			}
+			else {
+				// the drop-off halt is gone; the carrier will rescue it at its next stop
+				label_shipping_list.buf().printf( "%s", translator::translate("Transfer stop no longer exists") );
+			}
+		}
+		else if(  carrying  ) {
+			label_shipping.buf().printf( "%s %u", translator::translate("Convoys aboard:"),
+				(unsigned)cnv->get_shipped_convois().get_count() );
+			// list what is aboard, with each convoy's own drop-off stop, so the player can see
+			// at a glance who is riding along and where they get off
+			bool first = true;
+			FOR(vector_tpl<convoihandle_t>, const c, cnv->get_shipped_convois()) {
+				if(  !c.is_bound()  ) {
+					continue;
+				}
+				if(  !first  ) {
+					label_shipping_list.buf().append( ", " );
+				}
+				first = false;
+				const halthandle_t d = c->get_shipping_dest_halt();
+				if(  d.is_bound()  ) {
+					label_shipping_list.buf().printf( "%s (%s)", c->get_name(), d->get_name() );
+				}
+				else {
+					label_shipping_list.buf().printf( "%s", c->get_name() );
+				}
+			}
+		}
+		label_shipping.update();
+		label_shipping_list.update();
+		label_shipping.set_visible( shipped || carrying );
+		label_shipping_list.set_visible( shipped || carrying );
+		show_carrier_button.set_visible( shipped && cnv->get_shipping_carrier().is_bound() );
+	}
+
 	label_resale.buf().printf("%s ", translator::translate("Restwert:"));
 	label_resale.buf().append_money( cnv->calc_restwert() / 100.0 );
 	label_resale.update();
@@ -445,6 +507,13 @@ bool convoi_detail_t::action_triggered(gui_action_creator_t *comp,value_t /* */)
 				create_win(new depot_picker_t(cnv, true), w_info, magic_depot_picker);
 			} else {
 				cnv->call_convoi_tool( 'y', NULL );
+			}
+			return true;
+		}
+		else if(comp==&show_carrier_button) {
+			convoihandle_t carrier = cnv->get_shipping_carrier();
+			if(  carrier.is_bound()  ) {
+				create_win( new convoi_info_t(carrier), w_info, magic_convoi_info+carrier.get_id() );
 			}
 			return true;
 		}

--- a/gui/convoi_detail_t.cc
+++ b/gui/convoi_detail_t.cc
@@ -377,8 +377,11 @@ void convoi_detail_t::update_labels()
 		const bool carrying = cnv->is_carrying_convoys();
 		if(  shipped  ) {
 			convoihandle_t carrier = cnv->get_shipping_carrier();
-			label_shipping.buf().printf( "%s %s", translator::translate("Aboard:"),
-				carrier.is_bound() ? carrier->get_name() : translator::translate("unknown") );
+			// the length is what this convoy costs the carrier, in the same car-length units
+			// the ferry's payload is given in, so the two can be compared directly
+			label_shipping.buf().printf( "%s %s (%s %u)", translator::translate("Aboard:"),
+				carrier.is_bound() ? carrier->get_name() : translator::translate("unknown"),
+				translator::translate("length:"), (unsigned)cnv->get_shipping_length() );
 			const halthandle_t dest = cnv->get_shipping_dest_halt();
 			if(  dest.is_bound()  ) {
 				label_shipping_list.buf().printf( "%s %s", translator::translate("Put ashore at:"), dest->get_name() );
@@ -389,10 +392,18 @@ void convoi_detail_t::update_labels()
 			}
 		}
 		else if(  carrying  ) {
-			label_shipping.buf().printf( "%s %u", translator::translate("Convoys aboard:"),
-				(unsigned)cnv->get_shipped_convois().get_count() );
-			// list what is aboard, with each convoy's own drop-off stop, so the player can see
-			// at a glance who is riding along and where they get off
+			// how much of the deck is taken, so the player can see at a glance whether another
+			// convoy would still fit
+			uint32 used = 0;
+			FOR(vector_tpl<convoihandle_t>, const c, cnv->get_shipped_convois()) {
+				if(  c.is_bound()  ) {
+					used += c->get_shipping_length();
+				}
+			}
+			label_shipping.buf().printf( "%s %u (%s %u)", translator::translate("Convoys aboard:"),
+				(unsigned)cnv->get_shipped_convois().get_count(),
+				translator::translate("length:"), (unsigned)used );
+			// list what is aboard, with each convoy's length and its own drop-off stop
 			bool first = true;
 			FOR(vector_tpl<convoihandle_t>, const c, cnv->get_shipped_convois()) {
 				if(  !c.is_bound()  ) {
@@ -403,11 +414,9 @@ void convoi_detail_t::update_labels()
 				}
 				first = false;
 				const halthandle_t d = c->get_shipping_dest_halt();
+				label_shipping_list.buf().printf( "%s (%u)", c->get_name(), (unsigned)c->get_shipping_length() );
 				if(  d.is_bound()  ) {
-					label_shipping_list.buf().printf( "%s (%s)", c->get_name(), d->get_name() );
-				}
-				else {
-					label_shipping_list.buf().printf( "%s", c->get_name() );
+					label_shipping_list.buf().printf( " %s %s", translator::translate("to"), d->get_name() );
 				}
 			}
 		}

--- a/gui/convoi_detail_t.h
+++ b/gui/convoi_detail_t.h
@@ -39,6 +39,9 @@ private:
 	gui_scrollpane_t scrolly;
 
 	gui_label_buf_t label_power, label_odometer, label_resale, label_length, label_speed, label_max_speed_kmh_of_convoi, label_balance_speed_kmh;
+	// convoy shipping: what this convoy carries, or which convoy carries it
+	gui_label_buf_t label_shipping, label_shipping_list;
+	button_t show_carrier_button;
 
 	convoihandle_t cnv;
 	button_t sale_button;

--- a/gui/depot_frame.cc
+++ b/gui/depot_frame.cc
@@ -1179,7 +1179,14 @@ void depot_frame_t::add_to_vehicle_list(const vehicle_desc_t *info, bool is_seco
 	// Only filter when required and never filter engines
 	if (depot->selected_filter > 0 && info->get_capacity() > 0) {
 		if (depot->selected_filter == VEHICLE_FILTER_RELEVANT) {
-			if(freight->get_catg_index() >= 3) {
+			// Convoy shipping: the SHIPPING_* dummy goods are never produced or consumed, so
+			// they can never appear in the world's goods list and a vehicle offering space for
+			// carrying convoys would always be filtered out here. They are relevant whenever
+			// the pakset defines them at all - which is exactly what is_shipping_goods() says.
+			if(  goods_manager_t::is_shipping_goods( freight )  ) {
+				// keep it
+			}
+			else if(freight->get_catg_index() >= 3) {
 				bool found = false;
 				FOR(vector_tpl<goods_desc_t const*>, const i, welt->get_goods_list()) {
 					if (freight->get_catg_index() == i->get_catg_index()) {

--- a/gui/schedule_gui.cc
+++ b/gui/schedule_gui.cc
@@ -11,6 +11,7 @@
 #include "../simworld.h"
 #include "../simmenu.h"
 #include "../simconvoi.h"
+#include "../bauer/goods_manager.h"
 #include "../display/simgraph.h"
 #include "../display/viewport.h"
 #include "components/gui_divider.h"
@@ -906,6 +907,11 @@ void schedule_gui_t::init(schedule_t* schedule_, player_t* player, convoihandle_
 		bt_no_overtake.set_tooltip("Do not overtake other cars until this stop.");
 		bt_no_overtake.add_listener(this);
 		add_component(&bt_no_overtake);
+
+		bt_start_shipped.init(button_t::square_automatic, "Wait to be shipped");
+		bt_start_shipped.set_tooltip("Wait here until a carrier convoy takes this convoy to its next stop. The convoy will not depart on its own.");
+		bt_start_shipped.add_listener(this);
+		add_component(&bt_start_shipped);
 		add_component(&sp_road_settings);
 		add_component(&sp_road_settings);
 	}
@@ -1063,6 +1069,7 @@ void schedule_gui_t::update_selection()
 	numimp_max_load.set_value(100);
 	bt_max_load_all_stops.disable();
 	bt_no_overtake.disable();
+	bt_start_shipped.disable();
 	bt_max_speed_kmh_of_convoi.disable();
 	bt_no_go_no_users.disable();
 	numimp_max_speed_kmh_of_convoi.disable();
@@ -1088,6 +1095,9 @@ void schedule_gui_t::update_selection()
     
 		bt_no_overtake.enable();
 		bt_no_overtake.pressed = schedule->at(current_stop).is_no_overtake();
+
+		bt_start_shipped.enable();
+		bt_start_shipped.pressed = schedule->at(current_stop).is_start_shipped();
 
 		if(  current_stop!=0  &&  (!schedule->get_next_line().is_bound()  ||  current_stop!=schedule->get_count()-1)  ) {
 			bt_up.enable();
@@ -1771,6 +1781,12 @@ dbg->message("schedule_gui_t::action_triggered()","comp=%p combo=%p",comp,&line_
 			update_selection();
 		}
 	}
+	else if(comp == &bt_start_shipped) {
+		if (!schedule->empty()) {
+			schedule->at(schedule->get_current_stop()).set_start_shipped(bt_start_shipped.pressed);
+			update_selection();
+		}
+	}
 	else if(comp == &bt_pass_stop) {
 		if(!schedule->empty()) {
 			schedule->at(schedule->get_current_stop()).set_pass_stop(!schedule->at(schedule->get_current_stop()).is_pass_stop());
@@ -2236,4 +2252,11 @@ void schedule_gui_t::extract_driving_settings(bool yesno) {
 	sp_coupling_settings.set_visible(coupling_waytype && yesno);
 	bt_no_overtake.set_visible(schedule->get_waytype()==road_wt && yesno); // only for road vehicle
 	sp_road_settings.set_visible(schedule->get_waytype()==road_wt && yesno);
+
+	// Convoy shipping needs no carrier-side flag: carrying is decided by the ship's capacity
+	// and its schedule. Only the carried side declares itself, and only where this pakset
+	// actually defines a shipping good, so the option never appears where it cannot work.
+	const bool is_shippable_waytype = schedule->get_waytype()!=air_wt
+		&&  goods_manager_t::get_shipping_goods(schedule->get_waytype())!=NULL;
+	bt_start_shipped.set_visible(is_shippable_waytype && yesno);
 }

--- a/gui/schedule_gui.h
+++ b/gui/schedule_gui.h
@@ -73,6 +73,8 @@ class schedule_gui_t : public gui_frame_t, public action_listener_t
 	button_t bt_find_parent, bt_wait_for_child, bt_reset_coupling; // convoy coupling
 	button_t bt_wait_for_other_convoy, bt_wait_allow_convoy_depart; // wait for departure allowance granted by another convoy
 	button_t bt_no_go_no_users;
+	// convoy shipping: carrier side (water schedules) and carried side (land schedules)
+	button_t bt_start_shipped;
 	button_t bt_wait_full_load;
 	button_t bt_no_use_electric;
 	button_t bt_no_load, bt_no_unload, bt_tmp_schedule, bt_wait_for_time, 

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -7331,6 +7331,18 @@ void convoi_t::withdraw_from_map_for_shipping()
 	while(  c.is_bound()  ) {
 		for(  uint8 i = 0;  i < c->anz_vehikel;  i++  ) {
 			vehicle_t *v = c->fahr[i];
+			// Road vehicles hold two reservations that leave_tile() does not touch: the tiles
+			// they have already reserved ahead of themselves, and a reserved position at the
+			// target halt used by choose roadsigns. Neither is refreshed while the convoy is
+			// aboard, so without this the halt position stays reserved for a convoy that is
+			// not even on the map and choose signs keep steering traffic away from it.
+			// Must happen before route.clear() below: unreserve_target_halt() walks the route
+			// backwards to find the positions it reserved.
+			if(  road_vehicle_t *rv = dynamic_cast<road_vehicle_t *>(v)  ) {
+				rv->unreserve_all_tiles();
+				rv->unreserve_target_halt();
+			}
+
 			grund_t *gr = welt->lookup( v->get_pos() );
 			if(  gr  ) {
 				// Repaint the tile we are about to vacate, or the vehicle stays painted on the

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -36,7 +36,9 @@
 #include "boden/wege/schiene.h"	// for railblocks
 #include "boden/wege/strasse.h"
 
+#include "bauer/goods_manager.h"
 #include "descriptor/citycar_desc.h"
+#include "descriptor/goods_desc.h"
 #include "descriptor/roadsign_desc.h"
 #include "descriptor/vehicle_desc.h"
 
@@ -94,7 +96,10 @@ static const char * state_names[convoi_t::MAX_STATES] =
 	"ENTERING_DEPOT",
 	"COUPLED",
 	"COUPLED_LOADING",
-	"WAITING_FOR_LEAVING_DEPOT"
+	"WAITING_FOR_LEAVING_DEPOT",
+	"SUSPENSION",
+	"SUSPENSION_LOADING",
+	"SHIPPED"
 };
 
 
@@ -172,6 +177,11 @@ void convoi_t::init(player_t *player)
 
 	coupling_convoi = convoihandle_t();
 	parent_convoi = convoihandle_t();
+
+	// convoy shipping
+	shipped_convois.clear();
+	carrier_convoi = convoihandle_t();
+	shipping_wait_since = 0;
 
 	line_update_pending = linehandle_t();
 
@@ -494,12 +504,14 @@ DBG_MESSAGE("convoi_t::finish_rd()","state=%s, next_stop_index=%d", state_names[
 				v->set_convoi(this);
 
 				// wrong alignment here => must relocate
-				if(v->need_realignment()) {
+				if(v->need_realignment()  &&  state!=SHIPPED) {
 					// diagonal => convoi must restart
 					realign_position |= ribi_t::is_bend(v->get_direction())  &&  (state==DRIVING  ||  is_waiting());
 				}
 				// if version is 99.17 or lower, some convois are broken, i.e. had too large gaps between vehicles
-				if(  !realign_position  &&  state!=INITIAL  &&  state!=LEAVING_DEPOT  &&  state != COUPLED  &&  state != COUPLED_LOADING  ) {
+				// SHIPPED convoys hold no tile, so their saved positions are stale by design and
+				// must never trigger realignment - move_to() would put them back on the map.
+				if(  !realign_position  &&  state!=INITIAL  &&  state!=LEAVING_DEPOT  &&  state != COUPLED  &&  state != COUPLED_LOADING  &&  state != SHIPPED  ) {
 					if(  i==0  ) {
 						step_pos = v->get_steps();
 					}
@@ -627,6 +639,19 @@ DBG_MESSAGE("convoi_t::finish_rd()","next_stop_index=%d", next_stop_index );
 	if(  state==COUPLED  ||  state==COUPLED_LOADING  ) {
 		front()->set_leading(false);
 	}
+	// Convoy shipping: restore the back link from each carried convoy to its carrier, the same
+	// way the coupling back link is restored below. Handles that no longer resolve (the carried
+	// convoy was destroyed while the save was made, or the save is inconsistent) are dropped
+	// here rather than left dangling.
+	for(  uint32 i = shipped_convois.get_count();  i-- != 0;  ) {
+		convoihandle_t c = shipped_convois[i];
+		if(  !c.is_bound()  ) {
+			shipped_convois.remove_at(i);
+			continue;
+		}
+		c->carrier_convoi = self;
+	}
+
 	// If this has a child convoi, the last car is not the last of the entire convoi.
 	if(  coupling_convoi.is_bound()  ) {
 		back()->set_last(false);
@@ -676,8 +701,9 @@ DBG_MESSAGE("convoi_t::finish_rd()","next_stop_index=%d", next_stop_index );
 	// Restore track reservations after all convoy data and vehicle positions are settled.
 	// Done here (not in rdwr) so all convoys are fully loaded before any reservation is
 	// attempted, avoiding convoy-vs-convoy conflicts during sequential rdwr loading.
-	// Skip when realignment already reserved the occupied tiles directly.
-	if(  !realign_position  ) {
+	// Skip when realignment already reserved the occupied tiles directly, and never reserve for
+	// a convoy that is aboard a carrier - it left its route behind when it was taken on board.
+	if(  !realign_position  &&  state!=SHIPPED  ) {
 		// A try-coupling convoy waiting at a guide signal may have next_reservation_index
 		// set beyond next_stop_index by a prior block_reserver(1001) call. Cap it first.
 		if(  is_waiting()  &&  next_coupling_index == route_t::INVALID_INDEX
@@ -732,6 +758,18 @@ void convoi_t::rotate90( const sint16 y_size )
 koord3d convoi_t::get_pos() const
 {
 	if(anz_vehikel > 0 && fahr[0]) {
+		// While aboard a carrier our own vehicles keep the stale position of the tile we left,
+		// which would strand the convoy list, the minimap and "follow convoy" at the quayside.
+		// Reporting the carrier's position instead lets the player watch their train cross the
+		// sea, and keeps distance-based logic (nearest depot, for one) sensible.
+		// resolved through the chain: a coupled child is aboard too, but only the head of the
+		// chain holds the carrier link
+		if(  state==SHIPPED  ) {
+			const convoihandle_t carrier = get_shipping_carrier();
+			if(  carrier.is_bound()  &&  carrier->get_vehicle_count() > 0  ) {
+				return carrier->front()->get_pos();
+			}
+		}
 		return state==INITIAL ? home_depot : fahr[0]->get_pos();
 	}
 	else {
@@ -849,6 +887,11 @@ void convoi_t::add_running_cost( const weg_t *weg )
 		book( -toll-wayobj_toll-signal_toll, CONVOI_PROFIT);
 
 	}
+	// Convoy shipping: the convoys we carry pay us a toll for the ride, on the same footing as
+	// a way toll - the carrier is the "way" they are travelling on. Charged here so it accrues
+	// per tile travelled, exactly like the way toll above.
+	book_shipping_toll();
+
 	sint64 const sum_running_costs = base_sum_running_costs * (welt->get_settings().is_overloading_runningcost_increase()?(sint64) max(loading_level,100) : (sint64) 100)/ (sint64) 100;
 	get_owner()->book_running_costs( sum_running_costs, get_schedule()->get_waytype());
 
@@ -1176,6 +1219,11 @@ sync_result convoi_t::sync_step(uint32 delta_t)
 		case SUSPENSION:
 			// this is an async task, see step()
 			break;
+
+		case SHIPPED:
+			// aboard a carrier convoy: not on the map, nothing to move. Stay in the sync list
+			// so that the handle keeps working, but never touch a tile from here.
+			return SYNC_OK;
 
 		case ENTERING_DEPOT:
 			break;
@@ -1607,6 +1655,26 @@ void convoi_t::step()
 		case SUSPENSION:
 			break;
 
+		case SHIPPED:
+			// The carrier drives us; we do nothing at all until it puts us ashore.
+			// Deliberately no route search, no reservation, no schedule advance.
+			wait_lock = 25000;
+			// Only the head of a shipped chain holds the carrier link - a coupled child is
+			// aboard because its parent is. Note is_coupled() is no help here: it tests for
+			// COUPLED/COUPLED_LOADING, and a carried child is SHIPPED like the rest of its
+			// chain, so the parent link is what identifies it. Without this check every child
+			// would see an unbound carrier on its very first step, "repair" itself into a
+			// depot, and tear the coupled convoy apart.
+			if(  !parent_convoi.is_bound()  &&  !carrier_convoi.is_bound()  ) {
+				// The carrier vanished without running its disembark path (should not happen,
+				// but a lost convoy is unrecoverable for the player, so repair it here).
+				dbg->warning("convoi_t::step()","%s is SHIPPED but its carrier is gone - sending it to a depot", get_name());
+				if(  !teleport_to_nearest_depot()  ) {
+					self_destruct();
+				}
+			}
+			break;
+
 		case EDIT_SCHEDULE:
 			unset_convoi_coupling_in_progress();
 			// schedule window closed?
@@ -1984,6 +2052,14 @@ void convoi_t::new_month()
 
 void convoi_t::betrete_depot(depot_t *dep, bool is_loading)
 {
+	// Convoy shipping: anything still aboard has to be dealt with before we file ourselves
+	// away. This is done here rather than by forbidding depot entry for a loaded carrier:
+	// there are many ways into a depot (the depot tool, the schedule, send_to_depot*, player
+	// liquidation, save/load repair) and a single missed one would leak or crash a convoy.
+	if(  is_carrying_convoys()  ) {
+		disembark_all_forced();
+	}
+
 	// first remove reservation, if train is still on track
 	unreserve_route();
 	clear_reserved_tiles();
@@ -3257,14 +3333,20 @@ void convoi_t::rdwr(loadsave_t *file)
 			s = EDIT_SCHEDULE;
 		} else if(  s==SUSPENSION_LOADING  ) {
 			s = LOADING;
+		} else if(  s==SHIPPED  ) {
+			// standard has no notion of a convoy aboard another convoy; the vehicles are not
+			// on the map, so INITIAL (in depot) is the only state that does not corrupt the save
+			s = INITIAL;
 		}
 		file->rdwr_enum(s);
-	} else if(  !file->is_loading()  &&  file->get_OTRP_version()<55  ) {
-		// we add SUSPENSION and SUSPENSION_LOADING in v55.
+	} else if(  !file->is_loading()  &&  file->get_OTRP_version()<61  ) {
+		// we add SHIPPED in v61.
 		states s = state;
-		if(  s==SUSPENSION  ) {
+		if(  s==SHIPPED  ) {
+			s = INITIAL;
+		} else if(  file->get_OTRP_version()<55  &&  s==SUSPENSION  ) {
 			s = EDIT_SCHEDULE;
-		} else if(  s==SUSPENSION_LOADING  ) {
+		} else if(  file->get_OTRP_version()<55  &&  s==SUSPENSION_LOADING  ) {
 			s = LOADING;
 		}
 		file->rdwr_enum(s);
@@ -3381,11 +3463,14 @@ void convoi_t::rdwr(loadsave_t *file)
 			}
 
 			// some versions save vehicles after leaving depot with koord3d::invalid
-			if(v->get_pos()==koord3d::invalid) {
+			if(v->get_pos()==koord3d::invalid  &&  state!=SHIPPED) {
 				state = INITIAL;
 			}
 
-			if(state!=INITIAL) {
+			// SHIPPED vehicles are aboard a carrier and belong to no tile. Putting them back on
+			// the ground here would make a land convoy reappear on its last tile (typically in
+			// the middle of the sea) and, worse, re-reserve the block it left behind.
+			if(state!=INITIAL  &&  state!=SHIPPED) {
 				grund_t *gr;
 				gr = welt->lookup(v->get_pos());
 				if(!gr) {
@@ -3830,6 +3915,24 @@ void convoi_t::rdwr(loadsave_t *file)
 		reversing_lane_hold = false;
 	}
 
+	if(  file->get_OTRP_version()>=61  ) {
+		// Convoy shipping. Only the forward link (carrier -> passengers) is stored; the back
+		// link carrier_convoi is restored in finish_rd(), the same way parent_convoi is.
+		// The drop-off point is deliberately NOT stored - it is the shipped convoy's own
+		// current schedule entry, which the schedule already saves as a position. Saving a
+		// halt id instead would go stale across a halt merge or rebuild, even though the
+		// position itself is still fine. See get_shipping_dest_halt().
+		std::function<void(loadsave_t*, convoihandle_t&)> rdwr_cnv = [](loadsave_t *f, convoihandle_t &c) {
+			rdwr_convoihandle_t( f, c );
+		};
+		file->rdwr_vector( shipped_convois, rdwr_cnv );
+		file->rdwr_long( shipping_wait_since );
+	} else if(  file->is_loading()  ) {
+		shipped_convois.clear();
+		carrier_convoi = convoihandle_t();
+		shipping_wait_since = 0;
+	}
+
 	if(  file->is_loading()  ) {
 		recalc_catg_index();
 	}
@@ -3928,7 +4031,10 @@ void convoi_t::get_freight_info(cbuffer_t & buf)
 			// first add to capacity indicator
 			const goods_desc_t* ware_desc = v->get_desc()->get_freight_type();
 			const uint16 menge = v->get_desc()->get_capacity();
-			if(menge>0  &&  ware_desc!=goods_manager_t::none) {
+			// Convoy shipping: the dummy goods are not cargo and have no meaningful unit, so
+			// they must not appear as a freight line here - the convoys occupying that space
+			// are listed separately below, by name.
+			if(menge>0  &&  ware_desc!=goods_manager_t::none  &&  !goods_manager_t::is_shipping_goods(ware_desc)) {
 				max_loaded_waren[ware_desc->get_index()] += menge;
 			}
 
@@ -3977,6 +4083,26 @@ void convoi_t::get_freight_info(cbuffer_t & buf)
 
 		// show new info
 		freight_list_sorter_t::sort_freight(total_fracht, buf, (freight_list_sorter_t::sort_mode_t)freight_info_order, &capacity, "loaded");
+
+		// Convoy shipping: the convoys we carry are not ware_t and so cannot go through the
+		// freight sorter, but this list is where a player looks to see what a convoy is
+		// carrying - so append them here, one line each, with where they get off.
+		if(  !shipped_convois.empty()  ) {
+			buf.append("\n");
+			buf.printf( "%s\n", translator::translate("Convoys aboard:") );
+			FOR(vector_tpl<convoihandle_t>, const c, shipped_convois) {
+				if(  !c.is_bound()  ||  c->get_vehicle_count() == 0  ) {
+					continue;
+				}
+				const halthandle_t d = c->get_shipping_dest_halt();
+				// length is what it actually costs us, so show that rather than a vehicle count
+				buf.printf( " %s (%u) %s %s\n",
+					c->get_name(),
+					(unsigned)c->get_shipping_length(),
+					translator::translate(">"),
+					d.is_bound() ? d->get_name() : translator::translate("unknown") );
+			}
+		}
 	}
 }
 
@@ -4156,6 +4282,21 @@ bool can_depart(convoihandle_t cnv, halthandle_t halt, uint32 arrived_time, uint
 	bool loading_cond = true;
 	bool coupling_done_cond = true;
 	bool allowance_cond = true;
+
+	// Convoy shipping: a convoy that is waiting to be taken aboard a carrier never departs on
+	// its own. Deliberately unconditional - no wait_for_time, no waiting_time_shift, no
+	// loading timeout - because in nearly every case there is no land route to its next stop,
+	// so departing would only strand it somewhere worse. try_start_shipping() reports it as a
+	// vehicle problem if no carrier turns up, rather than letting it hang silently.
+	c = cnv;
+	while(  c.is_bound()  ) {
+		if(  c->is_waiting_for_carrier()  ) {
+			return false;
+		}
+		c = c->get_coupling_convoi();
+	}
+
+	c = cnv;
 	while(  c.is_bound()  ) {
 		const schedule_entry_t e = c->get_schedule()->get_current_entry();
 		// First, check whether we have to wait for coupling at this stop.
@@ -4183,6 +4324,8 @@ bool can_depart(convoihandle_t cnv, halthandle_t halt, uint32 arrived_time, uint
 		c_cond |= c->get_no_load()||c->is_invalid_convoy(); // no load
 		c_cond |= waiting_time_cond;
 		loading_cond &= c_cond;
+
+
 		c = c->get_coupling_convoi();
 	}
 
@@ -4435,6 +4578,18 @@ void convoi_t::hat_gehalten(halthandle_t halt, uint32 halt_length_in_vehicle_ste
 	if(!is_coupled()) {
 		// check the vehicle length for coupling done
 		check_and_set_coupling_done_over_length();
+	}
+
+	// Convoy shipping. Run before loading so that a convoy put ashore here is on the map for
+	// the rest of this stop, and so that a convoy taken aboard has already finished loading
+	// its own goods (it went through hat_gehalten() itself earlier in this halt's queue).
+	if(  !is_coupled()  ) {
+		if(  is_carrying_convoys()  ||  has_shipping_capacity()  ) {
+			handle_shipping_at_halt( halt );
+		}
+		if(  is_waiting_for_carrier()  ) {
+			try_start_shipping( halt );
+		}
 	}
 
 	// Count how many vehicles can load and unload.
@@ -4762,8 +4917,26 @@ uint16 convoi_t::fetch_goods_and_load(vehicle_t* vehicle, const halthandle_t hal
 sint32 convoi_t::get_capacity_left() const
 {
 	sint32 convoy_capacity_left = 0;
+	// Same treatment as calc_loading(): a carrier's shipping space is real capacity, but the
+	// load sitting in it is held as convoy handles, not as cargo in the vehicles, so it is
+	// added once per shipping good instead of per vehicle.
+	const goods_desc_t *counted[16] = { NULL };
+	uint32 counted_num = 0;
 	for( uint8 i=0; i<anz_vehikel; i++) {
-		convoy_capacity_left += (sint32)fahr[i]->get_cargo_max()*(sint32)get_schedule()->get_current_entry().minimum_loading/100-fahr[i]->get_total_cargo();
+		const goods_desc_t *g = fahr[i]->get_cargo_type();
+		convoy_capacity_left += (sint32)fahr[i]->get_cargo_max()*(sint32)get_schedule()->get_current_entry().minimum_loading/100;
+		if(  goods_manager_t::is_shipping_goods( g )  ) {
+			bool seen = false;
+			for(  uint32 n = 0;  n < counted_num;  n++  ) {
+				seen |= (counted[n] == g);
+			}
+			if(  !seen  &&  counted_num < lengthof(counted)  ) {
+				counted[counted_num++] = g;
+				convoy_capacity_left -= (sint32)get_shipping_load_for_goods( g );
+			}
+			continue;
+		}
+		convoy_capacity_left -= fahr[i]->get_total_cargo();
 	}
 	return convoy_capacity_left;
 }
@@ -4873,8 +5046,28 @@ void convoi_t::calc_loading()
 {
 	int fracht_max = 0;
 	int fracht_menge = 0;
+	// Convoy shipping: space for carried convoys counts towards the loading percentage just
+	// like cargo does, so minimum_loading on a ferry means "wait until this full of convoys".
+	// The carried load is not held in the vehicles (there is no ware_t for it), so it has to
+	// be added per shipping good rather than per vehicle - and only once per good, since
+	// several vehicles can share one pool and rail and tram share one good.
+	const goods_desc_t *counted[16] = { NULL };
+	uint32 counted_num = 0;
 	for(unsigned i=0; i<anz_vehikel; i++) {
 		const vehicle_t* v = fahr[i];
+		const goods_desc_t *g = v->get_cargo_type();
+		if(  goods_manager_t::is_shipping_goods( g )  ) {
+			fracht_max += v->get_cargo_max();
+			bool seen = false;
+			for(  uint32 n = 0;  n < counted_num;  n++  ) {
+				seen |= (counted[n] == g);
+			}
+			if(  !seen  &&  counted_num < lengthof(counted)  ) {
+				counted[counted_num++] = g;
+				fracht_menge += (int)get_shipping_load_for_goods( g );
+			}
+			continue;
+		}
 		fracht_max += v->get_cargo_max();
 		fracht_menge += v->get_total_cargo();
 	}
@@ -5057,6 +5250,19 @@ void convoi_t::self_destruct()
  */
 void convoi_t::destroy()
 {
+	// Convoy shipping: never let a carrier take its passengers down with it. They belong to
+	// other players as often as not, so they go to a depot and are only destroyed when there
+	// is no depot left that could take them.
+	if(  is_carrying_convoys()  ) {
+		disembark_all_forced();
+	}
+	// and if we are ourselves aboard something, tell the carrier we are gone. The handle would
+	// invalidate on its own, but leaving stale entries would distort its capacity accounting.
+	if(  carrier_convoi.is_bound()  ) {
+		carrier_convoi->shipped_convois.remove( self );
+		carrier_convoi = convoihandle_t();
+	}
+
 	// can be only done here, with a valid convoihandle ...
 	if(fahr[0]) {
 		fahr[0]->set_convoi(NULL);
@@ -6958,4 +7164,807 @@ void convoi_t::threaded_step()
 {
 	// TODO: implement threaded operations from step()
 	// This will be called after all convoys have completed their regular step()
+}
+
+
+/* =========================================================================
+ * Convoy shipping
+ *
+ * A carrier convoy (in practice a ship) takes whole convoys of another waytype
+ * aboard and drives them to another halt. While aboard, a convoy is in state
+ * SHIPPED: it holds no way reservation, occupies no tile, is not drawn, and is
+ * not driven - but it keeps its identity, its cargo, its schedule and its
+ * coupling chain, so it simply resumes where it left off once put ashore.
+ *
+ * Capacity is expressed through dummy goods (SHIPPING_TRACK, SHIPPING_ROAD,
+ * ...): a carrier vehicle whose freight type is one of them contributes its
+ * capacity as space for convoys of the matching waytype. Those goods are never
+ * real cargo - calc_loading() skips them - so a carrier's loading percentages
+ * keep working normally for the goods it also carries.
+ * ========================================================================= */
+
+halthandle_t convoi_t::get_shipping_dest_halt() const
+{
+	// Derived, never stored. board_carrier() advanced this convoy's schedule to the entry it
+	// is being carried to, so the current entry is the drop-off point. A schedule holds a
+	// position and nothing else, so the halt has to be looked up from that position every
+	// time: halts merge, split and get rebuilt, and a halthandle saved at boarding time would
+	// then point at a destroyed haltestelle_t even though the position is still served.
+	// Returns an unbound handle when the position has stopped being a usable halt for us,
+	// which is exactly the signal handle_shipping_at_halt() uses to rescue the convoy.
+	if(  state != SHIPPED  ||  schedule == NULL  ||  schedule->empty()  ||  anz_vehikel == 0  ) {
+		return halthandle_t();
+	}
+	// A coupled child goes wherever its chain goes, and it is the head whose schedule was
+	// advanced to the drop-off entry by board_carrier(); the children's own schedules are
+	// advanced too, but the head is the authority for where the chain gets off.
+	const convoihandle_t head = get_most_parent_convoi();
+	if(  head.is_bound()  &&  head != self  ) {
+		return head->get_shipping_dest_halt();
+	}
+	return haltestelle_t::get_stoppable_halt( schedule->get_current_entry().pos, get_owner(), front()->get_waytype() );
+}
+
+uint32 convoi_t::get_shipping_length() const
+{
+	// the whole coupled chain rides together, so it costs what the whole chain is long
+	uint32 len = 0;
+	convoihandle_t c = self;
+	while(  c.is_bound()  ) {
+		len += c->get_length();
+		c = c->get_coupling_convoi();
+	}
+	return len;
+}
+
+
+uint32 convoi_t::get_shipping_capacity(waytype_t wt) const
+{
+	const goods_desc_t *g = goods_manager_t::get_shipping_goods(wt);
+	if(  g == NULL  ) {
+		// this pakset cannot ship this waytype at all
+		return 0;
+	}
+	uint32 cap = 0;
+	for(  uint8 i = 0;  i < anz_vehikel;  i++  ) {
+		if(  fahr[i]->get_cargo_type() == g  ) {
+			cap += fahr[i]->get_cargo_max();
+		}
+	}
+	return cap;
+}
+
+
+uint32 convoi_t::get_shipping_load(waytype_t wt) const
+{
+	return get_shipping_load_for_goods( goods_manager_t::get_shipping_goods(wt) );
+}
+
+
+uint32 convoi_t::get_shipping_load_for_goods(const goods_desc_t *g) const
+{
+	if(  g == NULL  ) {
+		return 0;
+	}
+	uint32 load = 0;
+	FOR(vector_tpl<convoihandle_t>, const c, shipped_convois) {
+		if(  !c.is_bound()  ||  c->get_vehicle_count() == 0  ) {
+			continue;
+		}
+		// waytypes that share a dummy good (rail and tram) also share the same space
+		if(  goods_manager_t::get_shipping_goods( c->front()->get_waytype() ) == g  ) {
+			load += c->get_shipping_length();
+		}
+	}
+	return load;
+}
+
+
+bool convoi_t::can_ship(convoihandle_t c) const
+{
+	if(  !c.is_bound()  ||  c == self  ||  c->get_vehicle_count() == 0  ||  anz_vehikel == 0  ) {
+		return false;
+	}
+	// only a convoy that is itself on the map and leads its own chain may carry
+	if(  is_coupled()  ||  is_shipped()  ||  in_depot()  ||  state == SELF_DESTRUCT  ) {
+		return false;
+	}
+	// the candidate must lead its own chain and not already be aboard something
+	if(  c->is_coupled()  ||  c->is_shipped()  ||  c->get_carrier_convoi().is_bound()  ) {
+		return false;
+	}
+	if(  c->in_depot()  ||  c->get_state() == SELF_DESTRUCT  ||  shipped_convois.is_contained(c)  ) {
+		return false;
+	}
+	const waytype_t wt = c->front()->get_waytype();
+	// aircraft are never carried: they manage their tile reservations through block_reserver
+	// in set_convoi() and have no leave_tile() unreservation path to undo it.
+	if(  wt == air_wt  ||  wt == invalid_wt  ||  wt == ignore_wt  ) {
+		return false;
+	}
+	const uint32 cap = get_shipping_capacity(wt);
+	if(  cap == 0  ) {
+		return false;
+	}
+	return get_shipping_load(wt) + c->get_shipping_length() <= cap;
+}
+
+
+void convoi_t::withdraw_from_map_for_shipping()
+{
+	// Release every reservation FIRST, and while the coupling chain is still intact:
+	// schiene_t::reserve()/unreserve() resolve through get_most_parent_convoi() and walk the
+	// chain, so touching the chain first would orphan the children's reservations forever.
+	unreserve_route();
+	clear_reserved_tiles();
+	set_next_reservation_index( 0 );
+
+	convoihandle_t c = self;
+	while(  c.is_bound()  ) {
+		for(  uint8 i = 0;  i < c->anz_vehikel;  i++  ) {
+			vehicle_t *v = c->fahr[i];
+			grund_t *gr = welt->lookup( v->get_pos() );
+			if(  gr  ) {
+				// Repaint the tile we are about to vacate, or the vehicle stays painted on the
+				// quayside until something else happens to dirty that tile. leave_tile() only
+				// removes the object from the ground; it does not mark the old image dirty -
+				// move_to() pairs the two calls for the same reason.
+				v->mark_image_dirty( v->get_image(), 0 );
+				// rail_vehicle_t::leave_tile() only unreserves when the vehicle is flagged as
+				// the last one of the convoy; betrete_depot() sets it for exactly this reason.
+				// Without it the block this convoy stands on stays reserved forever.
+				v->set_last( true );
+				v->leave_tile();
+				if(  crossing_t *cr = gr->get_crossing()  ) {
+					cr->release_crossing( v );
+				}
+			}
+			v->set_flag( obj_t::not_on_map );
+			// nothing must draw us while we are aboard; the image is rebuilt on disembarking
+			v->set_image( IMG_EMPTY );
+		}
+		c = c->get_coupling_convoi();
+	}
+
+	// the route is meaningless while carried; it is recomputed when put ashore
+	route.clear();
+	set_next_coupling( route_t::INVALID_INDEX, 0 );
+}
+
+
+halthandle_t convoi_t::get_shipping_target_halt() const
+{
+	// the halt this convoy needs to reach is simply its next scheduled stop
+	if(  schedule == NULL  ||  schedule->get_count() < 2  ||  anz_vehikel == 0  ) {
+		return halthandle_t();
+	}
+	const waytype_t wt = front()->get_waytype();
+	for(  uint8 i = 1;  i < schedule->get_count();  i++  ) {
+		const uint8 idx = (schedule->get_current_stop() + i) % schedule->get_count();
+		halthandle_t h = haltestelle_t::get_stoppable_halt( schedule->at(idx).pos, get_owner(), wt );
+		if(  h.is_bound()  ) {
+			return h;
+		}
+	}
+	return halthandle_t();
+}
+
+
+bool convoi_t::can_deliver_shipped_to(halthandle_t dest) const
+{
+	if(  !dest.is_bound()  ||  schedule == NULL  ||  anz_vehikel == 0  ) {
+		return false;
+	}
+	const waytype_t wt = front()->get_waytype();
+	const uint8 count = schedule->get_count();
+	const uint8 cur   = schedule->get_current_stop();
+	const halthandle_t current_halt = haltestelle_t::get_stoppable_halt( schedule->at(cur).pos, get_owner(), wt );
+
+	// Walk forward from the current stop and answer "does this trip actually deliver to dest".
+	// This is the same reachability question the goods code asks in collect_reachable_halts(),
+	// and it is answered the same way, because a carried convoy is subject to exactly the
+	// conditions a crate of cargo is: it can only get off where the carrier unloads, it cannot
+	// stay aboard past a stop that puts everything ashore, and a schedule that comes back to
+	// where we are now has ended this trip.
+	for(  uint8 i = 1;  i < count;  i++  ) {
+		const uint8 idx = (cur + i) % count;
+		const schedule_entry_t &e = schedule->at(idx);
+		if(  e.is_pass_stop()  ) {
+			// the carrier drives through without stopping
+			continue;
+		}
+		const halthandle_t h = haltestelle_t::get_stoppable_halt( e.pos, get_owner(), wt );
+		if(  !h.is_bound()  ) {
+			// a waypoint or a depot entry, not a stop where anything can get off
+			continue;
+		}
+
+		if(  h == dest  &&  !e.is_no_unload()  ) {
+			// we stop there and we do put things ashore there: connected
+			return true;
+		}
+
+		if(  h == current_halt  ) {
+			// S -> ... -> S -> G: we are back where the convoy would board before ever having
+			// reached its destination, so this trip does not connect. Whatever happens on the
+			// next lap is the next lap's business - riding round to it would mean sitting
+			// aboard past the point where the convoy could just as well have waited ashore.
+			return false;
+		}
+
+		if(  e.is_unload_all()  ) {
+			// S -> c -> G with UNLOAD_ALL at c: everything is put ashore at c, so the ride
+			// ends there and G is not reachable on this trip. Checked after the dest test, so
+			// UNLOAD_ALL at the destination itself is fine - that is where we want off anyway.
+			return false;
+		}
+	}
+	return false;
+}
+
+
+bool convoi_t::has_shipping_capacity() const
+{
+	for(  uint8 i = 0;  i < anz_vehikel;  i++  ) {
+		if(  goods_manager_t::is_shipping_goods( fahr[i]->get_cargo_type() )  ) {
+			return true;
+		}
+	}
+	return false;
+}
+
+
+bool convoi_t::board_carrier(convoihandle_t c, halthandle_t dest)
+{
+	if(  !dest.is_bound()  ||  !can_ship(c)  ) {
+		return false;
+	}
+
+	// Going aboard is this convoy's departure from this stop, so its schedule has to advance
+	// exactly as it would on a normal departure. Without this, the convoy would be put ashore
+	// at the far end still pointing at the port it came from, and would promptly try to find a
+	// land route back to it.
+	//
+	// Advance all the way to `dest` rather than by a single entry: get_shipping_target_halt()
+	// skips waypoints and depot entries when it picks the destination, so a single advance()
+	// could leave the convoy pointing at a waypoint it is now nowhere near. The bound on the
+	// loop is the schedule length, so a destination that somehow cannot be reached leaves the
+	// schedule untouched instead of spinning.
+	{
+		convoihandle_t k = c;
+		while(  k.is_bound()  ) {
+			schedule_t *s = k->get_schedule();
+			if(  s != NULL  &&  !s->empty()  ) {
+				const waytype_t kwt = k->front()->get_waytype();
+				const uint8 start_stop = s->get_current_stop();
+				for(  uint8 n = 0;  n < s->get_count();  n++  ) {
+					s->advance();
+					if(  haltestelle_t::get_stoppable_halt( s->get_current_entry().pos, k->get_owner(), kwt ) == dest  ) {
+						break;
+					}
+					if(  s->get_current_stop() == start_stop  ) {
+						// walked the whole schedule without finding it; leave it where it was
+						break;
+					}
+				}
+			}
+			k = k->get_coupling_convoi();
+		}
+	}
+
+	c->withdraw_from_map_for_shipping();
+
+	// the whole chain rides; every convoy in it stops being driven
+	convoihandle_t k = c;
+	while(  k.is_bound()  ) {
+		k->state = SHIPPED;
+		k->wait_lock = 0;
+		k->scheduled_departure_time = 0;
+		k->loading_limit = 0;
+		k->loading_waiting_time = 0;
+		k->unloading_done = false;
+		k = k->get_coupling_convoi();
+	}
+	// but only the head holds the link to the carrier, exactly as only the head holds
+	// the link to the parent in a coupled chain
+	c->carrier_convoi      = self;
+	// no drop-off halt is stored: c's schedule was just advanced to the destination entry,
+	// and get_shipping_dest_halt() resolves that position freshly every time it is asked
+	c->shipping_wait_since = 0;
+	shipped_convois.append( c );
+	recalc_shipping_images();
+	// the carried convoys show up in our goods list and count towards our loading level
+	freight_info_resort = true;
+	calc_loading();
+
+	dbg->message("convoi_t::board_carrier()","%s took %s aboard, to be put ashore at %s",
+		get_name(), c->get_name(), dest->get_name());
+	return true;
+}
+
+
+bool convoi_t::disembark_convoy(convoihandle_t c, halthandle_t halt)
+{
+	if(  !c.is_bound()  ||  !halt.is_bound()  ||  c->get_vehicle_count() == 0  ) {
+		return false;
+	}
+	const waytype_t wt = c->front()->get_waytype();
+
+	// The whole chain has to be placed at once: objlist_t is a uint8-indexed list capped at
+	// 254 entries and obj_add() simply returns false when it is full - a caller that ignores
+	// that (as convoi_t::start() does) leaves a vehicle belonging to no tile at all. A partial
+	// placement cannot be undone, so count first and place only if everything fits.
+	uint32 vehicle_count = 0;
+	convoihandle_t k = c;
+	while(  k.is_bound()  ) {
+		vehicle_count += k->get_vehicle_count();
+		k = k->get_coupling_convoi();
+	}
+
+	// The convoy's own current schedule entry is the tile it actually wants to stand on, so
+	// try that first; landing anywhere else in the halt only costs it a short shuffle, but
+	// landing exactly right means it can carry on without moving at all.
+	koord3d preferred = koord3d::invalid;
+	if(  c->get_schedule() != NULL  &&  !c->get_schedule()->empty()  ) {
+		preferred = c->get_schedule()->get_current_entry().pos;
+	}
+
+	grund_t *target = NULL;
+	for(  uint8 pass = 0;  pass < 2  &&  target == NULL;  pass++  ) {
+	FOR(slist_tpl<haltestelle_t::tile_t>, const &t, halt->get_tiles()) {
+		grund_t *gr = t.grund;
+		if(  gr == NULL  ) {
+			continue;
+		}
+		if(  pass == 0  &&  gr->get_pos() != preferred  ) {
+			// first pass: only the convoy's own scheduled tile
+			continue;
+		}
+		weg_t *w = gr->get_weg( wt );
+		if(  w == NULL  ) {
+			// no way of the convoy's waytype here
+			continue;
+		}
+		// the halt must really be usable by this convoy's owner - the carrier's owner is
+		// irrelevant, and access may have been revoked while the convoy was aboard
+		if(  !haltestelle_t::get_stoppable_halt( gr->get_pos(), c->get_owner(), wt ).is_bound()  ) {
+			continue;
+		}
+		if(  (uint32)gr->get_top() + vehicle_count > 254u  ) {
+			// tile object list would overflow
+			continue;
+		}
+		if(  schiene_t *sch = obj_cast<schiene_t>(w)  ) {
+			// Rail-like ways are block reserved and schiene_t::reserve() grants its second
+			// slot only on a four-way tile with non-crossing directions - which a platform
+			// never is. So unlike road and water, only one convoy fits on a rail tile.
+			if(  sch->is_reserved()  ) {
+				continue;
+			}
+		}
+		target = gr;
+		break;
+	}
+	}
+
+	if(  target == NULL  ) {
+		// Nothing free right now. Keeping the convoy aboard and retrying at a later stop is
+		// far better than materialising it on top of another train.
+		return false;
+	}
+
+	// Put every vehicle of the chain on the target tile, off-map for now. start() adds the
+	// leading vehicle to the ground and vorfahren() spreads the rest out along the route,
+	// which is exactly how a convoy leaves a depot.
+	k = c;
+	while(  k.is_bound()  ) {
+		for(  uint8 i = 0;  i < k->anz_vehikel;  i++  ) {
+			k->fahr[i]->set_pos( target->get_pos() );
+			k->fahr[i]->set_flag( obj_t::not_on_map );
+		}
+		k = k->get_coupling_convoi();
+	}
+
+	// detach from the carrier before starting, so nothing can observe a half-shipped convoy
+	shipped_convois.remove( c );
+	c->carrier_convoi      = convoihandle_t();
+	c->shipping_wait_since = 0;
+
+	// Bring the whole chain back onto the map. This does by hand what start() plus the depot
+	// branch of vorfahren() do between them; start() cannot be used directly because it would
+	// only place the leading vehicle and would overwrite home_depot, and the ROUTING_1 path it
+	// leads to short-circuits straight into ziel_erreicht() when the convoy is already standing
+	// on its scheduled tile - so vorfahren() would never run and the rest of the vehicles would
+	// never reach a tile at all. Every vehicle goes onto the landing tile, exactly as a convoy
+	// standing in a depot has all its vehicles on the depot tile; the next departure lays them
+	// out along the real route through vorfahren()'s move_to().
+	// initialise_journey() derives the facing from pos_next, i.e. from the second tile of the
+	// route. With a one-tile route pos_next would keep whatever stale value it had before the
+	// voyage and the convoy would end up facing nowhere - calc_image() would then give it no
+	// image at all. So give it a real two-tile route pointing along the way it is standing on;
+	// it is thrown away and recomputed by drive_to() on departure anyway.
+	koord3d facing = target->get_pos();
+	{
+		const ribi_t::ribi way_ribi = target->get_weg_ribi( wt );
+		for(  uint8 r = 0;  r < 4;  r++  ) {
+			const ribi_t::ribi d = ribi_t::nesw[r];
+			grund_t *to = NULL;
+			if(  (way_ribi & d)  &&  target->get_neighbour( to, wt, d )  &&  to  ) {
+				facing = to->get_pos();
+				break;
+			}
+		}
+	}
+
+	k = c;
+	while(  k.is_bound()  ) {
+		k->access_route()->clear();
+		k->access_route()->append( target->get_pos() );
+		k->access_route()->append( facing );
+		for(  uint8 i = 0;  i < k->anz_vehikel;  i++  ) {
+			vehicle_t *v = k->fahr[i];
+			v->set_leading( false );
+			v->set_last( false );
+			v->set_driven();
+			v->clear_flag( obj_t::not_on_map );
+			v->initialise_journey( 0, true );
+			v->enter_tile( target );
+			v->calc_image();
+			v->mark_image_dirty( v->get_image(), 0 );
+		}
+		k = k->get_coupling_convoi();
+	}
+	// chain ends, the way couple_convoi() sets them: only the very first and very last
+	// vehicle of the whole chain are leading/last
+	c->front()->set_leading( true );
+	c->find_most_child_convoi()->back()->set_last( true );
+
+	// the coupled children ride on as children; only the head runs the arrival
+	k = c->get_coupling_convoi();
+	while(  k.is_bound()  ) {
+		k->state = COUPLED;
+		k = k->get_coupling_convoi();
+	}
+
+	c->steps_driven = -1;
+	c->alte_richtung = ribi_t::none;
+	c->state = ROUTING_1;
+	if(  !welt->sync.is_contained( c.get_rep() )  ) {
+		welt->sync.add( c.get_rep() );
+	}
+	c->must_recalc_min_top_speed();
+	c->must_recalc_friction_weight();
+	c->check_electrification();
+	c->calc_loading();
+	c->calc_speedbonus_kmh();
+
+	// Arrive properly instead of just standing here: ziel_erreicht() books the arrival at the
+	// halt, sets LOADING (and COUPLED_LOADING down the chain), stamps arrived_time and applies
+	// the stop's flags. That is what makes the drop-off stop behave like any other stop - the
+	// convoy loads and unloads here, and WAIT_FOR_COUPLING at this entry works, because
+	// can_depart() then holds the convoy until a child couples.
+	c->ziel_erreicht();
+
+	recalc_shipping_images();
+	freight_info_resort = true;
+	calc_loading();
+	c->freight_info_resort = true;
+
+	dbg->message("convoi_t::disembark_convoy()","%s put %s ashore at %s (%s)",
+		get_name(), c->get_name(), halt->get_name(), target->get_pos().get_str());
+	return true;
+}
+
+
+void convoi_t::handle_shipping_at_halt(halthandle_t halt)
+{
+	if(  !halt.is_bound()  ||  is_coupled()  ||  schedule == NULL  ||  anz_vehikel == 0  ) {
+		return;
+	}
+
+	// ---- 1. put ashore everyone who has arrived, and rescue anyone who never can ----
+	// The same two goods flags that decide whether cargo may leave a convoy here decide it for
+	// carried convoys: NO_UNLOAD means nothing gets off at this stop at all, UNLOAD_ALL means
+	// everything does, destination or not.
+	const schedule_entry_t &here = schedule->get_current_entry();
+	const bool can_unload_here  = !here.is_no_unload();
+	const bool unload_all_here  = here.is_unload_all()  ||  get_unload_all();
+
+	for(  uint32 i = shipped_convois.get_count();  i-- != 0;  ) {
+		convoihandle_t c = shipped_convois[i];
+		if(  !c.is_bound()  ) {
+			// the carried convoy was destroyed; the handle already told us so
+			shipped_convois.remove_at( i );
+			continue;
+		}
+		const halthandle_t dest = c->get_shipping_dest_halt();
+
+		// ---- arrived: this is the stop it wanted, and we may put things ashore here ----
+		if(  can_unload_here  &&  dest.is_bound()  &&  dest == halt  ) {
+			// disembark_convoy() removes it from shipped_convois on success; on failure (no
+			// free tile of its waytype right now) it simply stays aboard and we try again at
+			// the next stop
+			disembark_convoy( c, halt );
+			continue;
+		}
+
+		// ---- still on its way? ----
+		// The drop-off point is derived from the convoy's own schedule position, so this test
+		// notices everything that can go wrong mid-voyage: an UNLOAD_ALL inserted here or
+		// anywhere before the destination, the carrier's schedule (or its line's) edited so it
+		// no longer calls there, or the stop itself rebuilt or demolished.
+		if(  !unload_all_here  &&  dest.is_bound()  &&  can_deliver_shipped_to( dest )  ) {
+			continue;
+		}
+
+		// ---- it can no longer reach its destination dock: put it in a depot ----
+		// Deliberately a depot rather than the nearest quayside. Being set down at a dock that
+		// is not on its schedule leaves the convoy stranded there, still pointing at a stop it
+		// cannot reach, and usually with no route out at all - which looks like the convoy
+		// broke. In a depot the player gets it back whole and can re-route or re-sell it.
+		if(  c->teleport_to_nearest_depot( false )  ) {
+			shipped_convois.remove_at( i );
+			c->carrier_convoi      = convoihandle_t();
+			c->shipping_wait_since = 0;
+			dbg->warning("convoi_t::handle_shipping_at_halt()",
+				"%s can no longer deliver %s to its stop - sent it to a depot", get_name(), c->get_name());
+			cbuffer_t buf;
+			buf.printf( translator::translate("%s was sent to a depot: %s can no longer reach its transfer stop."), c->get_name(), get_name() );
+			welt->get_message()->add_message( buf, halt->get_basis_pos(), message_t::warnings, PLAYER_FLAG|c->get_owner()->get_player_nr(), IMG_EMPTY );
+			continue;
+		}
+
+		// No depot of its waytype exists at all. Setting it down here is a poor outcome, but
+		// it beats destroying it - so try that before giving up.
+		if(  can_unload_here  &&  disembark_convoy( c, halt )  ) {
+			cbuffer_t buf;
+			buf.printf( translator::translate("%s was put ashore at %s: it can no longer reach its transfer stop and there is no depot for it."), c->get_name(), halt->get_name() );
+			welt->get_message()->add_message( buf, halt->get_basis_pos(), message_t::warnings, PLAYER_FLAG|c->get_owner()->get_player_nr(), IMG_EMPTY );
+			continue;
+		}
+
+		// Nowhere to put it and no depot to take it: a convoy that is on no tile and in no
+		// depot cannot exist, so this is the one case where it has to go.
+		shipped_convois.remove_at( i );
+		c->carrier_convoi = convoihandle_t();
+		cbuffer_t buf;
+		buf.printf( translator::translate("%s was lost: no depot could be found for it."), c->get_name() );
+		welt->get_message()->add_message( buf, halt->get_basis_pos(), message_t::warnings, PLAYER_FLAG|c->get_owner()->get_player_nr(), IMG_EMPTY );
+		c->destroy();
+	}
+
+	// ---- 2. take new convoys aboard ----
+	// No dedicated flag: having shipping capacity is what makes a convoy a carrier, and its
+	// schedule already says where it goes. NO_LOAD on this entry doubles as "do not pick up
+	// convoys here", which gives per-stop control through a flag the player can already see.
+	if(  !has_shipping_capacity()  ||  schedule->get_current_entry().is_no_load()  ||  get_no_load()  ) {
+		return;
+	}
+	if(  unload_all_here  ) {
+		// everything is being put ashore here, so taking anything on board would be undone in
+		// the same breath
+		return;
+	}
+
+	// Snapshot the halt's convoy list: boarding takes convoys off the map and therefore
+	// mutates it. The vector order is stable across clients, which keeps the choice of who
+	// boards first deterministic - a requirement in network games.
+	vector_tpl<convoihandle_t> candidates;
+	FOR(vector_tpl<convoihandle_t>, const c, halt->get_loading_convois()) {
+		candidates.append( c );
+	}
+
+	FOR(vector_tpl<convoihandle_t>, const c, candidates) {
+		if(  !c.is_bound()  ||  c == self  ||  c->is_coupled()  ) {
+			continue;
+		}
+		if(  c->get_schedule() == NULL  ||  !c->get_schedule()->get_current_entry().is_start_shipped()  ) {
+			continue;
+		}
+		if(  !can_ship( c )  ) {
+			continue;
+		}
+		const halthandle_t dest = c->get_shipping_target_halt();
+		if(  !dest.is_bound()  ||  dest == halt  ) {
+			continue;
+		}
+		// Only take it if this trip really delivers it: we stop at dest, we unload there, and
+		// we get there without an UNLOAD_ALL stop or a return to this halt in between.
+		if(  !can_deliver_shipped_to( dest )  ) {
+			continue;
+		}
+		board_carrier( c, dest );
+	}
+}
+
+
+bool convoi_t::is_waiting_for_carrier() const
+{
+	if(  schedule == NULL  ||  is_shipped()  ||  is_coupled()  ) {
+		return false;
+	}
+	return schedule->get_current_entry().is_start_shipped();
+}
+
+
+bool convoi_t::try_start_shipping(halthandle_t halt)
+{
+	// The waiting side only keeps book; the actual boarding is driven by the carrier in
+	// handle_shipping_at_halt(), because the carrier is the one that knows its capacity
+	// and its remaining schedule.
+	if(  !halt.is_bound()  ||  !is_waiting_for_carrier()  ) {
+		return false;
+	}
+
+	if(  shipping_wait_since == 0  ) {
+		shipping_wait_since = welt->get_ticks();
+		return true;
+	}
+
+	// A convoy that waits for a carrier must not use wait_for_time or a loading timeout: if
+	// no carrier comes it has, almost always, no route to its next stop either, so departing
+	// would only strand it somewhere else. But it must not hang silently forever, so after
+	// two months report it through the usual "convoy has a problem" channel. The state is
+	// deliberately left alone - it keeps waiting, and boards as soon as a carrier turns up.
+	const sint32 two_months = (sint32)(welt->ticks_per_world_month * 2);
+	const sint32 waited = subtract_ticks( welt->get_ticks(), shipping_wait_since );
+	if(  waited > two_months  ) {
+		owner->report_vehicle_problem( self, koord3d::invalid );
+		// report once per two-month window rather than every step
+		shipping_wait_since = welt->get_ticks();
+	}
+	return true;
+}
+
+
+bool convoi_t::teleport_to_nearest_depot(bool announce)
+{
+	// Deliberately no route search. send_to_depot_immediately() route-searches from get_pos()
+	// for every candidate depot, which can never succeed for a land convoy sitting aboard a
+	// ship in mid-ocean: it would always report "Home depot not found" and change nothing.
+	if(  anz_vehikel == 0  ) {
+		return false;
+	}
+	const waytype_t wt = front()->get_desc()->get_waytype();
+
+	// the whole chain has to belong to the same player and waytype, as betrete_depot() assumes
+	convoihandle_t c = get_coupling_convoi();
+	while(  c.is_bound()  ) {
+		if(  c->get_owner() != get_owner()  ||  c->front()->get_waytype() != front()->get_waytype()  ) {
+			return false;
+		}
+		c = c->get_coupling_convoi();
+	}
+
+	depot_t *best = NULL;
+	uint32 best_dist = 0xFFFFFFFFu;
+	const koord ref = get_pos().get_2d();
+	// get_depot_list() has a stable order, and the strict < keeps the first of any tie, so
+	// every client picks the same depot
+	FOR(slist_tpl<depot_t*>, const dep, depot_t::get_depot_list()) {
+		if(  !dep->can_accept_waytype( wt )  ||  dep->get_owner() != get_owner()  ) {
+			continue;
+		}
+		const uint32 dist = koord_distance( dep->get_pos().get_2d(), ref );
+		if(  dist < best_dist  ) {
+			best_dist = dist;
+			best = dep;
+		}
+	}
+	if(  best == NULL  ) {
+		return false;
+	}
+
+	// betrete_depot() files the vehicles away from wherever they stand, so move them to the
+	// depot tile first. They are already flagged not_on_map, so its leave_tile() calls are
+	// no-ops and nothing on the map is disturbed.
+	c = self;
+	while(  c.is_bound()  ) {
+		for(  uint8 i = 0;  i < c->anz_vehikel;  i++  ) {
+			c->fahr[i]->set_pos( best->get_pos() );
+			c->fahr[i]->set_flag( obj_t::not_on_map );
+		}
+		c->route.clear();
+		c = c->get_coupling_convoi();
+	}
+	state = ROUTING_1;
+	betrete_depot( best, false );
+
+	// callers that explain the reason themselves pass announce=false, so the player gets one
+	// informative message instead of this generic one on top of it
+	if(  announce  ) {
+		cbuffer_t buf;
+		buf.printf( translator::translate("%s has entered a depot."), get_name() );
+		welt->get_message()->add_message( buf, best->get_pos().get_2d(), message_t::warnings, PLAYER_FLAG|get_owner()->get_player_nr(), IMG_EMPTY );
+	}
+	return true;
+}
+
+
+void convoi_t::disembark_all_forced()
+{
+	while(  !shipped_convois.empty()  ) {
+		convoihandle_t c = shipped_convois[0];
+		shipped_convois.remove_at( 0 );
+		if(  !c.is_bound()  ) {
+			continue;
+		}
+		c->carrier_convoi      = convoihandle_t();
+		c->shipping_wait_since = 0;
+
+		if(  c->teleport_to_nearest_depot()  ) {
+			continue;
+		}
+		// A convoy that is on no tile and in no depot cannot exist, so this is the one place
+		// where destroying someone else's convoy is the only remaining option.
+		cbuffer_t buf;
+		buf.printf( translator::translate("%s was lost with its carrier: no depot could be found for it."), c->get_name() );
+		welt->get_message()->add_message( buf, koord::invalid, message_t::warnings, PLAYER_FLAG|c->get_owner()->get_player_nr(), IMG_EMPTY );
+		c->destroy();
+	}
+}
+
+
+bool convoi_t::is_carrying_for_goods(const goods_desc_t *g) const
+{
+	if(  g == NULL  ||  shipped_convois.empty()  ) {
+		return false;
+	}
+	FOR(vector_tpl<convoihandle_t>, const c, shipped_convois) {
+		if(  !c.is_bound()  ||  c->get_vehicle_count() == 0  ) {
+			continue;
+		}
+		if(  goods_manager_t::get_shipping_goods( c->front()->get_waytype() ) == g  ) {
+			return true;
+		}
+	}
+	return false;
+}
+
+
+void convoi_t::recalc_shipping_images()
+{
+	// A carrier holds no real cargo for the convoys it carries, so calc_image() has to be
+	// told to look again - see vehicle_t::calc_image(), which asks is_carrying_for_goods().
+	for(  uint8 i = 0;  i < anz_vehikel;  i++  ) {
+		if(  goods_manager_t::is_shipping_goods( fahr[i]->get_cargo_type() )  ) {
+			fahr[i]->mark_image_dirty( fahr[i]->get_image(), 0 );
+			fahr[i]->calc_image();
+		}
+	}
+}
+
+
+void convoi_t::book_shipping_toll()
+{
+	if(  shipped_convois.empty()  ) {
+		return;
+	}
+	const sint64 pct = (sint64)welt->get_settings().get_way_toll_runningcost_percentage();
+	if(  pct == 0  ) {
+		return;
+	}
+	// Same shape as the way toll in add_running_cost(): base_sum_running_costs is accumulated
+	// by subtraction and is therefore negative, so negating gives a positive amount to charge.
+	// The base is deliberately the CARRIER's running cost, not the passenger's: a carried
+	// convoy has its engine off, so its own running cost says nothing about what the ride
+	// costs - what the ferry burns to move does.
+	const sint64 toll = -(base_sum_running_costs * pct) / 100l;
+	if(  toll == 0  ) {
+		return;
+	}
+	const waytype_t carrier_wt = get_schedule()->get_waytype();
+	FOR(vector_tpl<convoihandle_t>, const c, shipped_convois) {
+		// no toll between a player's own convoys, exactly as a player pays no toll on their
+		// own ways
+		if(  !c.is_bound()  ||  c->get_owner() == get_owner()  ||  c->get_schedule() == NULL  ) {
+			continue;
+		}
+		get_owner()->book_toll_received( toll, carrier_wt );
+		c->get_owner()->book_toll_paid( -toll, c->get_schedule()->get_waytype() );
+		// booked against the carried convoy, so the cost shows up on the convoy that incurred
+		// it - and only against the chain head, which is what shipped_convois holds
+		c->book( -toll, CONVOI_WAYTOLL );
+		c->book( -toll, CONVOI_PROFIT );
+	}
 }

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -4935,7 +4935,7 @@ sint32 convoi_t::get_capacity_left() const
 				counted[counted_num++] = g;
 				const uint32 cap = get_shipping_capacity_for_goods( g );
 				convoy_capacity_left += (sint32)cap * min_pct/100;
-				convoy_capacity_left -= (sint32)get_effective_shipping_load( g, cap );
+				convoy_capacity_left -= (sint32)get_shipping_load_for_goods( g );
 			}
 			continue;
 		}
@@ -5071,7 +5071,7 @@ void convoi_t::calc_loading()
 				counted[counted_num++] = g;
 				const uint32 cap = get_shipping_capacity_for_goods( g );
 				fracht_max   += (int)cap;
-				fracht_menge += (int)get_effective_shipping_load( g, cap );
+				fracht_menge += (int)get_shipping_load_for_goods( g );
 			}
 			continue;
 		}
@@ -7263,19 +7263,6 @@ uint32 convoi_t::get_shipping_capacity_for_goods(const goods_desc_t *g) const
 }
 
 
-uint32 convoi_t::get_effective_shipping_load(const goods_desc_t *g, uint32 capacity) const
-{
-	const uint32 load = get_shipping_load_for_goods( g );
-	if(  capacity > load  &&  capacity - load < (uint32)SHIPPING_MIN_USABLE_LENGTH  ) {
-		// The gap that is left is shorter than any normal vehicle, so nothing can ever fill
-		// it. Reporting it as free would leave a ferry with minimum_loading 100% waiting at
-		// the quay for a convoy that cannot exist - so call it full instead.
-		return capacity;
-	}
-	return load;
-}
-
-
 uint32 convoi_t::get_shipping_load_for_goods(const goods_desc_t *g) const
 {
 	if(  g == NULL  ) {
@@ -7321,7 +7308,13 @@ bool convoi_t::can_ship(convoihandle_t c) const
 	if(  cap == 0  ) {
 		return false;
 	}
-	return get_shipping_load(wt) + c->get_shipping_length() <= cap;
+	// Any free space at all is enough to take one more convoy aboard, however long it is.
+	// Deliberately not "does it fit": refusing a convoy longer than the space left would leave
+	// a ferry holding a gap no arriving convoy happens to match, and it would never fill up.
+	// Overloading is bounded to a single convoy - once the load reaches capacity nothing more
+	// boards - and the overshoot is what makes the loading level cross minimum_loading, which
+	// is what lets the ferry depart.
+	return get_shipping_load(wt) < cap;
 }
 
 
@@ -7812,7 +7805,7 @@ void convoi_t::handle_shipping_at_halt(halthandle_t halt)
 		if(  !can_ship( c )  ) {
 			const waytype_t cwt = c->front()->get_waytype();
 			dbg->message("convoi_t::handle_shipping_at_halt()",
-				"%s: cannot take %s aboard - waytype %d, shipping good %s, my capacity %u, in use %u, it needs %u",
+				"%s: cannot take %s aboard - waytype %d, shipping good %s, my capacity %u, already in use %u (its own length is %u; a convoy boards while ANY space is left, so a full deck is the usual reason)",
 				get_name(), c->get_name(), (int)cwt,
 				goods_manager_t::get_shipping_goods(cwt) ? goods_manager_t::get_shipping_goods(cwt)->get_name() : "<none in this pakset>",
 				get_shipping_capacity(cwt), get_shipping_load(cwt), c->get_shipping_length());

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -4922,20 +4922,24 @@ sint32 convoi_t::get_capacity_left() const
 	// added once per shipping good instead of per vehicle.
 	const goods_desc_t *counted[16] = { NULL };
 	uint32 counted_num = 0;
+	const sint32 min_pct = (sint32)get_schedule()->get_current_entry().minimum_loading;
 	for( uint8 i=0; i<anz_vehikel; i++) {
 		const goods_desc_t *g = fahr[i]->get_cargo_type();
-		convoy_capacity_left += (sint32)fahr[i]->get_cargo_max()*(sint32)get_schedule()->get_current_entry().minimum_loading/100;
 		if(  goods_manager_t::is_shipping_goods( g )  ) {
+			// capacity and load both come from the helpers, once per good
 			bool seen = false;
 			for(  uint32 n = 0;  n < counted_num;  n++  ) {
 				seen |= (counted[n] == g);
 			}
 			if(  !seen  &&  counted_num < lengthof(counted)  ) {
 				counted[counted_num++] = g;
-				convoy_capacity_left -= (sint32)get_shipping_load_for_goods( g );
+				const uint32 cap = get_shipping_capacity_for_goods( g );
+				convoy_capacity_left += (sint32)cap * min_pct/100;
+				convoy_capacity_left -= (sint32)get_effective_shipping_load( g, cap );
 			}
 			continue;
 		}
+		convoy_capacity_left += (sint32)fahr[i]->get_cargo_max() * min_pct/100;
 		convoy_capacity_left -= fahr[i]->get_total_cargo();
 	}
 	return convoy_capacity_left;
@@ -5057,14 +5061,17 @@ void convoi_t::calc_loading()
 		const vehicle_t* v = fahr[i];
 		const goods_desc_t *g = v->get_cargo_type();
 		if(  goods_manager_t::is_shipping_goods( g )  ) {
-			fracht_max += v->get_cargo_max();
+			// capacity is summed per good inside the helper, so add both once per good rather
+			// than the capacity per vehicle and the load per good
 			bool seen = false;
 			for(  uint32 n = 0;  n < counted_num;  n++  ) {
 				seen |= (counted[n] == g);
 			}
 			if(  !seen  &&  counted_num < lengthof(counted)  ) {
 				counted[counted_num++] = g;
-				fracht_menge += (int)get_shipping_load_for_goods( g );
+				const uint32 cap = get_shipping_capacity_for_goods( g );
+				fracht_max   += (int)cap;
+				fracht_menge += (int)get_effective_shipping_load( g, cap );
 			}
 			continue;
 		}
@@ -7241,6 +7248,34 @@ uint32 convoi_t::get_shipping_load(waytype_t wt) const
 }
 
 
+uint32 convoi_t::get_shipping_capacity_for_goods(const goods_desc_t *g) const
+{
+	if(  g == NULL  ) {
+		return 0;
+	}
+	uint32 cap = 0;
+	for(  uint8 i = 0;  i < anz_vehikel;  i++  ) {
+		if(  fahr[i]->get_cargo_type() == g  ) {
+			cap += fahr[i]->get_cargo_max();
+		}
+	}
+	return cap;
+}
+
+
+uint32 convoi_t::get_effective_shipping_load(const goods_desc_t *g, uint32 capacity) const
+{
+	const uint32 load = get_shipping_load_for_goods( g );
+	if(  capacity > load  &&  capacity - load < (uint32)SHIPPING_MIN_USABLE_LENGTH  ) {
+		// The gap that is left is shorter than any normal vehicle, so nothing can ever fill
+		// it. Reporting it as free would leave a ferry with minimum_loading 100% waiting at
+		// the quay for a convoy that cannot exist - so call it full instead.
+		return capacity;
+	}
+	return load;
+}
+
+
 uint32 convoi_t::get_shipping_load_for_goods(const goods_desc_t *g) const
 {
 	if(  g == NULL  ) {
@@ -7754,26 +7789,66 @@ void convoi_t::handle_shipping_at_halt(halthandle_t halt)
 		candidates.append( c );
 	}
 
+	// Every rejection below is reported at debug level, because from the outside a convoy that
+	// simply never boards gives the player nothing to go on. Only convoys that actually asked
+	// to be shipped (START_SHIPPED) are reported, so this stays quiet in normal play.
+	uint32 asked_to_be_shipped = 0;
+
 	FOR(vector_tpl<convoihandle_t>, const c, candidates) {
-		if(  !c.is_bound()  ||  c == self  ||  c->is_coupled()  ) {
+		if(  !c.is_bound()  ||  c == self  ) {
 			continue;
 		}
 		if(  c->get_schedule() == NULL  ||  !c->get_schedule()->get_current_entry().is_start_shipped()  ) {
 			continue;
 		}
+		asked_to_be_shipped++;
+
+		if(  c->is_coupled()  ) {
+			dbg->message("convoi_t::handle_shipping_at_halt()",
+				"%s: not taking %s aboard - it is a coupled child, only the head of a chain boards",
+				get_name(), c->get_name());
+			continue;
+		}
 		if(  !can_ship( c )  ) {
+			const waytype_t cwt = c->front()->get_waytype();
+			dbg->message("convoi_t::handle_shipping_at_halt()",
+				"%s: cannot take %s aboard - waytype %d, shipping good %s, my capacity %u, in use %u, it needs %u",
+				get_name(), c->get_name(), (int)cwt,
+				goods_manager_t::get_shipping_goods(cwt) ? goods_manager_t::get_shipping_goods(cwt)->get_name() : "<none in this pakset>",
+				get_shipping_capacity(cwt), get_shipping_load(cwt), c->get_shipping_length());
 			continue;
 		}
 		const halthandle_t dest = c->get_shipping_target_halt();
-		if(  !dest.is_bound()  ||  dest == halt  ) {
+		if(  !dest.is_bound()  ) {
+			dbg->message("convoi_t::handle_shipping_at_halt()",
+				"%s: cannot take %s aboard - its next schedule entry is not a stop it can use",
+				get_name(), c->get_name());
+			continue;
+		}
+		if(  dest == halt  ) {
+			dbg->message("convoi_t::handle_shipping_at_halt()",
+				"%s: not taking %s aboard - its next stop is this same halt",
+				get_name(), c->get_name());
 			continue;
 		}
 		// Only take it if this trip really delivers it: we stop at dest, we unload there, and
 		// we get there without an UNLOAD_ALL stop or a return to this halt in between.
 		if(  !can_deliver_shipped_to( dest )  ) {
+			dbg->message("convoi_t::handle_shipping_at_halt()",
+				"%s: cannot take %s aboard - this trip does not deliver it to '%s' (not called at, no_unload there, or unload_all/return to here first)",
+				get_name(), c->get_name(), dest->get_name());
 			continue;
 		}
 		board_carrier( c, dest );
+	}
+
+	if(  asked_to_be_shipped == 0  ) {
+		// The commonest setup mistake by far: the dock and the land station are two separate
+		// halts, so the waiting convoy is queued at a different haltestelle_t than the one the
+		// carrier is loading at, and the carrier simply never sees it.
+		dbg->message("convoi_t::handle_shipping_at_halt()",
+			"%s: no convoy at '%s' is waiting to be shipped (%u convoys loading here). If a convoy is waiting nearby, check that the dock and its station are ONE joined halt.",
+			get_name(), halt->get_name(), (unsigned)candidates.get_count());
 	}
 }
 
@@ -7798,6 +7873,16 @@ bool convoi_t::try_start_shipping(halthandle_t halt)
 
 	if(  shipping_wait_since == 0  ) {
 		shipping_wait_since = welt->get_ticks();
+		// logged once per wait, so the player can confirm the flag really took effect and see
+		// which halt and which waytype a carrier has to serve to pick this convoy up
+		const halthandle_t dest = get_shipping_target_halt();
+		const waytype_t wt = front()->get_waytype();
+		dbg->message("convoi_t::try_start_shipping()",
+			"%s is waiting at '%s' to be shipped to '%s' (waytype %d, shipping good %s)",
+			get_name(), halt->get_name(),
+			dest.is_bound() ? dest->get_name() : "<next stop is not a usable halt>",
+			(int)wt,
+			goods_manager_t::get_shipping_goods(wt) ? goods_manager_t::get_shipping_goods(wt)->get_name() : "<none in this pakset>");
 		return true;
 	}
 

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -996,6 +996,12 @@ void convoi_t::calc_acceleration(uint32 delta_t)
 				// max speed of schedule is enforced.
 				speed_limit = min( speed_limit, kmh_to_speed(c->get_schedule()->get_max_speed()) );
 			}
+			if(  c->is_carrying_convoys()  &&  recalc_data  ) {
+				// Convoy shipping: what we carry rides with us, so it weighs on the engine
+				// exactly as cargo does. Without this a fully laden ferry accelerates like an
+				// empty one.
+				sum_gesamtweight += (uint32)c->get_carried_weight();
+			}
 			if(  c->get_max_speed_kmh_of_convoi()>0  ) {
 				// max speed of convoi is enforced.
 				speed_limit = min( speed_limit, kmh_to_speed(c->get_max_speed_kmh_of_convoi()) );
@@ -6871,6 +6877,12 @@ void convoi_t::calc_sum_friction_weight() {
 			const sint64 total_vehicle_weight = v->get_total_weight();
 			sum_friction_weight += v->get_frictionfactor() * total_vehicle_weight;
 		}
+		if(  c->is_carrying_convoys()  ) {
+			// Convoy shipping: carried convoys add their weight here too, at the friction of
+			// the carrier vehicle they are riding on rather than their own - a train on a
+			// ferry deck is dragged through water, not along rails.
+			sum_friction_weight += (sint64)c->front()->get_frictionfactor() * c->get_carried_weight();
+		}
 		c->reset_recalc_friction_weight();
 		c = c->get_coupling_convoi();
 	}
@@ -7248,6 +7260,34 @@ uint32 convoi_t::get_shipping_load(waytype_t wt) const
 }
 
 
+sint64 convoi_t::get_shipping_weight() const
+{
+	// the whole coupled chain rides together, so it weighs what the whole chain weighs -
+	// including the cargo the carried convoys have aboard, which rides along too
+	sint64 w = 0;
+	convoihandle_t c = self;
+	while(  c.is_bound()  ) {
+		for(  uint8 i = 0;  i < c->anz_vehikel;  i++  ) {
+			w += (sint64)c->fahr[i]->get_total_weight();
+		}
+		c = c->get_coupling_convoi();
+	}
+	return w;
+}
+
+
+sint64 convoi_t::get_carried_weight() const
+{
+	sint64 w = 0;
+	FOR(vector_tpl<convoihandle_t>, const c, shipped_convois) {
+		if(  c.is_bound()  ) {
+			w += c->get_shipping_weight();
+		}
+	}
+	return w;
+}
+
+
 uint32 convoi_t::get_shipping_capacity_for_goods(const goods_desc_t *g) const
 {
 	if(  g == NULL  ) {
@@ -7516,6 +7556,8 @@ bool convoi_t::board_carrier(convoihandle_t c, halthandle_t dest)
 	// the carried convoys show up in our goods list and count towards our loading level
 	freight_info_resort = true;
 	calc_loading();
+	// and they weigh on us from now on - calc_loading() sets recalc_data, this covers friction
+	must_recalc_friction_weight();
 
 	dbg->message("convoi_t::board_carrier()","%s took %s aboard, to be put ashore at %s",
 		get_name(), c->get_name(), dest->get_name());
@@ -7562,8 +7604,12 @@ bool convoi_t::disembark_convoy(convoihandle_t c, halthandle_t halt)
 		}
 		weg_t *w = gr->get_weg( wt );
 		if(  w == NULL  ) {
-			// no way of the convoy's waytype here
-			continue;
+			// Ships travel on open water, which carries no way object at all - so for water
+			// convoys a plain water tile of the halt is a perfectly good place to be set down.
+			// Every other waytype needs a real way here.
+			if(  !(wt == water_wt  &&  gr->is_water())  ) {
+				continue;
+			}
 		}
 		// the halt must really be usable by this convoy's owner - the carrier's owner is
 		// irrelevant, and access may have been revoked while the convoy was aboard
@@ -7574,7 +7620,7 @@ bool convoi_t::disembark_convoy(convoihandle_t c, halthandle_t halt)
 			// tile object list would overflow
 			continue;
 		}
-		if(  schiene_t *sch = obj_cast<schiene_t>(w)  ) {
+		if(  schiene_t *sch = (w ? obj_cast<schiene_t>(w) : NULL)  ) {
 			// Rail-like ways are block reserved and schiene_t::reserve() grants its second
 			// slot only on a four-way tile with non-crossing directions - which a platform
 			// never is. So unlike road and water, only one convoy fits on a rail tile.
@@ -7688,6 +7734,8 @@ bool convoi_t::disembark_convoy(convoihandle_t c, halthandle_t halt)
 	recalc_shipping_images();
 	freight_info_resort = true;
 	calc_loading();
+	// we just got lighter by everything that walked off
+	must_recalc_friction_weight();
 	c->freight_info_resort = true;
 
 	dbg->message("convoi_t::disembark_convoy()","%s put %s ashore at %s (%s)",

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -1273,20 +1273,11 @@ public:
 	/// total capacity of the vehicles offering space for this shipping good
 	uint32 get_shipping_capacity_for_goods(const goods_desc_t *g) const;
 
-	/**
-	 * Shipping space that is left over but too short for any convoy to use counts as filled,
-	 * so that a ferry with 4 units free does not sit at the quay forever waiting for a 100%
-	 * load that can never arrive. See SHIPPING_MIN_USABLE_LENGTH.
-	 */
-	uint32 get_effective_shipping_load(const goods_desc_t *g, uint32 capacity) const;
-
-	/**
-	 * Shortest run of shipping space worth holding a ferry for, in the same car-length units
-	 * as vehicle_desc_t::get_length() (a standard vehicle is 8, a tile is CARUNITS_PER_TILE).
-	 * Anything shorter than this cannot fit a normal vehicle, so it is treated as full rather
-	 * than as a gap still waiting to be filled.
-	 */
-	enum { SHIPPING_MIN_USABLE_LENGTH = 8 };
+	// NOTE on capacity: a convoy boards whenever ANY shipping space is left, even if it is
+	// longer than that space, so the load may exceed the capacity by up to one convoy. That
+	// overshoot is deliberate - it is what carries the loading level past minimum_loading and
+	// releases the ferry, and it removes the deadlock a strict "does it fit" test creates when
+	// the gap left over happens to match no waiting convoy.
 
 	/**
 	 * true if this trip actually delivers a carried convoy to `dest`: the carrier stops there,

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -1296,6 +1296,12 @@ public:
 	/// length this convoy (including its coupled children) occupies aboard a carrier
 	uint32 get_shipping_length() const;
 
+	/// total weight of this convoy and its coupled children, as it rides aboard a carrier
+	sint64 get_shipping_weight() const;
+
+	/// combined weight of everything this convoy is carrying aboard
+	sint64 get_carried_weight() const;
+
 	/// true if this convoy is a carrier that could in principle take `c` aboard right now
 	bool can_ship(convoihandle_t c) const;
 

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -36,6 +36,7 @@ class vehicle_desc_t;
 class schedule_t;
 class cbuffer_t;
 class signal_t;
+class goods_desc_t;
 
 // A struct to represent the directly reachable halts
 struct convoi_reachable_halt_t {
@@ -94,6 +95,12 @@ public:
 		WAITING_FOR_LEAVING_DEPOT,
 		SUSPENSION,
 		SUSPENSION_LOADING,
+		// The convoy is aboard another convoy (see "convoy shipping" below). It is not on the
+		// map, holds no way reservation and is not sync-stepped.
+		// NOTE: SHIPPED must stay the last real state. Several places compare states ordinally
+		// (e.g. `state > EDIT_SCHEDULE`, `state >= LEAVING_DEPOT`); those sites explicitly
+		// exclude SHIPPED, and appending here keeps `is_waiting()`'s range check correct.
+		SHIPPED,
 		MAX_STATES
 	};
 
@@ -251,6 +258,26 @@ private:
 	* a convoy that pulls me.
 	*/
 	convoihandle_t parent_convoi;
+
+	/**
+	* Convoy shipping: the convoys this convoy currently carries aboard.
+	* Only the most-parent convoy of each coupled chain is listed here; the rest of a
+	* chain is reached through coupling_convoi, exactly as betrete_depot() does.
+	* Only a most-parent convoy ever carries; a coupled child never does.
+	*/
+	vector_tpl<convoihandle_t> shipped_convois;
+
+	/**
+	* Convoy shipping: the convoy that carries me, if I am SHIPPED.
+	* Only set on the most-parent convoy of a shipped chain.
+	*/
+	convoihandle_t carrier_convoi;
+
+	/**
+	* Convoy shipping: ticks at which this convoy began waiting for a carrier, so that a
+	* convoy nobody ever comes to fetch can eventually be reported instead of hanging forever.
+	*/
+	uint32 shipping_wait_since;
 
 	/**
 	* a convoy that is coupling now.
@@ -1192,6 +1219,131 @@ public:
 
 	bool can_continue_coupling() const;
 	bool can_start_coupling(convoi_t* parent) const;
+
+	/* ---------------------------------------------------------------------------
+	 * Convoy shipping: carrying whole convoys of another waytype aboard a convoy.
+	 *
+	 * A "carrier" is a water convoy with vehicles whose freight type is one of the
+	 * shipping goods (see shipping_goods_t). A "shipped" convoy leaves the map
+	 * entirely while aboard: it holds no way reservation, occupies no tile, is not
+	 * sync-stepped, and keeps its coupling chain intact.
+	 * --------------------------------------------------------------------------- */
+
+	bool is_shipped() const { return state==SHIPPED; }
+
+	/// true if this convoy currently has at least one convoy aboard
+	bool is_carrying_convoys() const { return !shipped_convois.empty(); }
+
+	const vector_tpl<convoihandle_t> &get_shipped_convois() const { return shipped_convois; }
+
+	/// the raw carrier link. Only ever set on the head of a shipped chain - callers that just
+	/// want "who is carrying me" should use get_shipping_carrier() instead.
+	convoihandle_t get_carrier_convoi() const { return carrier_convoi; }
+
+	/**
+	 * The convoy carrying me, resolved through the coupling chain, or an unbound handle.
+	 * A carried chain keeps its coupling and every convoy in it is SHIPPED, but only the head
+	 * holds the link to the carrier - so anything asking on behalf of a coupled child has to
+	 * walk up to the head first.
+	 */
+	convoihandle_t get_shipping_carrier() const { return get_most_parent_convoi()->carrier_convoi; }
+
+	/**
+	 * The halt where I am to be put ashore, or an unbound handle.
+	 *
+	 * Deliberately derived, never stored. board_carrier() advances my schedule to the
+	 * destination entry, so my own current schedule entry already *is* the drop-off point -
+	 * and a schedule holds a position, not a halt. Storing a halthandle would drift out of
+	 * sync with that position the moment halts merge, split or are rebuilt: the handle would
+	 * go stale even though the position still has a perfectly usable station, and the convoy
+	 * would be "rescued" to a depot for no reason. Resolving the position afresh on every
+	 * call, the way the rest of the code does, cannot drift.
+	 */
+	halthandle_t get_shipping_dest_halt() const;
+
+	/// total shipping capacity of this convoy for the given waytype, in convoy length units
+	uint32 get_shipping_capacity(waytype_t wt) const;
+
+	/// shipping capacity for `wt` currently taken up by the convoys aboard
+	uint32 get_shipping_load(waytype_t wt) const;
+
+	/// as get_shipping_load(), but keyed on the shipping good itself (rail and tram share one)
+	uint32 get_shipping_load_for_goods(const goods_desc_t *g) const;
+
+	/**
+	 * true if this trip actually delivers a carried convoy to `dest`: the carrier stops there,
+	 * unloads there, and gets there without first putting everything ashore (UNLOAD_ALL) or
+	 * returning to the stop it is at now. Re-evaluated at every stop, so editing the carrier's
+	 * schedule (or its line's) while convoys are aboard strands nobody silently.
+	 */
+	bool can_deliver_shipped_to(halthandle_t dest) const;
+
+	/// true if any vehicle of this convoy offers space for carrying convoys
+	bool has_shipping_capacity() const;
+
+	/// the halt a convoy with START_SHIPPED needs to be carried to (its next scheduled halt)
+	halthandle_t get_shipping_target_halt() const;
+
+	/// length this convoy (including its coupled children) occupies aboard a carrier
+	uint32 get_shipping_length() const;
+
+	/// true if this convoy is a carrier that could in principle take `c` aboard right now
+	bool can_ship(convoihandle_t c) const;
+
+	/**
+	 * true if at least one convoy aboard occupies space of the shipping good `g`.
+	 * Used to give carrier vehicles their loaded image without inventing fake cargo.
+	 */
+	bool is_carrying_for_goods(const goods_desc_t *g) const;
+
+	/// mark the carrier's vehicles for an image update after boarding/disembarking
+	void recalc_shipping_images();
+
+	/**
+	 * Charge the convoys we carry for one tile of the ride, booked as CONVOI_WAYTOLL against
+	 * them and as toll received by us - the carrier is the "way" they are travelling on.
+	 * Called from add_running_cost(), so it accrues per tile like the way toll does.
+	 */
+	void book_shipping_toll();
+
+	/**
+	 * Take `c` (a most-parent convoy, together with its coupled children) aboard this
+	 * carrier, to be put ashore at `dest`. Removes `c` from the map and releases every
+	 * reservation it holds. Returns false if it does not fit or the state is wrong.
+	 */
+	bool board_carrier(convoihandle_t c, halthandle_t dest);
+
+	/**
+	 * Put `c` ashore at `halt`, on a tile of its own waytype. Returns false when there is
+	 * no usable tile, in which case `c` simply stays aboard and we retry at a later stop.
+	 */
+	bool disembark_convoy(convoihandle_t c, halthandle_t halt);
+
+	/// called on the carrier when it has stopped at `halt`: drop off and pick up convoys
+	void handle_shipping_at_halt(halthandle_t halt);
+
+	/// called on a convoy standing at `halt` with START_SHIPPED set: look for a carrier
+	bool try_start_shipping(halthandle_t halt);
+
+	/// true while this convoy is waiting at a stop for a carrier that has not arrived yet
+	bool is_waiting_for_carrier() const;
+
+	/**
+	 * Last resort for every convoy still aboard: put it in a depot, or destroy it if there
+	 * is none. Used when the carrier is destroyed, enters a depot, or can no longer reach
+	 * the drop-off halt. Never leaves a convoy in a half-shipped state.
+	 */
+	void disembark_all_forced();
+
+	/**
+	 * Send this convoy straight to the nearest suitable depot without a route search.
+	 * send_to_depot_immediately() cannot be used for a shipped convoy: it route-searches
+	 * from get_pos(), and a land convoy in the middle of the sea can never find a route.
+	 */
+	bool teleport_to_nearest_depot(bool announce = true);
+
+	/// release every way reservation held by this convoy and take it off the map
+	void withdraw_from_map_for_shipping();
 
 	// Whether this convoy can reach other_cnv's position by water (same river, same sea,
 	// or a sea connected to a river etc.) - used to find valid TRY_COUPLING partners at a

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -1270,6 +1270,24 @@ public:
 	/// as get_shipping_load(), but keyed on the shipping good itself (rail and tram share one)
 	uint32 get_shipping_load_for_goods(const goods_desc_t *g) const;
 
+	/// total capacity of the vehicles offering space for this shipping good
+	uint32 get_shipping_capacity_for_goods(const goods_desc_t *g) const;
+
+	/**
+	 * Shipping space that is left over but too short for any convoy to use counts as filled,
+	 * so that a ferry with 4 units free does not sit at the quay forever waiting for a 100%
+	 * load that can never arrive. See SHIPPING_MIN_USABLE_LENGTH.
+	 */
+	uint32 get_effective_shipping_load(const goods_desc_t *g, uint32 capacity) const;
+
+	/**
+	 * Shortest run of shipping space worth holding a ferry for, in the same car-length units
+	 * as vehicle_desc_t::get_length() (a standard vehicle is 8, a tile is CARUNITS_PER_TILE).
+	 * Anything shorter than this cannot fit a normal vehicle, so it is treated as full rather
+	 * than as a gap still waiting to be filled.
+	 */
+	enum { SHIPPING_MIN_USABLE_LENGTH = 8 };
+
 	/**
 	 * true if this trip actually delivers a carried convoy to `dest`: the carrier stops there,
 	 * unloads there, and gets there without first putting everything ashore (UNLOAD_ALL) or

--- a/simtool.cc
+++ b/simtool.cc
@@ -2053,7 +2053,12 @@ const char *tool_clear_reservation_t::work( player_t *, koord3d pos )
 				if( veh->get_convoi() ) {
 					convoihandle_t c = veh->get_convoi()->get_most_parent_convoi();
 					uint16 state = c->get_state();
-					if( state > convoi_t::EDIT_SCHEDULE ) {
+					// A convoy aboard a carrier holds no reservation and is not on the map, so
+					// it can normally not be reached from a tile at all. Guard anyway: the test
+					// below is an ordinal comparison and SHIPPED is > EDIT_SCHEDULE, so if a
+					// shipped vehicle ever were still on a tile (a transition, or a load bug)
+					// this would set it driving and a train would roll out of a ship.
+					if( state > convoi_t::EDIT_SCHEDULE  &&  state != convoi_t::SHIPPED  &&  !c->is_shipped() ) {
 						c->set_state(convoi_t::ROUTING_1);
 					}
 				}
@@ -10093,6 +10098,12 @@ bool tool_change_line_t::init( player_t *player )
 
 							for(  int j=initial-1;  j >= 0  &&  initial-destroyed > max_left  &&  new_sum_capacity < old_sum_capacity;  j--  ) {
 								convoihandle_t cnv = line->get_convoy(j);
+								// SHIPPED is ordinally above WAITING_FOR_CLEARANCE_ONE_MONTH, so
+								// without this guard the excess-capacity cleanup would happily
+								// self_destruct() convoys that are aboard a carrier.
+								if(  cnv->is_shipped()  ||  cnv->is_carrying_convoys()  ) {
+									continue;
+								}
 								if(  cnv->get_state() == convoi_t::INITIAL  ||  cnv->get_state() >= convoi_t::WAITING_FOR_CLEARANCE_ONE_MONTH  ) {
 									for(  int i=0;  i<cnv->get_vehicle_count();  i++  ) {
 										old_sum_capacity -= cnv->get_vehikel(i)->get_desc()->get_capacity();

--- a/simversion.h
+++ b/simversion.h
@@ -30,7 +30,7 @@
 #define SIM_SERVER_MINOR    0
 // NOTE: increment before next release to enable save/load of new features
 
-#define OTRP_VERSION_MAJOR 60
+#define OTRP_VERSION_MAJOR 61
 #define OTRP_VERSION_MINOR 1
 #define OTRP_VERSION_PATCH 1
 // NOTE: increment OTRP_VERSION_MAJOR when the save data structure changes.

--- a/simversion.h
+++ b/simversion.h
@@ -30,7 +30,7 @@
 #define SIM_SERVER_MINOR    0
 // NOTE: increment before next release to enable save/load of new features
 
-#define OTRP_VERSION_MAJOR 61
+#define OTRP_VERSION_MAJOR 60
 #define OTRP_VERSION_MINOR 1
 #define OTRP_VERSION_PATCH 1
 // NOTE: increment OTRP_VERSION_MAJOR when the save data structure changes.

--- a/simworld.cc
+++ b/simworld.cc
@@ -3709,6 +3709,17 @@ void karte_t::sync_step(uint32 delta_t, bool do_sync_step, bool display )
 
 		// change view due to following a convoi?
 		convoihandle_t follow_convoi = viewport->get_follow_convoi();
+		// Convoy shipping: a convoy aboard a carrier is not on the map at all, and its vehicles
+		// keep the stale position of the quay it left - following them would freeze the camera
+		// at the harbour. Follow the carrier instead, so the player keeps watching the convoy
+		// they asked to watch as it crosses. Once it is put ashore is_shipped() goes false and
+		// the camera returns to it on its own.
+		if(  follow_convoi.is_bound()  &&  follow_convoi->is_shipped()  ) {
+			const convoihandle_t carrier = follow_convoi->get_shipping_carrier();
+			if(  carrier.is_bound()  &&  carrier->get_vehicle_count() > 0  ) {
+				follow_convoi = carrier;
+			}
+		}
 		if(follow_convoi.is_bound()  &&  follow_convoi->get_vehicle_count()>0) {
 			vehicle_t const& v       = *follow_convoi->front();
 			koord3d   const  new_pos = v.get_pos();

--- a/simworld.cc
+++ b/simworld.cc
@@ -6304,6 +6304,9 @@ void karte_t::rdwr_gamestate(loadsave_t *file, loadingscreen_t *ls)
 				}
 			}
 			else {
+				// A SHIPPED convoy is aboard a carrier: it is on no tile and in no depot. It
+				// still joins the sync list (its sync_step does nothing at all in that state)
+				// so that its handle keeps working and it resumes normally when put ashore.
 				sync.add( cnv );
 			}
 		}
@@ -8288,7 +8291,18 @@ void karte_t::step_schedule_route()
 	// compute exactly one stop-to-stop leg this step, instead of pathfinding
 	// the whole schedule's circuit in a single burst
 	const uint8 i = schedule_route_next_leg++;
-	if(  !(  schedule->get_next_line().is_bound()  &&  i==count-1  )  ) {
+	if(  schedule->at(i).is_start_shipped()  ) {
+		// Convoy shipping: this leg is not driven at all - the convoy waits here and is
+		// carried to the next stop aboard another convoy. There is no way of its own waytype
+		// spanning the gap, so pathfinding it would burn a full search only to fail and then
+		// report the whole schedule as having no route. Just mark the gap so the overlay does
+		// not draw a line across it, and leave schedule_route_complete alone: nothing is
+		// broken here, this stretch is simply travelled by other means.
+		if(  !schedule_route.empty()  &&  schedule_route.back() != koord3d::invalid  ) {
+			schedule_route.append( koord3d::invalid );
+		}
+	}
+	else if(  !(  schedule->get_next_line().is_bound()  &&  i==count-1  )  ) {
 		const koord3d start  = schedule->at(i).pos;
 		const koord3d target = schedule->at((i+1) % count).pos;
 		if(  start != target  ) {

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -1604,7 +1604,15 @@ void vehicle_t::calc_image()
 	const bool is_reversed = (cnv==NULL  ||  cnv==(convoi_t *)1) ? false : cnv->is_reversed();
 	const bool is_no_electric = (cnv==NULL  ||  cnv==(convoi_t *)1) ? false : !cnv->get_use_electric();
 	if (fracht.empty()) {
-		set_image(desc->get_image_id(ribi_t::get_dir(get_image_direction()),NULL,is_reversed,is_no_electric));
+		// Convoy shipping: a carrier vehicle holds no real cargo for the convoys it carries -
+		// they are tracked as convoy handles, not as ware_t - so ask the convoy directly and
+		// show the loaded image while something is aboard.
+		const goods_desc_t *carried = NULL;
+		if(  cnv != NULL  &&  cnv != (convoi_t *)1  &&  goods_manager_t::is_shipping_goods( desc->get_freight_type() )
+		  &&  cnv->is_carrying_for_goods( desc->get_freight_type() )  ) {
+			carried = desc->get_freight_type();
+		}
+		set_image(desc->get_image_id(ribi_t::get_dir(get_image_direction()),carried,is_reversed,is_no_electric));
 	}
 	else {
 		set_image(desc->get_image_id(ribi_t::get_dir(get_image_direction()), fracht.front().get_desc(),is_reversed,is_no_electric));
@@ -2042,6 +2050,15 @@ void vehicle_t::display_after(int xpos, int ypos, bool is_global) const
 			case convoi_t::SUSPENSION:
 			case convoi_t::SUSPENSION_LOADING:
 				tstrncpy( states_text, translator::translate("suspended"), lengthof(states_text));
+				break;
+
+			case convoi_t::SHIPPED:
+				if(  cnv->get_shipping_carrier().is_bound()  ) {
+					snprintf( states_text, lengthof(states_text), "%s (%s)", translator::translate("aboard"), cnv->get_shipping_carrier()->get_name() );
+				}
+				else {
+					tstrncpy( states_text, translator::translate("aboard"), lengthof(states_text));
+				}
 				break;
 
 			case convoi_t::WAITING_FOR_CLEARANCE_ONE_MONTH:
@@ -3673,7 +3690,10 @@ void rail_vehicle_t::set_convoi(convoi_t *c)
 				// set default next stop index
 				c->set_next_stop_index( max(route_index,1)-1 );
 				// need to reserve new route?
-				if(  !check_for_finish  &&  c->get_state()!=convoi_t::SELF_DESTRUCT  &&  (c->get_state()==convoi_t::DRIVING  ||  c->get_state()>=convoi_t::LEAVING_DEPOT)  ) {
+				// SHIPPED is ordinally above LEAVING_DEPOT. Without excluding it, a rail convoy
+				// aboard a carrier would re-reserve the block it left behind - and this runs on
+				// every save/load, so the stale reservation would come back every time.
+				if(  !check_for_finish  &&  c->get_state()!=convoi_t::SELF_DESTRUCT  &&  c->get_state()!=convoi_t::SHIPPED  &&  (c->get_state()==convoi_t::DRIVING  ||  c->get_state()>=convoi_t::LEAVING_DEPOT)  ) {
 					sint32 num_index = cnv==(convoi_t *)1 ? 1001 : 0; // only during loadtype: cnv==1 indicates, that the convoi did reserve a stop
 					uint16 next_signal, next_crossing;
 					cnv = c;


### PR DESCRIPTION
船舶が陸上交通車両(`track_wt`や`road_wt`)を輸送可能にしました。
# 概要
- 船舶による鉄道・自動車等の航送
# 設計
## 運ぶ側 shipping convoy
- ダミー貨物`SHIPPING_ROAD`(自動車用)、`SHIPPING_TRACK`(鉄道車両用)などを積載した船を運行する。
- 停車駅(港)において停車した際に、運ばれる側が条件を満たせば乗降する
## 運ばれる側 shipped convoy
- スケジュールでは、乗車する駅(港)に`Wait to be shipped`を入れる(タイルは自由)
- 乗車する駅の次の駅(港)は降車する駅とし、途中駅は設定しない(降車タイルも自由)
- 乗車する駅(港)に、この編成のwaytypeを輸送可能な船が到着すると、その場から消滅し乗船扱いとなる。ただし、乗車対象の船は、次の駅(降車駅)に停まる船である。
- 下船時は、スケジュールで指定したタイルに出現して停車扱いとなる。その場合、扱いとしては車庫出庫時と同様の挙動となる(複数タイルにまたがる編成等では一時的に縮退する)。
- 連結しながら乗船した場合は、連結状態を保って出庫する。
## 異常時対応
- 航送中にスケジュール変更や撤去が行われると航送されている車両が影響を受ける。そこで、航送が親船撤去・船のスケジュール変更等によって下船できなくなった場合等に中断されると車庫へ転送する。転送可能な車庫がなければ除去される。
# 積載量の設定方法
- 航送可能な船はアドオン側で`SHIPPIN_ROAD`等のダミー貨物を設定する。その積載量が積載可能な編成の車両長の総和である。
  - 自動車`SHIPPING_ROAD`
  - 鉄道`SHIPPING_TRACK`
  - モノレール`SHIPPING_MONORAIL`
  - マグレブ`SHIPPING_MAGLEV`
  - ナローゲージ`SHIPPING_NAROOWGAUGE`
  - 船`SHIPPING_WATER`
- いずれも、貨物自体のpak(`good.SHIPPING_ROAD.pak`)が必須である
  