### PR TITLE
Cache 1024 passenger routing search contexts

### DIFF
--- a/simhalt.cc
+++ b/simhalt.cc
@@ -2306,7 +2306,7 @@ public:
 	void insert(const T item)
 	{
 		node_count++;
-		uint16 weight = *item;
+		const uint32 weight = *item;
 
 		if (weight < WEIGHT_HEAP) {
 			if (weight < min_weight) {

--- a/simhalt.cc
+++ b/simhalt.cc
@@ -59,6 +59,8 @@
 #include "vehicle/simvehicle.h"
 #include "vehicle/pedestrian.h"
 
+#include "utils/route_tree_routing.h"
+
 karte_ptr_t haltestelle_t::welt;
 
 vector_tpl<halthandle_t> haltestelle_t::alle_haltestellen;
@@ -478,8 +480,16 @@ struct haltestelle_t::cargo_queue_t {
 		const_iterator cend() const { return const_iterator(cargos.cend()); }
 };
 
+void haltestelle_t::invalidate_route_tree_cache()
+{
+	route_tree_routing::clear();
+	last_search_origin = halthandle_t();
+}
+
+
 void haltestelle_t::reset_routing()
 {
+	invalidate_route_tree_cache();
 	reconnect_counter = welt->get_schedule_counter()-1;
 }
 
@@ -854,6 +864,7 @@ void haltestelle_t::destroy_all()
 
 haltestelle_t::haltestelle_t(loadsave_t* file)
 {
+	invalidate_route_tree_cache();
 	last_loading_step = welt->get_steps();
 
 	cargo = new cargo_queue_t*[goods_manager_t::get_max_catg_index()];
@@ -889,6 +900,7 @@ haltestelle_t::haltestelle_t(loadsave_t* file)
 
 haltestelle_t::haltestelle_t(koord k, player_t* player)
 {
+	invalidate_route_tree_cache();
 	self = halthandle_t(this);
 	assert( !alle_haltestellen.is_contained(self) );
 	alle_haltestellen.append(self);
@@ -930,6 +942,7 @@ haltestelle_t::haltestelle_t(koord k, player_t* player)
 
 haltestelle_t::~haltestelle_t()
 {
+	invalidate_route_tree_cache();
 	assert(self.is_bound());
 
 	// first: remove halt from all lists
@@ -2234,6 +2247,7 @@ void haltestelle_t::fill_connected_component(uint8 catg_idx, uint16 comp)
 
 void haltestelle_t::rebuild_connected_components()
 {
+	invalidate_route_tree_cache();
 	// commit staged_all_links of all halts
 	FOR(vector_tpl<halthandle_t>, halt, alle_haltestellen) {
 		if(  halt->staged_all_links  ) {
@@ -2523,6 +2537,18 @@ int haltestelle_t::search_route( const halthandle_t *const start_halts, const ui
 		}
 		return NO_ROUTE;
 	}
+	// The cache is destination independent only for this routing mode. Walking
+	// and overcrowding searches retain their existing destination-specific rules.
+	if (ware_catg_idx == goods_manager_t::INDEX_PAS && return_ware && ware.menge > 0 &&
+		!no_routing_over_overcrowding && !welt->get_settings().is_transit_by_foot() &&
+		welt->get_settings().get_time_based_routing_enabled(ware_catg_idx)) {
+		int result;
+		if (route_tree_routing::search(start_halts, start_halt_count, end_halts,
+			welt->get_settings().get_max_transfers(), welt->get_settings().get_max_hops(), ware, *return_ware, result)) {
+			return result;
+		}
+	}
+
 	// invalidate search history
 	last_search_origin = halthandle_t();
 
@@ -2707,8 +2733,9 @@ int haltestelle_t::search_route( const halthandle_t *const start_halts, const ui
 						open_list.insert( route_node_t(current_conn.halt, total_weight + WEIGHT_MIN) );
 					}
 					else {
-						// Case: non-optimal transfer halt -> put in closed list
-						halt_data[ reachable_halt_id ].best_weight = 0;
+						// Only this incoming path is too expensive. A later path may
+						// improve it, so do not close the halt before it is explored.
+						markers[ reachable_halt_id ] = current_marker - 1u;
 					}
 				}
 				else {

--- a/simhalt.h
+++ b/simhalt.h
@@ -178,6 +178,9 @@ public:
 	 */
 	static void reset_routing();
 
+	// Discard cached passenger searches before graph or handle changes.
+	static void invalidate_route_tree_cache();
+
 	/**
 	 * Tries to generate some pedestrians on the square and the
 	 * adjacent squares. Return actual number of generated

--- a/simworld.cc
+++ b/simworld.cc
@@ -4268,6 +4268,7 @@ void karte_t::set_schedule_counter()
 	// do not call this from gui when playing in network mode!
 	assert( (get_random_mode() & INTERACTIVE_RANDOM) == 0  );
 
+	haltestelle_t::invalidate_route_tree_cache();
 	schedule_counter++;
 }
 

--- a/tests/automated-tests/all_tests.nut
+++ b/tests/automated-tests/all_tests.nut
@@ -233,6 +233,8 @@ all_tests <- [
 	test_transport_generate_pax_walked,
 	test_transport_generate_pax_no_route,
 	test_transport_pax_valid_route,
+	test_transport_pax_cached_route,
+	test_transport_pax_cached_transfer_interval,
 	test_transport_mail_valid_route,
 	test_transport_freight_valid_route,
 	test_transport_pax_no_load,

--- a/tests/automated-tests/tests/test_transport.nut
+++ b/tests/automated-tests/tests/test_transport.nut
@@ -59,6 +59,12 @@ function test_transport_generate_pax_no_route()
 
 function test_transport_pax_valid_route()
 {
+	run_transport_pax_valid_route(false)
+}
+
+
+function run_transport_pax_valid_route(cached_repeat)
+{
 	local pl = player_x(0)
 
 	ASSERT_EQUAL(command_x(tool_build_way).work(pl, coord3d(4, 2, 0), coord3d(4, 8, 0), "cobblestone_road"), null)
@@ -83,11 +89,17 @@ function test_transport_pax_valid_route()
 	sleep()
 
 	{
-		ASSERT_EQUAL(world.generate_goods(coord(3, 7), coord(3, 2), good_desc_x.passenger, 30), 1) // 1 == OK
+		if (cached_repeat) {
+			ASSERT_EQUAL(world.generate_goods(coord(3, 7), coord(3, 2), good_desc_x.passenger, 15), 1)
+			ASSERT_EQUAL(world.generate_goods(coord(3, 7), coord(3, 2), good_desc_x.passenger, 15), 1)
+		} else {
+			ASSERT_EQUAL(world.generate_goods(coord(3, 7), coord(3, 2), good_desc_x.passenger, 30), 1) // 1 == OK
+		}
 
 		ASSERT_EQUAL(from_halt.waiting[0], 30)
 		ASSERT_EQUAL(from_halt.get_freight_to_halt(good_desc_x.passenger, to_halt), 30)
-		ASSERT_EQUAL(from_halt.get_freight_to_dest(good_desc_x.passenger, coord3d(3, 2, 0)), 30)
+		// This API returns the first packet, not the total. TBGR keeps FIFO packets separate.
+		ASSERT_EQUAL(from_halt.get_freight_to_dest(good_desc_x.passenger, coord3d(3, 2, 0)), cached_repeat ? 15 : 30)
 		ASSERT_EQUAL(from_halt.get_freight_to_dest(good_desc_x.passenger, coord3d(4, 2, 0)), 0)
 		ASSERT_EQUAL(from_halt.happy[0], 30)
 		ASSERT_EQUAL(from_halt.unhappy[0], 0)
@@ -144,6 +156,10 @@ function test_transport_pax_valid_route()
 	cnv.destroy(pl)
 	sleep()
 	sleep() // make sure the convoy is destroyed
+	if (cached_repeat) {
+		// The old cached route must disappear after the network is rebuilt.
+		ASSERT_EQUAL(world.generate_goods(coord(3, 7), coord(3, 2), good_desc_x.passenger, 1), 0)
+	}
 	ASSERT_EQUAL(command_x(tool_remover).work(player_x(0), coord3d(4, 2, 0)), null)
 	ASSERT_EQUAL(command_x(tool_remover).work(player_x(0), coord3d(4, 7, 0)), null)
 	ASSERT_EQUAL(command_x(tool_remover).work(player_x(0), coord3d(4, 8, 0)), null)
@@ -1420,4 +1436,34 @@ function test_transport_route_cache_convoy_length()
 
 	settings.set_advance_to_end(true)
 	debug.set_game_speed(1)
+}
+
+
+// Exercise actual cached TBGR output through loading, transport and arrival.
+function test_transport_pax_cached_route()
+{
+	local pax = good_desc_x.passenger
+	local old_tbgr = settings.get_time_based_routing_enabled(pax)
+	local old_foot = settings.get_transit_by_foot()
+	settings.set_time_based_routing_enabled(pax, true)
+	settings.set_transit_by_foot(false)
+	run_transport_pax_valid_route(true)
+	// The helper destroys its halts. Repeating it reuses handle slots and must
+	// not see search state belonging to the deleted transport network.
+	run_transport_pax_valid_route(true)
+	settings.set_transit_by_foot(old_foot)
+	settings.set_time_based_routing_enabled(pax, old_tbgr)
+}
+
+
+function test_transport_pax_cached_transfer_interval()
+{
+	local pax = good_desc_x.passenger
+	local old_tbgr = settings.get_time_based_routing_enabled(pax)
+	local old_foot = settings.get_transit_by_foot()
+	settings.set_time_based_routing_enabled(pax, true)
+	settings.set_transit_by_foot(false)
+	test_transport_pax_transfer_interval()
+	settings.set_transit_by_foot(old_foot)
+	settings.set_time_based_routing_enabled(pax, old_tbgr)
 }

--- a/utils/route_tree_cache.h
+++ b/utils/route_tree_cache.h
@@ -1,0 +1,311 @@
+/*
+ * This file is part of the Simutrans project under the Artistic License.
+ * (see LICENSE.txt)
+ */
+
+#ifndef UTILS_ROUTE_TREE_CACHE_H
+#define UTILS_ROUTE_TREE_CACHE_H
+
+#include "../simtypes.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <list>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+namespace route_tree {
+using node_id = uint32;
+static constexpr uint32 infinity = std::numeric_limits<uint32>::max();
+
+struct result_t
+{
+	bool found = false, fallback = false, hit = false, ready = false;
+	uint32 cost = infinity;
+	uint64 pops = 0, edges = 0;
+	std::vector<node_id> path; // includes the origin and the selected destination
+};
+
+// Graph supplies edge_t, size(), edges(id), target(edge), weight(edge), and transfer(id).
+// Only nonnegative weights, no walking edges, no overcrowding are supported.
+// Node zero is invalid. The caller must clear the cache before changing the
+// graph (including transfer flags and handle reuse). Keys include the complete
+// source set and limits; destinations never change the expansion order.
+// A bounded search may decline to answer, but must never report NO_ROUTE merely
+// because it exhausted its budget or encountered the transfer-depth boundary.
+class cache_t
+{
+	struct label_t
+	{
+		uint32 distance = infinity, previous = 0;
+		uint16 depth = 0;
+		bool origin = false;
+	};
+
+	struct item_t
+	{
+		uint32 distance;
+		node_id id;
+	};
+
+	struct later_t
+	{
+		bool operator()(const item_t &a, const item_t &b) const
+		{
+			return a.distance!=b.distance ? a.distance>b.distance : a.id>b.id;
+		}
+	};
+
+	struct context_t
+	{
+		std::vector<label_t> labels;
+		std::vector<item_t> queue;
+		uint32 allocations = 0;
+		bool limited = false;
+		uint32 certified_distance = 0;
+
+		void reset(size_t size, const std::vector<node_id> &origins)
+		{
+			labels.assign(size, label_t{});
+			queue.clear();
+			allocations = 0;
+			limited = false;
+			certified_distance = 0;
+			for(node_id id : origins) {
+				labels[id] = {1, 0, 0, true};
+				push({1, id});
+				++allocations;
+			}
+		}
+
+		void push(item_t n)
+		{
+			queue.push_back(n);
+			std::push_heap(queue.begin(), queue.end(), later_t{});
+		}
+
+		item_t pop()
+		{
+			std::pop_heap(queue.begin(), queue.end(), later_t{});
+			item_t n = queue.back();
+			queue.pop_back();
+			return n;
+		}
+
+		size_t bytes() const
+		{
+			return labels.capacity() * sizeof(label_t) + queue.capacity() * sizeof(item_t);
+		}
+	};
+
+	struct hash_t
+	{
+		size_t operator()(const std::vector<node_id> &v) const
+		{
+			size_t h = 0;
+			for(node_id x : v) {
+				h = (h * 1099511628211ULL) ^ x;
+			}
+			return h;
+		}
+	};
+
+	using entry_t = std::pair<std::vector<node_id>, std::unique_ptr<context_t>>;
+	using list_t = std::list<entry_t>;
+	size_t capacity;
+	list_t lru;
+	std::unordered_map<std::vector<node_id>, typename list_t::iterator, hash_t> index;
+	context_t scratch;
+	size_t live_bytes = 0, peak_bytes = 0;
+
+public:
+	explicit cache_t(size_t n) : capacity(n)
+	{}
+
+	void clear()
+	{
+		index.clear();
+		lru.clear();
+		scratch = context_t{};
+		live_bytes = 0;
+	}
+
+	size_t bytes() const
+	{
+		return live_bytes;
+	}
+
+	size_t peak() const
+	{
+		return peak_bytes;
+	}
+
+	size_t count() const
+	{
+		return lru.size();
+	}
+
+	template <class Graph>
+	result_t query(const Graph &g, std::vector<node_id> origins, const std::vector<node_id> &targets, uint32 max_transfers,
+	      uint32 max_hops)
+	{
+		result_t result;
+		if(origins.empty()  ||  targets.empty()) {
+			return result;
+		}
+		if(max_transfers>=UINT16_MAX) {
+			result.fallback = true;
+			return result;
+		}
+		std::sort(origins.begin(), origins.end());
+		origins.erase(std::unique(origins.begin(), origins.end()), origins.end());
+		for(node_id id : origins) {
+			if(!id  ||  id>=g.size()) {
+				result.fallback = true;
+				return result;
+			}
+		}
+		for(node_id id : targets) {
+			if(!id  ||  id>=g.size()) {
+				result.fallback = true;
+				return result;
+			}
+		}
+		if(origins.size()>max_hops) {
+			result.fallback = true;
+			return result;
+		}
+		std::vector<node_id> key = origins;
+		key.push_back(g.size());
+		key.push_back(max_transfers);
+		key.push_back(max_hops);
+		context_t *ctx;
+		size_t old_bytes = 0;
+		if(!capacity) {
+			old_bytes = scratch.bytes();
+			scratch.reset(g.size(), origins);
+			ctx = &scratch;
+		} else {
+			auto found = index.find(key);
+			if(found!=index.end()) {
+				lru.splice(lru.begin(), lru, found->second);
+				ctx = lru.front().second.get();
+				result.hit = true;
+				old_bytes = ctx->bytes();
+			} else {
+				std::unique_ptr<context_t> context;
+				if(lru.size()==capacity) {
+					live_bytes -= lru.back().second->bytes();
+					context = std::move(lru.back().second);
+					index.erase(lru.back().first);
+					lru.pop_back();
+				} else {
+					context = std::make_unique<context_t>();
+				}
+				context->reset(g.size(), origins);
+				ctx = context.get();
+				lru.emplace_front(key, std::move(context));
+				index.emplace(std::move(key), lru.begin());
+			}
+		}
+		// Keep using certified destinations after the context reaches its bound.
+		// Unknown destinations fall back: a fresh targeted search may still succeed.
+		auto search = [&]() {
+			auto best_target = [&]() {
+				node_id id = 0;
+				uint32 best = infinity;
+				for(node_id t : targets) {
+					if(ctx->labels[t].distance<best  ||
+					   (ctx->labels[t].distance==best  &&  best!=infinity  &&  t<id)) {
+						id = t;
+						best = ctx->labels[t].distance;
+					}
+				}
+				return id;
+			};
+			node_id best = best_target();
+			if(ctx->limited  &&  (!best  ||  ctx->labels[best].distance>=ctx->certified_distance)) {
+				result.fallback = true;
+				return;
+			}
+			while(!ctx->limited  &&  !ctx->queue.empty()) {
+				const item_t front = ctx->queue.front();
+				// Finish the entire equal-distance layer, including zero-weight edges,
+				// so the selected destination/path is independent of previous queries.
+				if(best  &&  ctx->labels[best].distance<front.distance) {
+					break;
+				}
+				const item_t item = ctx->pop();
+				++result.pops;
+				const label_t label = ctx->labels[item.id];
+				if(label.distance!=item.distance) {
+					continue;
+				}
+				ctx->certified_distance = item.distance;
+				if(label.depth>max_transfers) {
+					ctx->limited = true;
+					break;
+				}
+				for(const typename Graph::edge_t &edge : g.edges(item.id)) {
+					++result.edges;
+					const node_id to = g.target(edge);
+					const uint32 weight = g.weight(edge);
+					if(!to  ||  to>=ctx->labels.size()  ||  weight>infinity - label.distance) {
+						continue;
+					}
+					label_t &next = ctx->labels[to];
+					if(next.origin  ||  label.distance + weight>=next.distance) {
+						continue;
+					}
+					// Like the existing search, bound queue insertions, not every edge
+					// or terminal label. Non-transfer destinations need no queue entry.
+					const bool enqueue = g.transfer(to);
+					if(enqueue  &&  ctx->allocations>=max_hops) {
+						ctx->limited = true;
+						break;
+					}
+					if(enqueue) {
+						++ctx->allocations;
+					}
+					next = {label.distance + weight, item.id, uint16(label.depth + 1), false};
+					if(enqueue) {
+						ctx->push({next.distance, to});
+					}
+				}
+				best = best_target();
+			}
+			if(ctx->limited  &&  (!best  ||  ctx->labels[best].distance>=ctx->certified_distance)) {
+				result.fallback = true;
+				return;
+			}
+			if(!best) {
+				return;
+			}
+			result.found = true;
+			result.cost = ctx->labels[best].distance;
+			for(node_id id = best; id; id = ctx->labels[id].previous) {
+				result.path.push_back(id);
+				if(result.path.size()>ctx->labels.size()) {
+					result.found = false;
+					result.fallback = true;
+					result.path.clear();
+					return;
+				}
+			}
+			std::reverse(result.path.begin(), result.path.end());
+			result.ready = result.hit  &&  result.pops==0;
+		};
+		search();
+		if(capacity) {
+			live_bytes += ctx->bytes() - old_bytes;
+		} else {
+			live_bytes = ctx->bytes();
+		}
+		peak_bytes = std::max(peak_bytes, live_bytes);
+		return result;
+	}
+};
+} // namespace route_tree
+#endif

--- a/utils/route_tree_routing.h
+++ b/utils/route_tree_routing.h
@@ -1,0 +1,196 @@
+/*
+ * This file is part of the Simutrans project under the Artistic License.
+ * (see LICENSE.txt)
+ */
+
+#ifndef UTILS_ROUTE_TREE_ROUTING_H
+#define UTILS_ROUTE_TREE_ROUTING_H
+
+#include "route_tree_cache.h"
+#include <cstdio>
+#include <cstdlib>
+
+// Adapter for passenger journey-time routing without walking or overcrowding.
+// Other routing modes continue to use the existing targeted search.
+namespace route_tree_routing {
+struct graph_t
+{
+	using edge_t = haltestelle_t::connection_t;
+
+	static size_t size()
+	{
+		return halthandle_t::get_size();
+	}
+
+	static halthandle_t halt(uint32 id)
+	{
+		halthandle_t h;
+		h.set_id(id);
+		return h;
+	}
+
+	static const vector_tpl<haltestelle_t::connection_t> &edges(uint32 id)
+	{
+		return halt(id)->get_connections(goods_manager_t::INDEX_PAS);
+	}
+
+	static uint32 target(const haltestelle_t::connection_t &e)
+	{
+		return e.halt.is_bound() ? e.halt.get_id() : 0;
+	}
+
+	static uint32 weight(const haltestelle_t::connection_t &e)
+	{
+		return e.weight;
+	}
+
+	static bool transfer(uint32 id)
+	{
+		return halt(id)->is_transfer(goods_manager_t::INDEX_PAS);
+	}
+};
+
+struct state_t
+{
+	route_tree::cache_t cache{1024};
+	bool checked = false, compatible = false;
+	// Optional exhaustive cached/fresh comparison, with the cached result used
+	// by the game. No second search or file I/O when this variable is absent.
+	FILE *verification = nullptr;
+	uint64 calls = 0, hits = 0, fallbacks = 0, mismatches = 0, clears = 0;
+
+	state_t()
+	{
+		if(const char *path = std::getenv("SIMUTRANS_ROUTE_TREE_VERIFY")) {
+			verification = std::fopen(path, "w");
+			if(verification) {
+				std::fprintf(verification, "calls,hits,fallbacks,mismatches,clears,contexts\n");
+			}
+		}
+	}
+
+	void dump()
+	{
+		if(verification) {
+			std::fprintf(verification, "%llu,%llu,%llu,%llu,%llu,%zu\n", (unsigned long long)calls,
+			             (unsigned long long)hits, (unsigned long long)fallbacks, (unsigned long long)mismatches,
+			             (unsigned long long)clears, cache.count());
+			std::fflush(verification);
+		}
+	}
+
+	~state_t()
+	{
+		dump();
+		if(verification) {
+			std::fclose(verification);
+		}
+	}
+};
+
+inline state_t &state()
+{
+	static state_t s;
+	return s;
+}
+
+inline void clear()
+{
+	state_t &s = state();
+	s.cache.clear();
+	s.checked = false;
+	++s.clears;
+}
+
+inline bool compatible()
+{
+	state_t &s = state();
+	if(!s.checked) {
+		s.checked = true;
+		s.compatible = true;
+		// A settings change can precede the next graph commit. Never interpret
+		// an old walking graph as the simpler graph supported by this cache.
+		for(uint32 id = 1; id<graph_t::size(); ++id) {
+			if(!graph_t::halt(id).is_bound()) {
+				continue;
+			}
+			for(const graph_t::edge_t &e : graph_t::edges(id)) {
+				if(e.is_foot_path  ||  (e.halt.is_bound()  &&  e.is_transfer!=graph_t::transfer(e.halt.get_id()))) {
+					s.compatible = false;
+					return false;
+				}
+			}
+		}
+	}
+	return s.compatible;
+}
+
+// Returns false when the bounded search cannot certify an answer; callers must
+// then run the targeted search with its own budget and untouched output goods.
+inline bool search(const halthandle_t *starts, uint32 count, const vector_tpl<halthandle_t> &targets, uint32 max_transfers,
+       uint32 max_hops, ware_t &ware, ware_t &reverse, int &status)
+{
+	if(!compatible()) {
+		return false;
+	}
+	std::vector<uint32> sources, destinations;
+	for(uint32 i = 0; i<count; ++i) {
+		sources.push_back(starts[i].get_id());
+	}
+	for(halthandle_t h : targets) {
+		destinations.push_back(h.get_id());
+	}
+	state_t &s = state();
+	route_tree::result_t result = s.cache.query(graph_t{}, sources, destinations, max_transfers, max_hops);
+	++s.calls;
+	s.hits += result.hit;
+	if(s.verification) {
+		route_tree::cache_t fresh(0);
+		route_tree::result_t reference = fresh.query(graph_t{}, sources, destinations, max_transfers, max_hops);
+		if(result.fallback!=reference.fallback  ||
+		   (!result.fallback  &&
+		    (result.found!=reference.found  ||  result.cost!=reference.cost  ||  result.path!=reference.path))) {
+			++s.mismatches;
+			result.fallback = true;
+		}
+	}
+	s.fallbacks += result.fallback;
+	if((s.calls % 1024)==0) {
+		s.dump();
+	}
+	if(result.fallback) {
+		return false;
+	}
+
+	ware.clear_transit_halts();
+	reverse.clear_transit_halts();
+	if(!result.found) {
+		ware.set_ziel(halthandle_t());
+		reverse.set_ziel(halthandle_t());
+		status = haltestelle_t::NO_ROUTE;
+		return true;
+	}
+	vector_tpl<halthandle_t> route;
+	for(size_t i = 1; i<result.path.size(); ++i) {
+		route.append(graph_t::halt(result.path[i]));
+	}
+	ware.set_ziel(graph_t::halt(result.path.back()));
+	ware.set_transit_halts(route);
+	reverse.set_ziel(graph_t::halt(result.path.front()));
+	uint32 transfers = graph_t::transfer(result.path.back());
+	for(const graph_t::edge_t &e : graph_t::edges(result.path.back())) {
+		if(transfers>1) {
+			break;
+		}
+		transfers += e.halt.is_bound()  &&  e.is_transfer;
+	}
+	if(transfers<=1) {
+		vector_tpl<halthandle_t> hop;
+		hop.append(graph_t::halt(result.path[result.path.size() - 2]));
+		reverse.set_transit_halts(hop);
+	}
+	status = haltestelle_t::ROUTE_OK;
+	return true;
+}
+} // namespace route_tree_routing
+#endif


### PR DESCRIPTION
旅客の journey-time based routing で、同じ出発停留所集合からの探索状態を全体コミットまで再利用し、目的地ごとに探索を最初からやり直す負荷を減らします。

## 変更内容

- 出発停留所集合・探索上限・乗換上限などをキーとする探索木を、LRUで最大1,024件保持します。対象は、徒歩乗換・混雑回避なしで復路情報を要求する旅客の通常探索です。
- 全体コミット、路線設定変更、routing reset、停留所の生成・削除・ロードでキャッシュを破棄します。
- 探索上限に達しても、確定済みの範囲は再利用します。回答を確定できない場合は従来の探索へ戻します。
- 同額経路とゼロ重み辺も含め、キャッシュの状態や過去の目的地によって回答が変わらないよう、同一距離の候補を処理してから回答します。
- 比較検証で見つかった従来探索の枝刈りも修正します。最初の流入経路が高すぎた停留所を探索済み扱いにせず、後から安い経路で到達した際に再検討できるようにします。
- 優先度キューへの投入前に重みを `uint16` へ切り詰めていた修正は、独立したコミットにしています。

通常起動ではキャッシュの回答をゲームに使用し、二重探索は行いません。`SIMUTRANS_ROUTE_TREE_VERIFY` を指定した場合だけ、毎回初期化する探索との全件照合を行います。

## 実施した検証

- `make -j8`: 成功。
- ASan/UBSan付きのローカルC++テスト: 成功。独立した最短経路計算との10,000問い合わせ、および低い探索・乗換上限、問い合わせ順序などの10,000問い合わせを確認しました。ゼロ重み・同額経路、重みの桁あふれ、グラフ変更・ID再利用、1,024/1,025件のLRU境界も含みます。このローカルC++テストはPRには含めていません。
- SEST3で発生した不一致3件のグラフを保存し、独立した参照計算で再現しました。3件とも上記の枝刈り修正で解消しました。
- 修正後の従来探索との実マップ比較: **173,578件、到達可否・コストの不一致0件**。
- SEST3を**1倍速**で動かし、キャッシュの回答を実際にゲームで使用しながら、毎回初期化する同一アルゴリズムと照合: **190,995件、経路全体・到達可否・コスト・fallback判定の不一致0件**。うち再利用116,874件、fallback 0件、最大保持数1,024件。全体コミットによる破棄・再構築を複数回含みます。
- 以下のSquirrelテストが成功しています。追加ケースはテスト一覧にも登録しています。
  - `test_transport_pax_cached_route`（追加）: 反復問い合わせ、旅客の待機・乗車・到着、車両廃止後の経路消滅、停留所の削除・再作成。
  - `test_transport_pax_cached_transfer_interval`（追加）: キャッシュ適用条件での乗換区間制約、到達可否、実際の到着。
  - `test_transport_pax_valid_route`（既存）: 比較診断を無効にした通常起動での旅客輸送。

## 未確認の範囲・性能値の扱い

同一プロセスでのGUI再ロード、新規セーブの往復、実ネットワーク同期は未検証です。空キャッシュとの経路一致を、ネットワーク同期の実測成功とは扱っていません。

試作段階では1,024件保持で対象探索のCPU時間を約39%削減しましたが、これはゲーム全体の高速化率ではありません。枝刈り修正などを含む本PRの最終版で、同じ条件の性能比較は再実施していません。
