### PR TITLE
remove SDL3 build for ubuntu

### DIFF
--- a/.github/workflows/otrp-ubuntu.yml
+++ b/.github/workflows/otrp-ubuntu.yml
@@ -20,11 +20,6 @@ jobs:
             backend: sdl2
             sdl_package: libsdl2-dev
             distribute: true
-          - name: Ubuntu 26.04 / SDL3
-            os: ubuntu-26.04
-            backend: sdl3
-            sdl_package: libsdl3-dev
-            distribute: false
     
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
ubuntu向けSDL3版の自動ビルドが度々失敗していたため、一旦削除します