### PR TITLE
BUG FIX: field groundlevel change

### DIFF
--- a/simtool.cc
+++ b/simtool.cc
@@ -1842,7 +1842,10 @@ const char *tool_setslope_t::tool_set_slope_work( player_t *player, koord3d pos,
 		// maximum difference check with tiles to north, south east and west
 		const sint8 test_hgt = hgt+(new_slope!=0);
 
-		if(  gr1->get_typ()==grund_t::boden  ) {
+		// Foundations reaching this point carry a field (building tiles were rejected above),
+		// but their height may still be altered by this tool, so they have to obey the
+		// neighbour height difference limit just like plain ground.
+		if(  gr1->get_typ()==grund_t::boden  ||  gr1->get_typ()==grund_t::fundament  ) {
 			for(  sint16 i = 0 ;  i < 4 ;  i++  ) {
 				const koord neighbour = k + koord::nesw[i];
 


### PR DESCRIPTION
畑などの産業の`field`について、高さが自由に変更可能になっていた不具合を修正し、通常のタイルと同様の取り扱いに変更します