### PR TITLE
add OTRPversion in obj_t::finish_rd()

### DIFF
--- a/bauer/brueckenbauer.cc
+++ b/bauer/brueckenbauer.cc
@@ -4,6 +4,7 @@
  */
 
 #include <string.h>
+#include "../simversion.h"
 
 #include "../simdebug.h"
 #include "../simtool.h"
@@ -810,7 +811,7 @@ void bridge_builder_t::build_bridge(player_t *player, const koord3d start, const
 				lt = new leitung_t(start_gr->get_pos(), player);
 				lt->set_desc( way_desc );
 				start_gr->obj_add( lt );
-				lt->finish_rd();
+				lt->finish_rd( OTRP_VERSION_MAJOR );
 			}
 		}
 		else if(  !start_gr->weg_erweitern( desc->get_waytype(), ribi )  ) {
@@ -853,14 +854,14 @@ void bridge_builder_t::build_bridge(player_t *player, const koord3d start, const
 		else {
 			leitung_t *lt = new leitung_t(bruecke->get_pos(), player);
 			bruecke->obj_add( lt );
-			lt->finish_rd();
+			lt->finish_rd( OTRP_VERSION_MAJOR );
 		}
 		grund_t *gr = welt->lookup_kartenboden(pos.get_2d());
 		sint16 height = pos.z - gr->get_pos().z;
 		bruecke_t *br = new bruecke_t(bruecke->get_pos(), player, desc, desc->get_straight(ribi,height-slope_t::max_diff(gr->get_grund_hang())));
 		bruecke->obj_add(br);
 		bruecke->calc_image();
-		br->finish_rd();
+		br->finish_rd( OTRP_VERSION_MAJOR );
 //DBG_MESSAGE("bool bridge_builder_t::build_bridge()","at (%i,%i)",pos.x,pos.y);
 		if(desc->get_pillar()>0  &&  !gr->hat_weg(air_wt)) {
 			// make a new pillar here (never on airways)
@@ -918,7 +919,7 @@ void bridge_builder_t::build_bridge(player_t *player, const koord3d start, const
 				player_t::book_construction_costs(player, -way_desc->get_price(), gr->get_pos().get_2d(), powerline_wt);
 				gr->obj_add(lt);
 				lt->set_desc(way_desc);
-				lt->finish_rd();
+				lt->finish_rd( OTRP_VERSION_MAJOR );
 			}
 			lt->calc_neighbourhood();
 		}
@@ -1014,11 +1015,11 @@ void bridge_builder_t::build_ramp(player_t* player, koord3d end, ribi_t::ribi ri
 			player_t::add_maintenance( player, -lt->get_desc()->get_maintenance(), powerline_wt);
 		}
 		// connect to neighbor tiles and networks, add maintenance
-		lt->finish_rd();
+		lt->finish_rd( OTRP_VERSION_MAJOR );
 	}
 	bruecke_t *br = new bruecke_t(end, player, desc, img);
 	bruecke->obj_add( br );
-	br->finish_rd();
+	br->finish_rd( OTRP_VERSION_MAJOR );
 	bruecke->calc_image();
 }
 
@@ -1231,7 +1232,7 @@ const char *bridge_builder_t::remove(player_t *player, koord3d pos_start, waytyp
 				delete lt;
 				// .. now create powerline to create new powernet
 				lt = new leitung_t(gr->get_pos(), old_owner);
-				lt->finish_rd();
+				lt->finish_rd( OTRP_VERSION_MAJOR );
 				gr->obj_add(lt);
 			}
 		}

--- a/bauer/tunnelbauer.cc
+++ b/bauer/tunnelbauer.cc
@@ -4,6 +4,7 @@
  */
 
 #include <stdio.h>
+#include "../simversion.h"
 
 #include "../simdebug.h"
 
@@ -496,7 +497,7 @@ DBG_MESSAGE("tunnel_builder_t::build()","build from (%d,%d,%d) to (%d,%d,%d) ", 
 			lt = new leitung_t(tunnel->get_pos(), player);
 			lt->set_desc(way_desc);
 			tunnel->obj_add( lt );
-			lt->finish_rd();
+			lt->finish_rd( OTRP_VERSION_MAJOR );
 		}
 		tunnel->obj_add(new tunnel_t(pos, player, desc));
 		tunnel->calc_image();
@@ -545,7 +546,7 @@ DBG_MESSAGE("tunnel_builder_t::build()","build from (%d,%d,%d) to (%d,%d,%d) ", 
 			lt = new leitung_t(tunnel->get_pos(), player);
 			lt->set_desc(way_desc);
 			tunnel->obj_add( lt );
-			lt->finish_rd();
+			lt->finish_rd( OTRP_VERSION_MAJOR );
 		}
 		tunnel->obj_add(new tunnel_t(pos, player, desc));
 		tunnel->calc_image();
@@ -620,7 +621,7 @@ void tunnel_builder_t::build_tunnel_portal(player_t *player, koord3d end, koord 
 			// subtract maintenance once since leitung_t::finish_rd will add it again
 			player_t::add_maintenance( player, -1*lt->get_desc()->get_maintenance(), powerline_wt );
 		}
-		lt->finish_rd();
+		lt->finish_rd( OTRP_VERSION_MAJOR );
 	}
 
 	// remove sidewalk
@@ -824,7 +825,7 @@ const char *tunnel_builder_t::remove(player_t *player, koord3d start, waytype_t 
 		welt->access(pos.get_2d())->kartenboden_setzen(gr_new);
 
 		if(gr_new->get_leitung()) {
-			gr_new->get_leitung()->finish_rd();
+			gr_new->get_leitung()->finish_rd( OTRP_VERSION_MAJOR );
 		}
 
 		// recalc image of ground

--- a/bauer/wegbauer.cc
+++ b/bauer/wegbauer.cc
@@ -4,6 +4,7 @@
  */
 
 #include <algorithm>
+#include "../simversion.h"
 
 #include "../simdebug.h"
 #include "../simworld.h"
@@ -2605,7 +2606,7 @@ bool way_builder_t::build_tunnel_tile()
 				leitung_t *lt = new leitung_t(tunnel->get_pos(), player_builder);
 				lt->set_desc( wb );
 				tunnel->obj_add( lt );
-				lt->finish_rd();
+				lt->finish_rd( OTRP_VERSION_MAJOR );
 			}
 			tunnel->calc_image();
 			cost -= tunnel_desc->get_price();
@@ -2771,7 +2772,7 @@ void way_builder_t::build_road()
 				str->set_owner(player_builder);
 				str->set_way_building(false);// show ribi
 				if (crossing_t* crossing = gr->get_crossing()) {
-					crossing->finish_rd();
+					crossing->finish_rd( OTRP_VERSION_MAJOR );
 				}
 			}
 			str->set_vehicle_offset(vehicle_offset);
@@ -2877,7 +2878,7 @@ void way_builder_t::build_track()
 					// respect speed limit of crossing
 					weg->count_sign();
 					if (crossing_t* crossing = gr->get_crossing()) {
-						crossing->finish_rd();
+						crossing->finish_rd( OTRP_VERSION_MAJOR );
 					}
 				}
 				weg->set_vehicle_offset(vehicle_offset);
@@ -2964,7 +2965,7 @@ void way_builder_t::build_powerline()
 			lt->set_desc(desc);
 			player_t::book_construction_costs(player_builder, -desc->get_price(), gr->get_pos().get_2d(), powerline_wt);
 			// this adds maintenance
-			lt->leitung_t::finish_rd();
+			lt->leitung_t::finish_rd( OTRP_VERSION_MAJOR );
 			minimap_t::get_instance()->calc_map_pixel( gr->get_pos().get_2d() );
 		}
 

--- a/boden/grund.cc
+++ b/boden/grund.cc
@@ -4,6 +4,7 @@
  */
 
 #include <string.h>
+#include "../simversion.h"
 
 #include "../simcolor.h"
 #include "../simconst.h"
@@ -459,7 +460,7 @@ void grund_t::rdwr(loadsave_t *file)
 		const bool disjoint_diagonal = ribi_t::are_disjoint_bends(w1->get_ribi_unmasked(), w2->get_ribi_unmasked());
 		if(w1->needs_crossing(w2->get_desc())  &&  !disjoint_diagonal){
 			if (crossing_t* cr = get_crossing()) {
-				cr->finish_rd();
+				cr->finish_rd( file->get_OTRP_version() );
 			}
 			else {
 				const crossing_desc_t* cr_desc = crossing_logic_t::get_crossing(w1->get_waytype(), w2->get_waytype(), w1->get_max_speed(), w2->get_max_speed(), 0);
@@ -472,7 +473,7 @@ void grund_t::rdwr(loadsave_t *file)
 				}
 				cr = new crossing_t(w1->get_owner(), pos, cr_desc, ribi_t::is_straight_ns(get_weg(cr_desc->get_waytype(1))->get_ribi_unmasked()));
 				objlist.add(cr);
-				cr->finish_rd(); // or else not multithred safe!
+				cr->finish_rd( file->get_OTRP_version() ); // or else not multithred safe!
 			}
 		}
 		else {
@@ -2007,7 +2008,7 @@ sint64 grund_t::neuen_weg_bauen(weg_t *weg, ribi_t::ribi ribi, player_t *player)
 				crossing_t *cr = new crossing_t(obj_bei(0)->get_owner(), pos, cr_desc, ribi_t::is_straight_ns(get_weg(cr_desc->get_waytype(1))->get_ribi_unmasked()) );
 				objlist.add( cr );
 				crossing_logic_t::add(cr, crossing_logic_t::CROSSING_INVALID);
-				cr->finish_rd();
+				cr->finish_rd( OTRP_VERSION_MAJOR );
 			}
 		}
 

--- a/boden/wege/weg.cc
+++ b/boden/wege/weg.cc
@@ -1151,7 +1151,7 @@ void weg_t::new_month()
 
 
 // correct speed and maintenance
-void weg_t::finish_rd()
+void weg_t::finish_rd(const uint8 /*loaded_OTRP_version*/)
 {
 	player_t *player = get_owner();
 	if(  player  &&  desc  ) {

--- a/boden/wege/weg.h
+++ b/boden/wege/weg.h
@@ -322,7 +322,7 @@ public:
 
 
 	// correct maintenance
-	void finish_rd() OVERRIDE;
+	void finish_rd(const uint8 loaded_OTRP_version) OVERRIDE;
 
 	virtual bool is_clipping_below_needed() const OVERRIDE;
 } GCC_PACKED;

--- a/obj/baum.cc
+++ b/obj/baum.cc
@@ -126,7 +126,7 @@ void baum_t::rdwr(loadsave_t *file)
 }
 
 
-void baum_t::finish_rd()
+void baum_t::finish_rd(const uint8 /*loaded_OTRP_version*/)
 {
 	if(get_xoff()==-128) {
 		calc_off(welt->lookup( get_pos())->get_grund_hang());

--- a/obj/baum.h
+++ b/obj/baum.h
@@ -71,7 +71,7 @@ public:
 	void rdwr(loadsave_t *file) OVERRIDE;
 
 	/// @copydoc obj_t::finish_rd
-	void finish_rd() OVERRIDE;
+	void finish_rd(const uint8 loaded_OTRP_version) OVERRIDE;
 
 	/// @copydoc obj_t::get_image
 	image_id get_image() const OVERRIDE;

--- a/obj/bruecke.cc
+++ b/obj/bruecke.cc
@@ -166,7 +166,7 @@ void bruecke_t::rdwr(loadsave_t *file)
 
 
 // correct speed and maintenance
-void bruecke_t::finish_rd()
+void bruecke_t::finish_rd(const uint8 /*loaded_OTRP_version*/)
 {
 	grund_t *gr = welt->lookup(get_pos());
 	if(desc==NULL) {

--- a/obj/bruecke.h
+++ b/obj/bruecke.h
@@ -53,7 +53,7 @@ public:
 	 */
 	bool check_season(const bool calc_only_season_change) OVERRIDE { if(  !calc_only_season_change  ) { calc_image(); } return true; }  // depends on snowline only
 
-	void finish_rd() OVERRIDE;
+	void finish_rd(const uint8 loaded_OTRP_version) OVERRIDE;
 
 	void cleanup(player_t *player) OVERRIDE;
 

--- a/obj/crossing.cc
+++ b/obj/crossing.cc
@@ -160,7 +160,7 @@ void crossing_t::rdwr(loadsave_t *file)
 }
 
 
-void crossing_t::finish_rd()
+void crossing_t::finish_rd(const uint8 /*loaded_OTRP_version*/)
 {
 	grund_t *gr=welt->lookup(get_pos());
 	if(gr==NULL  ||  !gr->hat_weg(desc->get_waytype(0))  ||  !gr->hat_weg(desc->get_waytype(1))) {

--- a/obj/crossing.h
+++ b/obj/crossing.h
@@ -105,7 +105,7 @@ public:
 
 	void rdwr(loadsave_t *file) OVERRIDE;
 
-	void finish_rd() OVERRIDE;
+	void finish_rd(const uint8 loaded_OTRP_version) OVERRIDE;
 };
 
 #endif

--- a/obj/gebaeude.cc
+++ b/obj/gebaeude.cc
@@ -1066,7 +1066,7 @@ void gebaeude_t::rdwr(loadsave_t *file)
 }
 
 
-void gebaeude_t::finish_rd()
+void gebaeude_t::finish_rd(const uint8 /*loaded_OTRP_version*/)
 {
 	player_t::add_maintenance(get_owner(), tile->get_desc()->get_maintenance(welt), tile->get_desc()->get_finance_waytype());
 

--- a/obj/gebaeude.h
+++ b/obj/gebaeude.h
@@ -163,7 +163,7 @@ public:
 	void cleanup(player_t *player) OVERRIDE;
 
 	/// @copydoc obj_t::finish_rd
-	void finish_rd() OVERRIDE;
+	void finish_rd(const uint8 loaded_OTRP_version) OVERRIDE;
 
 	// currently animated
 	bool is_sync() const { return sync; }

--- a/obj/label.cc
+++ b/obj/label.cc
@@ -64,7 +64,7 @@ label_t::~label_t()
 }
 
 
-void label_t::finish_rd()
+void label_t::finish_rd(const uint8 /*loaded_OTRP_version*/)
 {
 #ifdef MULTI_THREAD
 	pthread_mutex_lock( &add_label_mutex );

--- a/obj/label.h
+++ b/obj/label.h
@@ -21,7 +21,7 @@ public:
 	label_t(koord3d pos, player_t *player, const char *text);
 	~label_t();
 
-	void finish_rd() OVERRIDE;
+	void finish_rd(const uint8 loaded_OTRP_version) OVERRIDE;
 
 	void show_info() OVERRIDE;
 

--- a/obj/leitung2.cc
+++ b/obj/leitung2.cc
@@ -342,7 +342,7 @@ void leitung_t::info(cbuffer_t & buf) const
 }
 
 
-void leitung_t::finish_rd()
+void leitung_t::finish_rd(const uint8 /*loaded_OTRP_version*/)
 {
 #ifdef MULTI_THREAD
 	pthread_mutex_lock( &verbinde_mutex );
@@ -556,9 +556,9 @@ void pumpe_t::rdwr(loadsave_t * file)
 }
 
 
-void pumpe_t::finish_rd()
+void pumpe_t::finish_rd(const uint8 loaded_OTRP_version)
 {
-	leitung_t::finish_rd();
+	leitung_t::finish_rd( loaded_OTRP_version );
 
 	assert(get_net());
 
@@ -899,9 +899,9 @@ void senke_t::rdwr(loadsave_t *file)
 	}
 }
 
-void senke_t::finish_rd()
+void senke_t::finish_rd(const uint8 loaded_OTRP_version)
 {
-	leitung_t::finish_rd();
+	leitung_t::finish_rd( loaded_OTRP_version );
 
 	assert(get_net());
 

--- a/obj/leitung2.h
+++ b/obj/leitung2.h
@@ -109,7 +109,7 @@ public:
 	void calc_neighbourhood();
 
 	void rdwr(loadsave_t *file) OVERRIDE;
-	void finish_rd() OVERRIDE;
+	void finish_rd(const uint8 loaded_OTRP_version) OVERRIDE;
 
 	/**
 	 * @return NULL if OK, otherwise an error message
@@ -170,7 +170,7 @@ public:
 	void info(cbuffer_t & buf) const OVERRIDE;
 
 	void rdwr(loadsave_t *file) OVERRIDE;
-	void finish_rd() OVERRIDE;
+	void finish_rd(const uint8 loaded_OTRP_version) OVERRIDE;
 
 	void calc_image() OVERRIDE {} // empty; otherwise it will change to leitung
 
@@ -261,7 +261,7 @@ public:
 	void info(cbuffer_t & buf) const OVERRIDE;
 
 	void rdwr(loadsave_t *file) OVERRIDE;
-	void finish_rd() OVERRIDE;
+	void finish_rd(const uint8 loaded_OTRP_version) OVERRIDE;
 
 	void calc_image() OVERRIDE {} // empty; otherwise it will change to leitung
 

--- a/obj/roadsign.cc
+++ b/obj/roadsign.cc
@@ -8,6 +8,7 @@
 
 #include "../simunits.h"
 #include "../simdebug.h"
+#include "../simversion.h"
 #include "simobj.h"
 #include "../display/simimg.h"
 #include "../player/simplay.h"
@@ -825,8 +826,18 @@ void roadsign_t::cleanup(player_t *player)
 }
 
 
-void roadsign_t::finish_rd()
+void roadsign_t::finish_rd(const uint8 loaded_OTRP_version)
 {
+	// Before OTRP v61 the end-of-choose flags of a road sign were never shown in the UI and road
+	// vehicles ignored them - they stopped at any END_OF_CHOOSE_AREA sign. Whatever is stored for
+	// such a sign is therefore meaningless, and now that road honours the flags an old sign whose
+	// bits happen to be unset would silently stop ending the choose area. Give it back the
+	// behaviour it had when it was saved.
+	if(  loaded_OTRP_version < 61  &&  desc  &&  desc->is_end_choose_signal()  &&  get_waytype()==road_wt  ) {
+		set_end_of_choose(true);
+		set_end_of_guide(true);
+	}
+
 	grund_t *gr=welt->lookup(get_pos());
 	if(  gr==NULL  ||  !gr->hat_weg(desc->get_wtyp()!=tram_wt ? desc->get_wtyp() : track_wt)  ) {
 		dbg->error("roadsign_t::finish_rd","roadsing: way/ground missing at %i,%i => ignore", get_pos().x, get_pos().y );

--- a/obj/roadsign.h
+++ b/obj/roadsign.h
@@ -268,7 +268,7 @@ public:
 	// subtracts cost
 	void cleanup(player_t *player) OVERRIDE;
 
-	void finish_rd() OVERRIDE;
+	void finish_rd(const uint8 loaded_OTRP_version) OVERRIDE;
 
 	// static routines from here
 private:

--- a/obj/simobj.h
+++ b/obj/simobj.h
@@ -264,7 +264,7 @@ public:
 	/**
 	 * Called after the world is completely loaded from savegame
 	 */
-	virtual void finish_rd() {}
+	virtual void finish_rd(const uint8 /*loaded_OTRP_version*/) {}
 
 	/**
 	 * @return position

--- a/obj/tunnel.cc
+++ b/obj/tunnel.cc
@@ -145,7 +145,7 @@ void tunnel_t::rdwr(loadsave_t *file)
 }
 
 
-void tunnel_t::finish_rd()
+void tunnel_t::finish_rd(const uint8 /*loaded_OTRP_version*/)
 {
 	const grund_t *gr = welt->lookup(get_pos());
 	player_t *player=get_owner();

--- a/obj/tunnel.h
+++ b/obj/tunnel.h
@@ -51,7 +51,7 @@ public:
 
 	void rdwr(loadsave_t *file) OVERRIDE;
 
-	void finish_rd() OVERRIDE;
+	void finish_rd(const uint8 loaded_OTRP_version) OVERRIDE;
 
 	void cleanup(player_t *player) OVERRIDE;
 

--- a/obj/wayobj.cc
+++ b/obj/wayobj.cc
@@ -4,6 +4,7 @@
  */
 
 #include <algorithm>
+#include "../simversion.h"
 
 #include "../boden/grund.h"
 #include "../simworld.h"
@@ -188,7 +189,7 @@ const char *wayobj_t::is_deletable(const player_t *player)
 }
 
 
-void wayobj_t::finish_rd()
+void wayobj_t::finish_rd(const uint8 /*loaded_OTRP_version*/)
 {
 	// (re)set dir
 	if(dir==dir_unknown) {
@@ -380,7 +381,7 @@ void wayobj_t::extend_wayobj(koord3d pos, player_t *owner, ribi_t::ribi dir, con
 		// nothing found => make a new one
 		wayobj_t *wo = new wayobj_t(pos,owner,dir,desc);
 		gr->obj_add(wo);
-		wo->finish_rd();
+		wo->finish_rd( OTRP_VERSION_MAJOR );
 		wo->calc_image();
 		wo->mark_image_dirty( wo->get_front_image_test(), 0 );
 		wo->set_flag(obj_t::dirty);

--- a/obj/wayobj.h
+++ b/obj/wayobj.h
@@ -113,7 +113,7 @@ public:
 
 	const char* is_deletable(const player_t *player) OVERRIDE;
 
-	void finish_rd() OVERRIDE;
+	void finish_rd(const uint8 loaded_OTRP_version) OVERRIDE;
 
 	// specific for wayobj
 	void set_dir(ribi_t::ribi d) { dir = d; calc_image(); }

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -3550,7 +3550,7 @@ void convoi_t::rdwr(loadsave_t *file)
 				}
 				// add to crossing
 				if(crossing_t *cr = gr->get_crossing()) {
-					cr->finish_rd();	// add crossing logic if needed (as finish_rd() was not yet processed
+					cr->finish_rd( file->get_OTRP_version() );	// add crossing logic if needed (as finish_rd() was not yet processed
 					cr->add_to_crossing(v);
 				}
 				if(  gr->get_top()>253  ) {

--- a/simtool.cc
+++ b/simtool.cc
@@ -4,6 +4,7 @@
  */
 
 #include <stdio.h>
+#include "simversion.h"
 #include <string.h>
 #include <math.h>
 
@@ -1947,7 +1948,7 @@ const char *tool_setslope_t::tool_set_slope_work( player_t *player, koord3d pos,
 			if(  lt  ) {
 				// remove maintenance for existing powerline
 				player_t::add_maintenance(lt->get_owner(), -lt->get_desc()->get_maintenance(), powerline_wt);
-				lt->finish_rd();
+				lt->finish_rd( OTRP_VERSION_MAJOR );
 			}
 
 			if(  gr1->ist_karten_boden()  ) {
@@ -2254,12 +2255,12 @@ const char *tool_transformer_t::work( player_t *player, koord3d pos )
 	if(fab && fab->get_desc()->is_electricity_producer()) {
 		pumpe_t *p = new pumpe_t(gr->get_pos(), player);
 		gr->obj_add( p );
-		p->finish_rd();
+		p->finish_rd( OTRP_VERSION_MAJOR );
 	}
 	else {
 		senke_t *s = new senke_t(gr->get_pos(), player);
 		gr->obj_add(s);
-		s->finish_rd();
+		s->finish_rd( OTRP_VERSION_MAJOR );
 	}
 
 	return NULL; // ok
@@ -6728,7 +6729,7 @@ const char *tool_build_roadsign_t::place_sign_intern( player_t *player, grund_t*
 					rs = new roadsign_t(player, gr->get_pos(), dir, desc);
 built_sign:
 					gr->obj_add(rs);
-					rs->finish_rd(); // to make them visible
+					rs->finish_rd( OTRP_VERSION_MAJOR ); // to make them visible
 					weg->count_sign();
 					player_t::book_construction_costs(player, -desc->get_price(), gr->get_pos().get_2d(), weg->get_waytype());
 				}

--- a/simworld.cc
+++ b/simworld.cc
@@ -2171,6 +2171,7 @@ karte_t::karte_t() :
 
 	// for new world just set load version to current savegame version
 	load_version = loadsave_t::int_version( env_t::savegame_version_str, NULL ).version;
+	load_otrp_version = OTRP_VERSION_MAJOR;
 
 	// standard prices
 	goods_manager_t::set_multiplier( 1000 );
@@ -5452,7 +5453,7 @@ void karte_t::plans_finish_rd( sint16 x_min, sint16 x_max, sint16 y_min, sint16 
 				for(  int n = 0;  n < gr->get_top();  n++  ) {
 					obj_t *obj = gr->obj_bei(n);
 					if(obj) {
-						obj->finish_rd();
+						obj->finish_rd( load_otrp_version );
 					}
 				}
 				if(  load_version<=111000  &&  gr->ist_natur()  ) {
@@ -5832,6 +5833,7 @@ DBG_MESSAGE("karte_t::load()", "%d factories loaded", fab_list.get_count());
 
 	// loading finished, reset savegame version to current
 	load_version = loadsave_t::int_version( env_t::savegame_version_str, NULL ).version;
+	load_otrp_version = OTRP_VERSION_MAJOR;
 
 	dbg->warning("karte_t::load()","loaded savegame from %i/%i, next month=%i, ticks=%i (per month=1<<%i)",last_month,last_year,next_month_ticks,ticks,karte_t::ticks_per_world_month_shift);
 }
@@ -5866,6 +5868,7 @@ void karte_t::rdwr_gamestate(loadsave_t *file, loadingscreen_t *ls)
 	if (file->is_loading()) {
 		// some functions (finish_rd) need to know what version was loaded
 		load_version = file->get_version_int();
+		load_otrp_version = file->get_OTRP_version();
 		loaded_rotation = settings.get_rotation();
 	}
 	else {

--- a/simworld.h
+++ b/simworld.h
@@ -1493,6 +1493,10 @@ public:
 	 */
 	uint32 load_version;
 
+	/// OTRP version of the savegame being loaded, so that finish_rd() of map objects can make
+	/// version dependent corrections. OTRP_VERSION_MAJOR while no savegame is being read.
+	uint8 load_otrp_version;
+
 	/**
 	 * Checks if the planquadrat (tile) at coordinate (x,y)
 	 * can be lowered at the specified height.

--- a/vehicle/simroadtraffic.cc
+++ b/vehicle/simroadtraffic.cc
@@ -218,7 +218,7 @@ void road_user_t::rdwr(loadsave_t *file)
 	weg_next &= 65535;
 }
 
-void road_user_t::finish_rd()
+void road_user_t::finish_rd(const uint8 /*loaded_OTRP_version*/)
 {
 	calc_height(NULL);
 	calc_image();

--- a/vehicle/simroadtraffic.h
+++ b/vehicle/simroadtraffic.h
@@ -61,7 +61,7 @@ public:
 	void rdwr(loadsave_t *file) OVERRIDE;
 
 	// finalizes direction
-	void finish_rd() OVERRIDE;
+	void finish_rd(const uint8 loaded_OTRP_version) OVERRIDE;
 
 	// we allow to remove all cars etc.
 	const char *is_deletable(const player_t *) OVERRIDE { return NULL; }


### PR DESCRIPTION
`finish_rd()`に`OTRP_version`引数を追加します。これにより、オブジェクトのフラグ上書き処理等をバージョン差分に応じて安全に行うことが可能になります