### PR TITLE
add new OTRP mode: only_one_car and stop_only_halt

### DIFF
--- a/bauer/wegbauer.cc
+++ b/bauer/wegbauer.cc
@@ -2743,7 +2743,7 @@ void way_builder_t::build_road()
 				str->set_way_building(false);// show ribi
 			}
 			// keep faster ways or if it is the same way ... (@author prissi)
-			else if((str->get_desc()==desc  &&  str->get_overtaking_mode()==overtaking_mode  &&  str->get_street_flag()==street_flag  )
+			else if((str->get_desc()==desc  &&  str->get_overtaking_mode_raw()==overtaking_mode  &&  str->get_street_flag()==street_flag  )
 				||  keep_existing_ways
 				||  (keep_existing_city_roads  &&  str->hat_gehweg())
 				||  (keep_existing_faster_ways  &&  str->get_desc()->get_topspeed()>desc->get_topspeed())

--- a/boden/grund.cc
+++ b/boden/grund.cc
@@ -415,8 +415,8 @@ void grund_t::rdwr(loadsave_t *file)
 						weg->set_pos(pos);
 						// check illegal overtaking_mode
 						if(  wtyp==road_wt  ) {
-							const overtaking_mode_t ov = ((strasse_t*)weg)->get_overtaking_mode();
-							if(  ov<halt_mode  ||  ov>inverted_mode  ) {
+							const overtaking_mode_t ov = ((strasse_t*)weg)->get_overtaking_mode_raw();
+							if(  ov<halt_mode  ||  ov>passing_lane_stop_only_mode  ) {
 								dbg->error( "grund_t::rdwr()", "Road %s has illegal overtaking mode %d.", get_pos().get_str(), ov );
 							}
 						}

--- a/boden/wege/strasse.cc
+++ b/boden/wege/strasse.cc
@@ -108,7 +108,7 @@ void strasse_t::rdwr(loadsave_t *file)
 		uint8 mask_oneway = get_ribi_mask_oneway();
 		file->rdwr_byte(mask_oneway);
 		set_ribi_mask_oneway(mask_oneway);
-		sint8 ov = get_overtaking_mode();
+		sint8 ov = get_overtaking_mode_raw();
 		file->rdwr_byte(ov);
 		overtaking_mode_t nov = (overtaking_mode_t)ov;
 		set_overtaking_mode(nov);

--- a/boden/wege/strasse.h
+++ b/boden/wege/strasse.h
@@ -108,9 +108,16 @@ public:
 	* loading_only_mode = overtaking a loading convoy only
 	* prohibited_mode = overtaking is completely forbidden
 	* inverted_mode = vehicles can go only on passing lane
+	* only_one_car_mode = drives like prohibited_mode, only one convoy at a time in the connected area
+	* passing_lane_stop_only_mode = drives like prohibited_mode, but a convoy may stop on the passing lane
+	*
+	* The last two are restrictions on top of prohibited_mode and are mapped onto it here, so that
+	* the ordering comparisons all over the driving logic keep working. Everything that shows, saves
+	* or builds a mode has to use get_overtaking_mode_raw() instead.
 	* @author teamhimeH
 	*/
-	overtaking_mode_t get_overtaking_mode() const { return overtaking_mode; };
+	overtaking_mode_t get_overtaking_mode() const { return effective_overtaking_mode(overtaking_mode); };
+	overtaking_mode_t get_overtaking_mode_raw() const { return overtaking_mode; };
 	void set_overtaking_mode(overtaking_mode_t o) { overtaking_mode = o; };
 
 	void set_ribi_mask_oneway(ribi_t::ribi ribi) { ribi_mask_oneway = (uint8)ribi; }

--- a/boden/wege/weg.cc
+++ b/boden/wege/weg.cc
@@ -326,7 +326,7 @@ void weg_t::info(cbuffer_t & buf) const
 		const strasse_t* str = (const strasse_t*) this;
 		assert(str);
 		// Display overtaking_info
-		switch (str->get_overtaking_mode()) {
+		switch (str->get_overtaking_mode_raw()) {
 			case halt_mode:
 				buf.printf("%s %s\n", translator::translate("Overtaking:"),translator::translate("halt mode"));
 				break;
@@ -345,8 +345,14 @@ void weg_t::info(cbuffer_t & buf) const
 			case inverted_mode:
 				buf.printf("%s %s\n", translator::translate("Overtaking:"),translator::translate("inverted"));
 				break;
+			case only_one_car_mode:
+				buf.printf("%s %s\n", translator::translate("Overtaking:"),translator::translate("only one car"));
+				break;
+			case passing_lane_stop_only_mode:
+				buf.printf("%s %s\n", translator::translate("Overtaking:"),translator::translate("passing lane stop only"));
+				break;
 			default:
-				buf.printf("%s %s %d\n", translator::translate("Overtaking:"),translator::translate("ERROR"),str->get_overtaking_mode());
+				buf.printf("%s %s %d\n", translator::translate("Overtaking:"),translator::translate("ERROR"),str->get_overtaking_mode_raw());
 				break;
 		}
 

--- a/documentation/ja.OTRP.tab
+++ b/documentation/ja.OTRP.tab
@@ -23,6 +23,10 @@ oneway
 片側二車線一方通行
 halt mode
 追越車線にも停車
+only one car
+一度に一編成のみ進入可
+passing lane stop only
+追越車線は停車のみ可
 avoid becoming cityroad
 市道化を禁止する
 no building adjacent

--- a/gui/overtaking_mode.cc
+++ b/gui/overtaking_mode.cc
@@ -16,7 +16,7 @@
 #define L_DIALOG_WIDTH (200)
 
 overtaking_mode_t overtaking_mode_frame_t::overtaking_mode = twoway_mode;
-char overtaking_mode_frame_t::mode_name[6][20] = {"halt mode", "oneway", "twoway", "only loading convoi", "prohibited", "inverted"};
+char overtaking_mode_frame_t::mode_name[8][32] = {"halt mode", "oneway", "twoway", "only loading convoi", "prohibited", "inverted", "only one car", "passing lane stop only"};
 
 overtaking_mode_frame_t::overtaking_mode_frame_t(player_t *player_, tool_build_way_t* tool_, bool show_avoid_cityroad) :
 	gui_frame_t( tool_->get_waytype()==road_wt? translator::translate("Road Configuration") : translator::translate("Way Configuration") )
@@ -81,7 +81,7 @@ void overtaking_mode_frame_t::init( player_t* player_, overtaking_mode_t overtak
 
 	if(  waytype==road_wt  ) {
 
-		for(int i = 0 ; i < 6; i++){
+		for(int i = 0 ; i < 8; i++){
 			mode_button[i].init( button_t::square_state, mode_name[i]);
 			mode_button[i].add_listener(this);
 			mode_button[i].pressed = false;
@@ -94,6 +94,8 @@ void overtaking_mode_frame_t::init( player_t* player_, overtaking_mode_t overtak
 		if(  overtaking_mode==loading_only_mode  ) mode_button[3].pressed = true;
 		if(  overtaking_mode==prohibited_mode    ) mode_button[4].pressed = true;
 		if(  overtaking_mode==inverted_mode      ) mode_button[5].pressed = true;
+		if(  overtaking_mode==only_one_car_mode   ) mode_button[6].pressed = true;
+		if(  overtaking_mode==passing_lane_stop_only_mode  ) mode_button[7].pressed = true;
 
 		add_component(&divider[0]);
 		
@@ -190,6 +192,12 @@ bool overtaking_mode_frame_t::action_triggered( gui_action_creator_t *komp, valu
 	}else if(  komp==&mode_button[5]  ) {
 		overtaking_mode = inverted_mode;
 		num = 5;
+	}else if(  komp==&mode_button[6]  ) {
+		overtaking_mode = only_one_car_mode;
+		num = 6;
+	}else if(  komp==&mode_button[7]  ) {
+		overtaking_mode = passing_lane_stop_only_mode;
+		num = 7;
 	}else if(  komp==&avoid_cityroad_button  ) {
 		avoid_cityroad_button.pressed = !(avoid_cityroad_button.pressed);
 
@@ -265,7 +273,7 @@ bool overtaking_mode_frame_t::action_triggered( gui_action_creator_t *komp, valu
 		return true;
 	}
 	if(num!=-1) {
-		for(int i = 0; i < 6; i++){
+		for(int i = 0; i < 8; i++){
 			if(  num==i  ){
 				mode_button[i].pressed = true;
 			}else{

--- a/gui/overtaking_mode.h
+++ b/gui/overtaking_mode.h
@@ -24,7 +24,7 @@ class overtaking_mode_frame_t : public gui_frame_t, private action_listener_t
 {
 private:
 	static overtaking_mode_t overtaking_mode;
-	static char mode_name[6][20];
+	static char mode_name[8][32];
 	player_t *player;
 	tool_build_way_t* tool_w;
 	tool_build_bridge_t* tool_b;
@@ -35,7 +35,7 @@ private:
 	sint8 vehicle_offset_value;
 	bool vehicle_offset_mode_value;
 	uint8 tool_class; // 0:way, 1:bridge, 2:tunnel, 3:change_way_settings, 4:change_way_offset
-	button_t mode_button[6];
+	button_t mode_button[8];
 	gui_divider_t divider[2];
 	button_t avoid_cityroad_button;
 	button_t citycar_no_entry_button;

--- a/script/api/api_const.cc
+++ b/script/api/api_const.cc
@@ -212,6 +212,10 @@ void export_global_constants(HSQUIRRELVM vm)
 	enum_slot(vm, "prohibited_mode", prohibited_mode);
 	/// vehicles can go only on passing lane
 	enum_slot(vm, "inverted_mode", inverted_mode);
+	/// like prohibited, but only one convoy at a time in the connected area
+	enum_slot(vm, "only_one_car_mode", only_one_car_mode);
+	/// like prohibited, but a convoy may stop on the passing lane
+	enum_slot(vm, "passing_lane_stop_only_mode", passing_lane_stop_only_mode);
 	end_enum();
 
 	/**

--- a/script/api/api_map_objects.cc
+++ b/script/api/api_map_objects.cc
@@ -304,7 +304,7 @@ static SQInteger get_overtaking_mode(HSQUIRRELVM vm)
 {
 	strasse_t *w = param<strasse_t*>::get(vm, 1);
 	if (w) {
-		return param<sint8>::push(vm, w->get_overtaking_mode());
+		return param<sint8>::push(vm, w->get_overtaking_mode_raw());
 	}
 	return param<sint8>::push(vm, twoway_mode);
 }

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -1661,7 +1661,7 @@ void convoi_t::step()
 			laden();
 			//When loading, vehicle should not be on passing lane.
 			str = (strasse_t*)welt->lookup(get_pos())->get_weg(road_wt);
-			if(  str  &&  str->get_overtaking_mode()!=inverted_mode  &&  str->get_overtaking_mode()!=halt_mode  ) set_tiles_overtaking(0);
+			if(  str  &&  str->get_overtaking_mode()!=inverted_mode  &&  str->get_overtaking_mode()!=halt_mode  &&  str->get_overtaking_mode_raw()!=passing_lane_stop_only_mode  ) set_tiles_overtaking(0);
 			break;
 
 		case DUMMY4:
@@ -1815,8 +1815,9 @@ void convoi_t::step()
 					akt_speed = restart_speed;
 				}
 				if(  fahr[0]->get_waytype()==road_wt  ) {
-					sint8 overtaking_mode = static_cast<strasse_t*>(welt->lookup(get_pos())->get_weg(road_wt))->get_overtaking_mode();
-					if(  (state==CAN_START  ||  state==CAN_START_ONE_MONTH)  &&  overtaking_mode>oneway_mode  &&  overtaking_mode!=inverted_mode  &&  !reversing_lane_hold  ) {
+					const strasse_t* str0 = static_cast<strasse_t*>(welt->lookup(get_pos())->get_weg(road_wt));
+					sint8 overtaking_mode = str0->get_overtaking_mode();
+					if(  (state==CAN_START  ||  state==CAN_START_ONE_MONTH)  &&  overtaking_mode>oneway_mode  &&  overtaking_mode!=inverted_mode  &&  str0->get_overtaking_mode_raw()!=passing_lane_stop_only_mode  &&  !reversing_lane_hold  ) {
 						set_tiles_overtaking( 0 );
 					}
 				}
@@ -1835,8 +1836,9 @@ void convoi_t::step()
 					akt_speed = restart_speed;
 				}
 				if(  fahr[0]->get_waytype()==road_wt  ) {
-					sint8 overtaking_mode = static_cast<strasse_t*>(welt->lookup(get_pos())->get_weg(road_wt))->get_overtaking_mode();
-					if(  state!=DRIVING  &&  overtaking_mode>oneway_mode  &&  overtaking_mode!=inverted_mode  &&  !reversing_lane_hold  ) {
+					const strasse_t* str0 = static_cast<strasse_t*>(welt->lookup(get_pos())->get_weg(road_wt));
+					sint8 overtaking_mode = str0->get_overtaking_mode();
+					if(  state!=DRIVING  &&  overtaking_mode>oneway_mode  &&  overtaking_mode!=inverted_mode  &&  str0->get_overtaking_mode_raw()!=passing_lane_stop_only_mode  &&  !reversing_lane_hold  ) {
 						set_tiles_overtaking( 0 );
 					}
 				}
@@ -5797,6 +5799,52 @@ void convoi_t::set_withdraw(bool new_withdraw)
 }
 
 
+// passing_lane_stop_only_mode allows the passing lane to be used for one purpose only: coming to a
+// stand beside a convoy that already occupies the traffic lane, so that two convoys fit into the
+// same stop. So the manoeuvre is granted exactly when the convoy to be passed stands still, every
+// tile needed for it carries that mode and has a free passing lane, and this convoy's route ends
+// within those tiles - i.e. it really does stop there instead of driving on past on the wrong lane.
+bool convoi_t::can_stop_on_passing_lane(sint32 other_speed, sint16 steps_other)
+{
+	if(  other_speed != 0  ) {
+		// only a standing convoy may be passed here
+		return false;
+	}
+	const uint32 idx = fahr[0]->get_route_index();
+	const sint32 tiles = (steps_other-1)/(CARUNITS_PER_TILE*VEHICLE_STEPS_PER_CARUNIT) + get_tile_length() + 1;
+	if(  idx + (uint32)tiles < route.get_count()  ) {
+		// the route goes on beyond the manoeuvre: we would be driving on the passing lane, not stopping on it
+		return false;
+	}
+	for(  sint32 i=0;  i<tiles  &&  idx+(uint32)i<route.get_count();  i++  ) {
+		grund_t *gr = welt->lookup( route.at( idx+i ) );
+		if(  gr==NULL  ||  gr->get_crossing()  ) {
+			return false;
+		}
+		strasse_t *str = (strasse_t*)gr->get_weg(road_wt);
+		if(  str==NULL  ||  str->get_overtaking_mode_raw()!=passing_lane_stop_only_mode  ) {
+			return false;
+		}
+		// the passing lane itself has to be free: with somebody already standing on it this convoy
+		// stays in the traffic lane, and waits behind if that one is taken as well.
+		const uint8 top = gr->get_top();
+		for(  uint8 j=1;  j<top;  j++  ) {
+			if(  vehicle_base_t* const v = obj_cast<vehicle_base_t>(gr->obj_bei(j))  ) {
+				if(  v->get_typ()==obj_t::pedestrian  ||  v->get_waytype()!=road_wt  ) {
+					continue;
+				}
+				const overtaker_t *ov = v->get_overtaker();
+				if(  ov  &&  ov!=this  &&  ov->is_overtaking()  ) {
+					return false;
+				}
+			}
+		}
+	}
+	set_tiles_overtaking( tiles );
+	return true;
+}
+
+
 /**
  * conditions for a city car to overtake another overtaker.
  * The city car is not overtaking/being overtaken.
@@ -5819,6 +5867,18 @@ bool convoi_t::can_overtake(overtaker_t *other_overtaker, sint32 other_speed, si
 	overtaking_mode_t overtaking_mode = str->get_overtaking_mode();
 	if (  !other_overtaker->can_be_overtaken()  &&  overtaking_mode > oneway_mode  ) {
 		return false;
+	}
+	// This road drives like a prohibited one, with a single exception: pulling onto the passing lane
+	// to stop beside a convoy that already occupies the traffic lane at the stop. The manoeuvre
+	// starts on the tile before the first one carrying the mode, so the tile we are about to enter
+	// decides as well as the one we are standing on.
+	{
+		const grund_t *gr_next = fahr[0]->get_route_index() < route.get_count() ? welt->lookup( route.at( fahr[0]->get_route_index() ) ) : NULL;
+		const strasse_t *str_next = gr_next ? (const strasse_t*)gr_next->get_weg(road_wt) : NULL;
+		if(  str->get_overtaking_mode_raw()==passing_lane_stop_only_mode
+		  ||  (str_next  &&  str_next->get_overtaking_mode_raw()==passing_lane_stop_only_mode)  ) {
+			return can_stop_on_passing_lane( other_speed, steps_other );
+		}
 	}
 	if(  overtaking_mode == prohibited_mode  ){
 		// This road prohibits overtaking.

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -1192,6 +1192,10 @@ public:
 	// Overtaking for convois
 	virtual bool can_overtake(overtaker_t *other_overtaker, sint32 other_speed, sint16 steps_other) OVERRIDE;
 
+	// passing_lane_stop_only_mode: may this convoy pull onto the passing lane in order to come to a
+	// stand beside the standing convoy in front of it? Grants the lane (set_tiles_overtaking) if so.
+	bool can_stop_on_passing_lane(sint32 other_speed, sint16 steps_other);
+
 	/*
 	 * Functions related to requested_change_lane
 	 * @author teamhimeH

--- a/simtool.cc
+++ b/simtool.cc
@@ -3478,6 +3478,12 @@ void tool_build_way_t::set_mode_str(char* str, overtaking_mode_t overtaking_mode
 		case inverted_mode:
 			sprintf(str, "I");
 		break;
+		case only_one_car_mode:
+			sprintf(str, "1");
+		break;
+		case passing_lane_stop_only_mode:
+			sprintf(str, "S");
+		break;
 		default:
 			sprintf(str, "X");
 		break;

--- a/simtypes.h
+++ b/simtypes.h
@@ -170,8 +170,24 @@ enum systemtype_t {
 	 loading_only_mode = 2,  // overtake a loading convoy only
 	 prohibited_mode   = 3,  // overtaking is completely forbidden
 	 inverted_mode     = 4,  // vehicles can go only on passing lane
+	 only_one_car_mode = 5,  // drives like prohibited_mode, but only one convoy at a time in the connected area
+	 passing_lane_stop_only_mode = 6, // drives like prohibited_mode, but a convoy may stop on the passing lane
 	 invalid_mode      = 63
  };
+
+/**
+ * only_one_car_mode and passing_lane_stop_only_mode are extra restrictions layered on top of
+ * prohibited_mode: a vehicle drives on such a road exactly as it drives on a prohibited one, the
+ * added rule is checked separately. The whole driving logic compares overtaking modes by their
+ * order (<=oneway_mode, >twoway_mode, <inverted_mode ...), so those two are mapped onto the mode
+ * they drive like before they ever reach it. strasse_t::get_overtaking_mode() returns the mapped
+ * mode and strasse_t::get_overtaking_mode_raw() the mode the player actually set.
+ * @author THLeaderH
+ */
+inline overtaking_mode_t effective_overtaking_mode(overtaking_mode_t m)
+{
+	return (m==only_one_car_mode  ||  m==passing_lane_stop_only_mode) ? prohibited_mode : m;
+}
 
 
 // define machine independent types

--- a/vehicle/simroadtraffic.cc
+++ b/vehicle/simroadtraffic.cc
@@ -1841,7 +1841,7 @@ vehicle_base_t* private_car_t::is_there_car (grund_t *gr) const
 	assert(  gr  );
 	// this function cannot process vehicles on twoway and related mode road.
 	const strasse_t* str = (strasse_t *)gr->get_weg(road_wt);
-	if(  !str  ||  (str->get_overtaking_mode()>=twoway_mode  &&  str->get_overtaking_mode()<inverted_mode)  ) {
+	if(  !str  ||  (str->get_overtaking_mode()>=twoway_mode  &&  str->get_overtaking_mode()<inverted_mode  &&  str->get_overtaking_mode_raw()!=passing_lane_stop_only_mode)  ) {
 		return NULL;
 	}
 	for(  uint8 pos=1;  pos<(volatile uint8)gr->get_top();  pos++  ) {

--- a/vehicle/simvehicle.cc
+++ b/vehicle/simvehicle.cc
@@ -2750,6 +2750,24 @@ bool road_vehicle_t::can_enter_tile(const grund_t *gr, sint32 &restart_speed, ui
 			}
 		}
 
+		// only_one_car_mode: the area of road behind this tile takes a single convoy at a time. The
+		// test is made when crossing the border into such an area - once inside, this convoy is the
+		// one holding it. Convoys check and hop one after the other within their own step, so two of
+		// them cannot both see an empty area and drive in.
+		if(  str->get_overtaking_mode_raw()==only_one_car_mode  ) {
+			const grund_t* gr_now = welt->lookup(get_pos());
+			const strasse_t* str_now = gr_now ? (const strasse_t*)gr_now->get_weg(road_wt) : NULL;
+			if(  !str_now  ||  str_now->get_overtaking_mode_raw()!=only_one_car_mode  ) {
+				if(  get_blocking_convoi_in_single_car_area(gr)  ) {
+					// somebody else is in there. Wait at the border, like at a block signal - this is
+					// a normal wait, not a traffic jam, so no stuck message.
+					restart_speed = 0;
+					cnv->reset_waiting();
+					return false;
+				}
+			}
+		}
+
 		// first: check roadsigns
 		const roadsign_t *rs = NULL;
 		if(  str->has_sign()  ) {
@@ -3240,6 +3258,21 @@ bool road_vehicle_t::can_enter_tile(const grund_t *gr, sint32 &restart_speed, ui
 			}
 			else {
 				// lane change is prohibited.
+				// The one exception is a passing-lane-stop-only road: a convoy whose route ends here
+				// may pull onto the passing lane to come to a stand beside the convoy standing in the
+				// traffic lane, so that both fit into the same stop.
+				if(  str->get_overtaking_mode_raw()==passing_lane_stop_only_mode  &&  !cnv->is_overtaking()
+				  &&  !cnv->get_schedule()->get_current_entry().is_no_overtake()  &&  test_index==route_index+1u  ) {
+					if(  road_vehicle_t const* const car = obj_cast<road_vehicle_t>(obj)  ) {
+						convoi_t* const ocnv = car->get_convoi();
+						const sint32 other_speed = ocnv->get_state()==convoi_t::LOADING ? 0 : ocnv->get_akt_speed();
+						if(  other_speed==0  &&  cnv->can_overtake( ocnv, 0, ocnv->get_length_in_steps()+ocnv->get_vehikel(0)->get_steps() )  ) {
+							// this vehicle changes lane. we have to unreserve tiles.
+							unreserve_all_tiles();
+							return true;
+						}
+					}
+				}
 				if(  obj->is_stuck()  ) {
 					// end of traffic jam, but no stuck message, because previous vehicle is stuck too
 					restart_speed = 0;
@@ -3267,7 +3300,10 @@ bool road_vehicle_t::can_enter_tile(const grund_t *gr, sint32 &restart_speed, ui
 		}
 		// If this vehicle is on passing lane and the next tile prohibites overtaking, this vehicle must wait until traffic lane become safe.
 		// When condition changes, overtaking should be quitted once.
-		if(  (cnv->is_overtaking()  &&  str->get_overtaking_mode()==prohibited_mode)  ||  (cnv->is_overtaking()  &&  str->get_overtaking_mode()>oneway_mode  &&  str->get_overtaking_mode()<inverted_mode  &&  static_cast<strasse_t*>(welt->lookup(get_pos())->get_weg(road_wt))->get_overtaking_mode()<=oneway_mode)  ) {
+		// A convoy holding the passing lane of a passing-lane-stop-only road to stop beside another
+		// one is exempt: the traffic lane it would be sent back to is precisely the one occupied by
+		// the convoy it is pulling up beside.
+		if(  !holds_passing_lane_to_stop(str)  &&  ((cnv->is_overtaking()  &&  str->get_overtaking_mode()==prohibited_mode)  ||  (cnv->is_overtaking()  &&  str->get_overtaking_mode()>oneway_mode  &&  str->get_overtaking_mode()<inverted_mode  &&  static_cast<strasse_t*>(welt->lookup(get_pos())->get_weg(road_wt))->get_overtaking_mode()<=oneway_mode))  ) {
 			if(  vehicle_base_t* v = other_lane_blocked(false, offset)  ) {
 				if(  v->get_waytype() == road_wt  ) {
 					restart_speed = 0;
@@ -3415,6 +3451,89 @@ bool road_vehicle_t::is_coupling_partner(const vehicle_base_t* v) const
 	road_vehicle_t const* const at = obj_cast<road_vehicle_t>(v);
 	// the partner may already be a chain of coupled convoys. Any of them is our target.
 	return at  &&  is_coupling_chain_member(cc, at->get_convoi());
+}
+
+
+// only_one_car_mode makes a whole connected area of road behave like a single-track section: only
+// one convoy may be inside it at a time. The area is the set of tiles carrying that mode that are
+// reachable from the entry tile along the road, so it does not matter where a convoy entered it.
+convoi_t* road_vehicle_t::get_blocking_convoi_in_single_car_area(const grund_t* entry) const
+{
+	if(  !entry  ||  !cnv  ||  cnv==(convoi_t*)1  ) {
+		return NULL;
+	}
+	// A convoy never blocks itself, and neither do the convoys it is coupled to - they are one
+	// vehicle chain and are driving in as one.
+	const convoihandle_t own_chain = cnv->get_most_parent_convoi();
+
+	// A misconfigured map could mark half the road network with this mode. Stop expanding rather
+	// than walk it every time a convoy reaches the border; an area that large is not a single-car
+	// section any more.
+	const uint32 MAX_AREA_TILES = 256;
+	vector_tpl<koord3d> area(MAX_AREA_TILES);
+	area.append( entry->get_pos() );
+
+	for(  uint32 i=0;  i<area.get_count();  i++  ) {
+		grund_t* gr = welt->lookup( area[i] );
+		if(  !gr  ) {
+			continue;
+		}
+
+		// is somebody in here?
+		for(  uint8 pos=1;  pos<(volatile uint8)gr->get_top();  pos++  ) {
+			road_vehicle_t* const at = obj_cast<road_vehicle_t>( gr->obj_bei(pos) );
+			if(  !at  ||  !at->get_convoi()  ||  at->get_convoi()==(convoi_t*)1  ) {
+				continue;
+			}
+			convoi_t* const ocnv = at->get_convoi();
+			if(  ocnv->get_most_parent_convoi()==own_chain  ) {
+				continue;
+			}
+			// The convoy we are going to couple with is the one exception: it is waiting in there
+			// for us, so keeping us out would deadlock the coupling.
+			if(  is_coupling_partner(at)  ) {
+				continue;
+			}
+			if(  cnv->can_start_coupling(ocnv)  &&  ocnv->is_loading()  ) {
+				continue;
+			}
+			return ocnv;
+		}
+
+		// expand over the roads leaving this tile
+		for(  uint8 r=0;  r<4  &&  area.get_count()<MAX_AREA_TILES;  r++  ) {
+			grund_t* to = NULL;
+			if(  !gr->get_neighbour( to, road_wt, ribi_t::nesw[r] )  ||  !to  ) {
+				continue;
+			}
+			const strasse_t* str_to = (const strasse_t*)to->get_weg(road_wt);
+			if(  !str_to  ||  str_to->get_overtaking_mode_raw()!=only_one_car_mode  ) {
+				continue;
+			}
+			if(  !area.is_contained( to->get_pos() )  ) {
+				area.append( to->get_pos() );
+			}
+		}
+	}
+	return NULL;
+}
+
+
+bool road_vehicle_t::holds_passing_lane_to_stop(const strasse_t* str) const
+{
+	if(  !str  ||  str->get_overtaking_mode_raw()!=passing_lane_stop_only_mode  ) {
+		return false;
+	}
+	if(  !cnv  ||  cnv==(convoi_t*)1  ||  !cnv->is_overtaking()  ||  cnv->get_route()->empty()  ) {
+		return false;
+	}
+	// can_overtake() only hands out the passing lane of such a road when the route ends inside the
+	// stretch of tiles the permission covers. route_index counts up by one per tile entered and
+	// tiles_overtaking counts down by one, so their sum is fixed and the test still identifies the
+	// permission while the convoy drives the last tiles up to its stop. A convoy departing again
+	// gets a fresh, longer route and fails it, so it is sent back to the traffic lane as on any
+	// other prohibited road.
+	return (uint32)route_index + (uint32)cnv->get_tiles_overtaking() >= cnv->get_route()->get_count();
 }
 
 
@@ -3813,8 +3932,10 @@ vehicle_base_t* road_vehicle_t::other_lane_blocked(const bool only_search_top, s
 			}
 
 			// this function cannot process vehicles on twoway and related mode road.
+			// passing_lane_stop_only roads are the exception: convoys do stand on their passing lane,
+			// so both lanes have to be inspected there.
 			const strasse_t* str = (strasse_t *)gr->get_weg(road_wt);
-			if(  !str  ||  (str->get_overtaking_mode()>=twoway_mode  &&  str->get_overtaking_mode()<inverted_mode)  ) {
+			if(  !str  ||  (str->get_overtaking_mode()>=twoway_mode  &&  str->get_overtaking_mode()<inverted_mode  &&  str->get_overtaking_mode_raw()!=passing_lane_stop_only_mode)  ) {
 				continue;
 			}
 
@@ -3968,7 +4089,15 @@ void road_vehicle_t::enter_tile(grund_t* gr)
 			grund_t* prev_gr = welt->lookup(pos_prev);
 			if(  prev_gr  ){
 				strasse_t* prev_str = (strasse_t*)prev_gr->get_weg(road_wt);
-				if(  str  &&  ((prev_str  &&  (prev_str->get_overtaking_mode()<=oneway_mode  &&  str->get_overtaking_mode()>oneway_mode  &&  str->get_overtaking_mode()<inverted_mode))  ||  str->get_overtaking_mode()==prohibited_mode)  ){
+				// On a passing-lane-stop-only road the convoy keeps the passing lane while it is
+				// driving up to the stop it was granted it for, and afterwards until the traffic lane
+				// is actually free again - it went there because somebody occupies that lane, and
+				// merging into them would be worse than staying put. can_enter_tile() makes it wait
+				// for that lane before it drives on, so the merge below always happens on a free one.
+				const bool keep_passing_lane = str  &&  str->get_overtaking_mode_raw()==passing_lane_stop_only_mode
+					&&  cnv->is_overtaking()
+					&&  (holds_passing_lane_to_stop(str)  ||  other_lane_blocked()!=NULL);
+				if(  str  &&  !keep_passing_lane  &&  ((prev_str  &&  (prev_str->get_overtaking_mode()<=oneway_mode  &&  str->get_overtaking_mode()>oneway_mode  &&  str->get_overtaking_mode()<inverted_mode))  ||  str->get_overtaking_mode()==prohibited_mode)  ){
 					cnv->set_tiles_overtaking(0);
 				}
 			}

--- a/vehicle/simvehicle.h
+++ b/vehicle/simvehicle.h
@@ -23,6 +23,7 @@ class schedule_t;
 class signal_t;
 class ware_t;
 class route_t;
+class strasse_t;
 
 /*----------------------- Movables ------------------------------------*/
 
@@ -613,6 +614,15 @@ public:
 	// true if v belongs to the coupling chain of the convoy we are currently approaching to couple
 	// with. Such a vehicle must not be treated as blocking, otherwise we could never drive up to it.
 	bool is_coupling_partner(const vehicle_base_t* v) const;
+
+	// only_one_car_mode: the connected area of tiles carrying that mode takes one convoy at a time.
+	// Returns a convoy already inside that area which keeps us out, or NULL when we may enter.
+	// A convoy waiting to be coupled with us does not keep us out - we are going there to join it.
+	convoi_t* get_blocking_convoi_in_single_car_area(const grund_t* entry) const;
+
+	// passing_lane_stop_only_mode: true while this convoy holds the passing lane under the
+	// permission can_overtake() gave it to come to a stand beside a convoy in the traffic lane.
+	bool holds_passing_lane_to_stop(const strasse_t* str) const;
 };
 
 


### PR DESCRIPTION
OTRP(`overtaking_mode`)に2種類を追加しました
- `only_one_car` 連続する区間に自動車1編成しか進入できない
  - 例外:停車している車両が連結待機で、進入しようとする車が当該連結待機編成と連結可能な時
  - 使い方:行き違い不可能な道路や鉄道転換BRTの再現、連結時の他車進入によるデッドロック回避など
- `can_stop_on_passing_lane` 停車する場合のみ追い越し車線に停車可能
  - 使い方:駐車場における交互停車など