### PR TITLE
add shipping income and fix toll shipping

### DIFF
--- a/dataobj/settings.cc
+++ b/dataobj/settings.cc
@@ -261,6 +261,9 @@ settings_t::settings_t() :
 
 	maint_building = 5000; // normal buildings
 	way_toll_runningcost_percentage = 0;
+	// convoy shipping: mirrors the way toll by default, and carrying earns only the toll
+	toll_shipping_percentage = 0;
+	shipping_income_percentage = 0;
 	way_toll_waycost_percentage = 0;
 	maintenance_cost_multiplier_way = 100;
 	maintenance_cost_multiplier_overhead = 100;
@@ -1251,6 +1254,17 @@ void settings_t::rdwr(loadsave_t *file)
 			maintenance_cost_multiplier_overhead = 100;
 			running_cost_multiplier_vehicle = 100;
 		}
+		if(  file->get_OTRP_version() >= 62  ) {
+			file->rdwr_long( toll_shipping_percentage );
+			file->rdwr_long( shipping_income_percentage );
+		}
+		else if(  file->is_loading()  ) {
+			// Before v62 the shipping toll shared the way toll's percentage, so an older save
+			// keeps behaving exactly as it did. Carrying earned no share of the transport
+			// income at all, so that starts at zero.
+			toll_shipping_percentage = way_toll_runningcost_percentage;
+			shipping_income_percentage = 0;
+		}
 		// v<56: values were never saved; parse_simuconf already set them from simuconf.tab
 		// otherwise the default values of the last one will be used
 	}
@@ -1898,6 +1912,11 @@ void settings_t::parse_simuconf( tabfile_t& simuconf, sint16& disp_width, sint16
 
 	way_toll_runningcost_percentage = contents.get_int_clamped("toll_runningcost_percentage", way_toll_runningcost_percentage, 0, 100 );
 	way_toll_waycost_percentage     = contents.get_int_clamped("toll_waycost_percentage",     way_toll_waycost_percentage,     0, 100 );
+	// Convoy shipping. The shipping toll defaults to whatever the way toll is, so a pakset
+	// that only sets toll_runningcost_percentage gets the behaviour it had before this setting
+	// existed; naming toll_shipping_percentage explicitly overrides that.
+	toll_shipping_percentage   = contents.get_int_clamped("toll_shipping_percentage",   way_toll_runningcost_percentage, 0, 100 );
+	shipping_income_percentage = contents.get_int_clamped("shipping_income_percentage", shipping_income_percentage,      0, 100 );
 	maintenance_cost_multiplier_way      = contents.get_int_clamped("maintenance_cost_multiplier_way",      maintenance_cost_multiplier_way,      1, 250 );
 	maintenance_cost_multiplier_overhead = contents.get_int_clamped("maintenance_cost_multiplier_overhead", maintenance_cost_multiplier_overhead, 1, 250 );
 	running_cost_multiplier_vehicle      = contents.get_int_clamped("running_cost_multiplier_vehicle",      running_cost_multiplier_vehicle,      1, 250 );

--- a/dataobj/settings.h
+++ b/dataobj/settings.h
@@ -340,6 +340,21 @@ private:
 	sint32 way_toll_runningcost_percentage;
 	sint32 way_toll_waycost_percentage;
 
+	/**
+	 * Convoy shipping: percentage of the running cost of the carrying vehicles charged as toll
+	 * to each convoy carried aboard. Separate from way_toll_runningcost_percentage so that a
+	 * pakset can price a ferry crossing differently from running over someone's track.
+	 * Defaults to way_toll_runningcost_percentage, including when loading a pre-v62 save.
+	 */
+	sint32 toll_shipping_percentage;
+
+	/**
+	 * Convoy shipping: percentage of the transport income earned over a shipped leg that goes
+	 * to the carrier instead of to the convoy it carried. 0 means the carried convoy keeps all
+	 * of it and the carrier earns only the toll.
+	 */
+	sint32 shipping_income_percentage;
+
 	// multipliers [%] applied on the pakset values of maintenance and running costs
 	sint32 maintenance_cost_multiplier_way;
 	sint32 maintenance_cost_multiplier_overhead;
@@ -770,6 +785,8 @@ public:
 
 	sint32 get_way_toll_runningcost_percentage() const { return way_toll_runningcost_percentage; }
 	sint32 get_way_toll_waycost_percentage() const { return way_toll_waycost_percentage; }
+	sint32 get_toll_shipping_percentage() const { return toll_shipping_percentage; }
+	sint32 get_shipping_income_percentage() const { return shipping_income_percentage; }
 
 	sint32 get_maintenance_cost_multiplier_way() const { return maintenance_cost_multiplier_way; }
 	sint32 get_maintenance_cost_multiplier_overhead() const { return maintenance_cost_multiplier_overhead; }

--- a/gui/settings_stats.cc
+++ b/gui/settings_stats.cc
@@ -368,6 +368,9 @@ void settings_economy_stats_t::init(settings_t const* const sets)
 
 	INIT_NUM( "toll_runningcost_percentage", sets->get_way_toll_runningcost_percentage(), 0, 100, gui_numberinput_t::AUTOLINEAR, false );
 	INIT_NUM( "toll_waycost_percentage", sets->get_way_toll_waycost_percentage(), 0, 100, gui_numberinput_t::AUTOLINEAR, false );
+	// convoy shipping - must stay in the same order as the matching READ_NUM_VALUE lines below
+	INIT_NUM( "toll_shipping_percentage", sets->get_toll_shipping_percentage(), 0, 100, gui_numberinput_t::AUTOLINEAR, false );
+	INIT_NUM( "shipping_income_percentage", sets->get_shipping_income_percentage(), 0, 100, gui_numberinput_t::AUTOLINEAR, false );
 	INIT_NUM( "maintenance_cost_multiplier_way", sets->get_maintenance_cost_multiplier_way(), 1, 250, gui_numberinput_t::AUTOLINEAR, false );
 	INIT_NUM( "maintenance_cost_multiplier_overhead", sets->get_maintenance_cost_multiplier_overhead(), 1, 250, gui_numberinput_t::AUTOLINEAR, false );
 	INIT_NUM( "running_cost_multiplier_vehicle", sets->get_running_cost_multiplier_vehicle(), 1, 250, gui_numberinput_t::AUTOLINEAR, false );
@@ -472,6 +475,8 @@ void settings_economy_stats_t::read(settings_t* const sets)
 
 	READ_NUM_VALUE( sets->way_toll_runningcost_percentage );
 	READ_NUM_VALUE( sets->way_toll_waycost_percentage );
+	READ_NUM_VALUE( sets->toll_shipping_percentage );
+	READ_NUM_VALUE( sets->shipping_income_percentage );
 	READ_NUM_VALUE( sets->maintenance_cost_multiplier_way );
 	READ_NUM_VALUE( sets->maintenance_cost_multiplier_overhead );
 	READ_NUM_VALUE( sets->running_cost_multiplier_vehicle );

--- a/simconvoi.cc
+++ b/simconvoi.cc
@@ -181,6 +181,7 @@ void convoi_t::init(player_t *player)
 	// convoy shipping
 	shipped_convois.clear();
 	carrier_convoi = convoihandle_t();
+	shipping_income_carrier = convoihandle_t();
 	shipping_wait_since = 0;
 
 	line_update_pending = linehandle_t();
@@ -3993,6 +3994,15 @@ void convoi_t::rdwr(loadsave_t *file)
 		shipping_wait_since = 0;
 	}
 
+	if(  file->get_OTRP_version()>=62  ) {
+		// A convoy can be saved between disembarking and the stop that settles the revenue for
+		// the shipped leg, so the pending payee has to survive the save. Unlike carrier_convoi
+		// this is a real forward link and is stored directly.
+		rdwr_convoihandle_t( file, shipping_income_carrier );
+	} else if(  file->is_loading()  ) {
+		shipping_income_carrier = convoihandle_t();
+	}
+
 	if(  file->is_loading()  ) {
 		recalc_catg_index();
 	}
@@ -4272,11 +4282,14 @@ void convoi_t::calc_gewinn()
 	for(unsigned i=0; i<anz_vehikel; i++) {
 		vehicle_t* v = fahr[i];
 		sint64 tmp;
-		gewinn += tmp = v->calc_revenue(v->last_stop_pos, v->get_pos() );
+		// a leg ridden aboard a carrier pays the carrier its share first
+		gewinn += tmp = deduct_shipping_income_share( v->calc_revenue(v->last_stop_pos, v->get_pos() ), v );
 		// get_schedule is needed as v->get_waytype() returns track_wt for trams (instead of tram_wt
 		owner->book_revenue(tmp, fahr[0]->get_pos().get_2d(), get_schedule()->get_waytype(), v->get_cargo_type()->get_index() );
 		v->last_stop_pos = v->get_pos();
 	}
+	// the shipped leg is settled - any later leg is our own again
+	shipping_income_carrier = convoihandle_t();
 
 	// update statistics of average speed
 	if(  distance_since_last_stop  ) {
@@ -4711,8 +4724,8 @@ void convoi_t::hat_gehalten(halthandle_t halt, uint32 halt_length_in_vehicle_ste
 		// we need not to call this on the same position
 		if(  v->last_stop_pos != v->get_pos()  ) {
 			sint64 tmp;
-			// calc_revenue
-			gewinn += tmp = v->calc_revenue(v->last_stop_pos, v->get_pos() );
+			// calc_revenue; a leg ridden aboard a carrier pays the carrier its share first
+			gewinn += tmp = deduct_shipping_income_share( v->calc_revenue(v->last_stop_pos, v->get_pos() ), v );
 			owner->book_revenue(tmp, fahr[0]->get_pos().get_2d(), get_schedule()->get_waytype(), v->get_cargo_type()->get_index());
 			v->last_stop_pos = v->get_pos();
 		}
@@ -4760,6 +4773,9 @@ void convoi_t::hat_gehalten(halthandle_t halt, uint32 halt_length_in_vehicle_ste
 			time = max( time, (max(v->get_cargo_max(),v->get_total_cargo())*2*v->get_desc()->get_loading_time()) / max(v->get_cargo_max(), 1) );
 		}
 	}
+	// The shipped leg has now been settled for every vehicle - any later leg is our own again.
+	shipping_income_carrier = convoihandle_t();
+
 	// Grant departure allowance to a waiting convoy of another line, if configured.
 	// This runs after unloading (self and all coupling children) so that goods just
 	// unloaded here are already available at the halt for the released convoy to load.
@@ -7719,6 +7735,17 @@ bool convoi_t::disembark_convoy(convoihandle_t c, halthandle_t halt)
 	shipped_convois.remove( c );
 	c->carrier_convoi      = convoihandle_t();
 	c->shipping_wait_since = 0;
+	// Remember who carried us until the revenue for this leg is booked. That happens at this
+	// stop, one step later in hat_gehalten(), because calc_revenue() measures from
+	// last_stop_pos - still the port we boarded at - so the whole leg's income is the
+	// carrier's doing. Every convoy of the chain books its own revenue, so all of them need it.
+	{
+		convoihandle_t k2 = c;
+		while(  k2.is_bound()  ) {
+			k2->shipping_income_carrier = self;
+			k2 = k2->get_coupling_convoi();
+		}
+	}
 
 	// Bring the whole chain back onto the map. This does by hand what start() plus the depot
 	// branch of vorfahren() do between them; start() cannot be used directly because it would
@@ -8185,7 +8212,10 @@ void convoi_t::book_shipping_toll()
 	if(  shipped_convois.empty()  ) {
 		return;
 	}
-	const sint64 pct = (sint64)welt->get_settings().get_way_toll_runningcost_percentage();
+	// Shipping has its own percentage: a ferry crossing is priced differently from running
+	// over someone else's track. It defaults to way_toll_runningcost_percentage, so a pakset
+	// or a save that never sets it behaves exactly as before.
+	const sint64 pct = (sint64)welt->get_settings().get_toll_shipping_percentage();
 	if(  pct == 0  ) {
 		return;
 	}
@@ -8222,4 +8252,35 @@ void convoi_t::book_shipping_toll()
 		c->book( -toll_convoy, CONVOI_WAYTOLL );
 		c->book( -toll_convoy, CONVOI_PROFIT );
 	}
+}
+
+
+sint64 convoi_t::deduct_shipping_income_share(sint64 revenue, const vehicle_t *v)
+{
+	// Convoy shipping: the leg just settled was ridden aboard a carrier - calc_revenue()
+	// measures from last_stop_pos, which is still the port we boarded at, so the whole of this
+	// leg's income was earned by the carrier moving us. Hand the carrier its configured share.
+	if(  !shipping_income_carrier.is_bound()  ||  revenue == 0  ) {
+		return revenue;
+	}
+	const sint64 pct = (sint64)welt->get_settings().get_shipping_income_percentage();
+	if(  pct <= 0  ) {
+		return revenue;
+	}
+	const sint64 share = revenue * pct / 100l;
+	if(  share == 0  ) {
+		return revenue;
+	}
+	convoi_t *carrier = shipping_income_carrier.get_rep();
+	if(  carrier == NULL  ||  carrier->get_vehicle_count() == 0  ||  carrier->get_schedule() == NULL  ) {
+		return revenue;
+	}
+	// booked under the carrier's own waytype, so a ferry's earnings show up in the water
+	// column rather than in the column of whatever it happened to be carrying
+	carrier->get_owner()->book_revenue( share, carrier->front()->get_pos().get_2d(),
+		carrier->get_schedule()->get_waytype(), v->get_cargo_type()->get_index() );
+	carrier->book( share, CONVOI_REVENUE );
+	carrier->book( share, CONVOI_PROFIT );
+	carrier->jahresgewinn += share;
+	return revenue - share;
 }

--- a/simconvoi.h
+++ b/simconvoi.h
@@ -274,6 +274,17 @@ private:
 	convoihandle_t carrier_convoi;
 
 	/**
+	* Convoy shipping: the convoy that just carried me, kept only until the revenue for that
+	* leg has been settled. Revenue is booked at the stop AFTER disembarking (calc_revenue()
+	* measures from last_stop_pos, which is still the port we boarded at), so the carrier has
+	* to stay reachable that long to be paid its share. Cleared as soon as the split is done.
+	*/
+	convoihandle_t shipping_income_carrier;
+
+	/// pay `carrier`'s share of a shipped leg's revenue and return what is left for us
+	sint64 deduct_shipping_income_share(sint64 revenue, const vehicle_t *v);
+
+	/**
 	* Convoy shipping: ticks at which this convoy began waiting for a carrier, so that a
 	* convoy nobody ever comes to fetch can eventually be reported instead of hanging forever.
 	*/


### PR DESCRIPTION
航送の運賃収受を修正しました
- 航送終了時、被航送編成の積載物の輸送賃のうち一部(高度な設定で比率を決定)を航送編成側が受け取れるようになります
- 航送中の「通行料」相当を高度な設定にて設定可能にしました